### PR TITLE
feat: add a hook to monitor the skill usage

### DIFF
--- a/plugins/signoz/hooks/hooks.json
+++ b/plugins/signoz/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Auto-allow WebFetch for official SigNoz HTTPS URLs",
+  "description": "SigNoz plugin hooks: auto-allow WebFetch for official URLs, monitor query generation via Slack",
   "hooks": {
     "PreToolUse": [
       {
@@ -8,6 +8,17 @@
           {
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/allow-signoz-webfetch.js\""
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/post-query-to-slack.js\""
           }
         ]
       }

--- a/plugins/signoz/hooks/scripts/post-query-to-slack.js
+++ b/plugins/signoz/hooks/scripts/post-query-to-slack.js
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+
+import { request } from "https";
+
+const SKILL_NAME = "signoz-clickhouse-query";
+
+function postToSlack(webhookUrl, message) {
+  return new Promise((resolve) => {
+    const url = new URL(webhookUrl);
+    const body = JSON.stringify(message);
+
+    const req = request(
+      {
+        hostname: url.hostname,
+        path: url.pathname,
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(body),
+        },
+      },
+      () => resolve(),
+    );
+
+    req.on("error", () => resolve());
+    req.setTimeout(5000, () => {
+      req.destroy();
+      resolve();
+    });
+
+    req.write(body);
+    req.end();
+  });
+}
+
+function extractQuery(toolResponse) {
+  if (typeof toolResponse === "string") {
+    return toolResponse;
+  }
+
+  if (toolResponse?.content) {
+    return typeof toolResponse.content === "string"
+      ? toolResponse.content
+      : JSON.stringify(toolResponse.content);
+  }
+
+  return JSON.stringify(toolResponse);
+}
+
+const chunks = [];
+
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => chunks.push(chunk));
+process.stdin.on("end", async () => {
+  const webhookUrl = process.env.SLACK_WEBHOOK_URL;
+  if (!webhookUrl) {
+    process.exit(0);
+  }
+
+  try {
+    const payload = JSON.parse(chunks.join(""));
+
+    if (payload?.tool_name !== "Skill") {
+      process.exit(0);
+    }
+
+    const skillName = payload?.tool_input?.skill;
+    if (skillName !== SKILL_NAME) {
+      process.exit(0);
+    }
+
+    const query = extractQuery(payload?.tool_response);
+    const slackMessage = {
+      blocks: [
+        {
+          type: "header",
+          text: {
+            type: "plain_text",
+            text: "ClickHouse Query Generated",
+          },
+        },
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: `*Skill:* \`${skillName}\`\n*Session:* \`${payload?.session_id || "unknown"}\``,
+          },
+        },
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: `*Generated Output:*\n\`\`\`\n${query.slice(0, 2900)}\n\`\`\``,
+          },
+        },
+      ],
+    };
+
+    await postToSlack(webhookUrl, slackMessage);
+  } catch {
+    // Fail silently — monitoring should never block the workflow.
+  }
+
+  process.exit(0);
+});


### PR DESCRIPTION
Call a webhook using plugin hooks for monitoring the usage of the skill.

Problems with approach:
    The webhook would need to be public and hard coded in the hook, which can invite spams.
    It would only work if claude or other tool plugin is used and won't work if skill is directly used.
    
Alternative: https://github.com/SigNoz/agent-skills/pull/9