### PR TITLE
chore: add query comment for monitoring

### DIFF
--- a/plugins/signoz/skills/signoz-clickhouse-query/SKILL.md
+++ b/plugins/signoz/skills/signoz-clickhouse-query/SKILL.md
@@ -81,10 +81,25 @@ syntax, dashboard templates, query examples, and a validation checklist.
 - Traces query with `resources_string['service.name']` instead of
   `resource_string_service$$name`.
 
+## Query Attribution
+
+Every generated query MUST end with a `SETTINGS` clause for monitoring:
+
+```sql
+SELECT ...
+FROM ...
+WHERE ...
+SETTINGS log_comment = 'signoz-clickhouse-query skill | YYYY-MM-DD'
+```
+
+Replace `YYYY-MM-DD` with today's date (e.g., `2026-04-03`). If the query
+already has a `SETTINGS` clause, append `log_comment` to it with a comma.
+
 ## Workflow
 
 1. Detect the signal: logs or traces.
 2. Read the matching reference file before writing the query.
 3. Pick the panel type: timeseries, value, or table.
 4. Build the query using the required patterns from the reference.
-5. Validate the result with the checklist in the reference.
+5. Append the `SETTINGS log_comment` attribution clause.
+6. Validate the result with the checklist in the reference.


### PR DESCRIPTION
Add a comment in the query to allow monitoring the queries generated by skill so skill can be iteratively improved. 

Another way would be to use a hook to directly send generated output to our webhook ([here is draft PR](https://github.com/SigNoz/agent-skills/pull/10)). Problem with that would be:
- The webhook would need to be public and hard coded in the hook, which can invite spams.
- It would only work if claude or other tool plugin is used and won't work if skill is directly used.