### PR TITLE
fix(signoz): improve clickhouse skill trigger description

### DIFF
--- a/plugins/signoz/skills/signoz-clickhouse-query/SKILL.md
+++ b/plugins/signoz/skills/signoz-clickhouse-query/SKILL.md
@@ -1,60 +1,90 @@
 ---
 name: signoz-clickhouse-query
-description: Write optimised ClickHouse queries for SigNoz OpenTelemetry data to build dashboard panels. Use this skill whenever the user asks to query SigNoz logs or traces, build a log-based or trace-based dashboard panel, analyse log volume, error rates, span counts, latency, duration distributions, or filter by service, severity, container, or environment — even if they don't mention ClickHouse. Trigger for logs (severity, body, log volume) AND traces (spans, latency, duration, p99, HTTP/DB operations).
+description: >-
+  Write ClickHouse queries for SigNoz dashboards over OpenTelemetry logs and
+  traces. Use this skill whenever the user asks for SigNoz ClickHouse queries
+  for logs or traces, SigNoz dashboard queries, log analysis, span counts,
+  latency, or trace breakdowns.
 ---
 
 # Writing ClickHouse Queries for SigNoz Dashboards
 
+## When to Use
+
+Use this skill when the user asks for SigNoz queries involving:
+
+- Logs: severity, body text, log volume, structured fields, containers,
+  services, or environments.
+- Traces: spans, latency, duration, p95 or p99, HTTP operations, DB
+  operations, or error spans.
+- Dashboard panels: timeseries charts, value widgets, and table breakdowns.
+
+If the user asks for a dashboard panel but does not mention ClickHouse, still
+use this skill.
+
 ## Signal Detection
 
-Identify whether the request is about **logs** or **traces**:
+Identify whether the request is about logs or traces.
 
-| User mentions | Signal |
-|---|---|
-| log lines, severity, body text, log volume, container logs, structured log fields | **Logs** |
-| spans, latency, duration, p99, HTTP/DB operations, trace, error spans | **Traces** |
+- Logs: log lines, severity, body text, log volume, container logs, or
+  structured log fields.
+- Traces: spans, latency, duration, p99, trace analysis, HTTP operations, DB
+  operations, or error spans.
 
-If ambiguous, ask the user to clarify.
+If the request is ambiguous, ask the user to clarify.
 
 ## Reference Routing
 
-- **Logs**: Read [`references/clickhouse-logs-reference.md`](./references/clickhouse-logs-reference.md) before writing any query.
-- **Traces**: Read [`references/clickhouse-traces-reference.md`](./references/clickhouse-traces-reference.md) before writing any query.
+- Logs: read
+  [`references/clickhouse-logs-reference.md`](./references/clickhouse-logs-reference.md)
+  before writing any query.
+- Traces: read
+  [`references/clickhouse-traces-reference.md`](./references/clickhouse-traces-reference.md)
+  before writing any query.
 
-Each reference covers: table schemas, the mandatory optimizations like resource filter CTE pattern, attribute access syntax, dashboard panel templates, query examples, and a validation checklist.
+Each reference covers table schemas, optimization patterns, attribute access
+syntax, dashboard templates, query examples, and a validation checklist.
 
 ## Quick Reference
 
-| Panel type | Returns | Use when |
-|---|---|---|
-| Timeseries | rows of `(ts, value)` | chart over time |
-| Value | single `value` | stat/counter widget |
-| Table | rows of labelled columns | breakdown by dimension |
+- Timeseries panel: return rows of `(ts, value)` for a chart over time.
+- Value panel: return a single `value` for a stat or counter widget.
+- Table panel: return labelled columns for a grouped breakdown.
 
 ## Key Variables by Signal
 
-| | Logs | Traces |
-|---|---|---|
-| Timestamp type | `UInt64` (nanoseconds) | `DateTime64(9)` |
-| Time filter | `$start_timestamp_nano` / `$end_timestamp_nano` | `$start_datetime` / `$end_datetime` |
-| Bucket filter | `$start_timestamp` / `$end_timestamp` | `$start_timestamp` / `$end_timestamp` |
-| Display conversion | `fromUnixTimestamp64Nano(timestamp)` | direct |
-| Main table | `signoz_logs.distributed_logs_v2` | `signoz_traces.distributed_signoz_index_v3` |
-| Resource table | `signoz_logs.distributed_logs_v2_resource` | `signoz_traces.distributed_traces_v3_resource` |
+### Logs
+
+- Timestamp type: `UInt64` in nanoseconds.
+- Time filter: `$start_timestamp_nano` and `$end_timestamp_nano`.
+- Bucket filter: `$start_timestamp` and `$end_timestamp`.
+- Display conversion: `fromUnixTimestamp64Nano(timestamp)`.
+- Main table: `signoz_logs.distributed_logs_v2`.
+- Resource table: `signoz_logs.distributed_logs_v2_resource`.
+
+### Traces
+
+- Timestamp type: `DateTime64(9)`.
+- Time filter: `$start_datetime` and `$end_datetime`.
+- Bucket filter: `$start_timestamp` and `$end_timestamp`.
+- Display conversion: use the timestamp directly.
+- Main table: `signoz_traces.distributed_signoz_index_v3`.
+- Resource table: `signoz_traces.distributed_traces_v3_resource`.
 
 ## Top Anti-Patterns
 
-- Missing `ts_bucket_start BETWEEN $start_timestamp - 1800 AND $end_timestamp`
-- Forgetting `GLOBAL IN` (not plain `IN`) on the resource fingerprint subquery
-- Adding a resource CTE when there is no resource attribute filter
-- **[Logs]** Using `$start_datetime` / `$end_datetime` (those are for traces)
-- **[Traces]** Using `$start_timestamp_nano` / `$end_timestamp_nano` (those are for logs)
-- **[Traces]** Using `resources_string['service.name']` instead of `resource_string_service$$name`
+- Missing `ts_bucket_start BETWEEN $start_timestamp - 1800 AND $end_timestamp`.
+- Using plain `IN` instead of `GLOBAL IN` on the resource fingerprint subquery.
+- Adding a resource CTE when there is no resource attribute filter.
+- Logs query with `$start_datetime` or `$end_datetime`.
+- Traces query with `$start_timestamp_nano` or `$end_timestamp_nano`.
+- Traces query with `resources_string['service.name']` instead of
+  `resource_string_service$$name`.
 
 ## Workflow
 
-1. **Detect signal**: Logs or traces? Use the table above.
-2. **Read the reference**: Load the appropriate reference file before writing any query.
-3. **Pick the panel type**: Timeseries, Value, or Table.
-4. **Build the query** following the mandatory patterns from the reference doc.
-5. **Validate** using the checklist at the bottom of the reference doc.
+1. Detect the signal: logs or traces.
+2. Read the matching reference file before writing the query.
+3. Pick the panel type: timeseries, value, or table.
+4. Build the query using the required patterns from the reference.
+5. Validate the result with the checklist in the reference.


### PR DESCRIPTION
## Summary
- improve the `signoz-clickhouse-query` skill description so it triggers more reliably for SigNoz ClickHouse queries over logs or traces
- keep the earlier SKILL.md cleanup that reduces Socket false-positive risk by using shorter ASCII-only text and clearer sections
- preserve the existing logs/traces routing, references, anti-patterns, and workflow guidance

## Testing
- verified YAML frontmatter parses correctly
- verified `SKILL.md` remains ASCII-only
- verified max line length is 92 characters