### PR TITLE
fix: harden auto-bump workflow, add contributing guide

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-**/.claude-plugin/plugin.json merge=ours

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+**/.claude-plugin/plugin.json merge=ours

--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -118,9 +118,11 @@ jobs:
           if [[ -z "$BUMPED" ]]; then
             echo "bumped=false" >> "$GITHUB_OUTPUT"
           else
-            echo "bumped=true" >> "$GITHUB_OUTPUT"
-            echo "names=$BUMPED" >> "$GITHUB_OUTPUT"
-            echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+            {
+              echo "bumped=true"
+              echo "names=$BUMPED"
+              echo "count=$COUNT"
+            } >> "$GITHUB_OUTPUT"
           fi
 
       - name: Commit and push

--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -84,6 +84,6 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add '**/.claude-plugin/plugin.json'
-          git pull --rebase origin jaine
           git commit -m "chore: auto-bump CalVer${{ steps.bump.outputs.names }}"
+          git pull --rebase origin jaine
           git push

--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -1,0 +1,89 @@
+name: Auto CalVer Bump
+
+# Runs on push to jaine branch — auto-bumps CalVer for changed plugins.
+# GITHUB_TOKEN bot commits don't re-trigger workflows → no loops.
+
+on:
+  push:
+    branches:
+      - 'jaine'
+
+jobs:
+  auto-bump:
+    runs-on: ubuntu-latest
+
+    # Skip if this push was already an auto-bump
+    if: "!contains(github.event.head_commit.message, 'chore: auto-bump CalVer')"
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Detect changed plugins and bump CalVer
+        id: bump
+        run: |
+          # Find changed plugin directories
+          CHANGED=$(git diff --name-only HEAD~1 HEAD -- 'plugins/' 'external_plugins/' 2>/dev/null || true)
+
+          if [[ -z "$CHANGED" ]]; then
+            echo "No plugin changes detected"
+            echo "bumped=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Extract unique plugin dirs
+          PLUGIN_DIRS=$(echo "$CHANGED" | grep -oE '^(plugins|external_plugins)/[^/]+' | sort -u)
+
+          TODAY=$(date -u +%Y.%m.%d)
+          BUMPED=""
+
+          for PLUGIN_DIR in $PLUGIN_DIRS; do
+            PLUGIN_JSON="$PLUGIN_DIR/.claude-plugin/plugin.json"
+
+            if [[ ! -f "$PLUGIN_JSON" ]]; then
+              continue
+            fi
+
+            CURRENT=$(grep '"version"' "$PLUGIN_JSON" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?' | head -1)
+
+            if [[ -z "$CURRENT" ]]; then
+              continue
+            fi
+
+            # CalVer bump logic (replicate _calver_bump)
+            if [[ "$CURRENT" == "$TODAY" ]]; then
+              NEW="${TODAY}.1"
+            elif [[ "$CURRENT" == "${TODAY}."* ]]; then
+              MICRO="${CURRENT##*.}"
+              NEW="${TODAY}.$((MICRO + 1))"
+            else
+              NEW="$TODAY"
+            fi
+
+            sed -i "s/\"version\": \"$CURRENT\"/\"version\": \"$NEW\"/" "$PLUGIN_JSON"
+            PLUGIN_NAME=$(basename "$PLUGIN_DIR")
+            BUMPED="$BUMPED $PLUGIN_NAME"
+            echo "Bumped $PLUGIN_NAME: $CURRENT -> $NEW"
+          done
+
+          if [[ -z "$BUMPED" ]]; then
+            echo "bumped=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "bumped=true" >> "$GITHUB_OUTPUT"
+            echo "names=$BUMPED" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit and push
+        if: steps.bump.outputs.bumped == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add '**/.claude-plugin/plugin.json'
+          git pull --rebase origin jaine
+          git commit -m "chore: auto-bump CalVer${{ steps.bump.outputs.names }}"
+          git push

--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -1,19 +1,28 @@
 name: Auto CalVer Bump
 
 # Runs on push to jaine branch — auto-bumps CalVer for changed plugins.
-# GITHUB_TOKEN bot commits don't re-trigger workflows → no loops.
+# Loop prevention: the commit-message check on the `if` line below is the
+# real safety net. GITHUB_TOKEN's no-retrigger behaviour is not guaranteed
+# across all repository configurations.
 
 on:
   push:
     branches:
       - 'jaine'
 
+# Serialise runs so concurrent pushes don't race each other.
+concurrency:
+  group: auto-bump-jaine
+  cancel-in-progress: true
+
 jobs:
   auto-bump:
     runs-on: ubuntu-latest
 
-    # Skip if this push was already an auto-bump
-    if: "!contains(github.event.head_commit.message, 'chore: auto-bump CalVer')"
+    # Skip if this push was already an auto-bump (null-safe).
+    if: >-
+      github.event.head_commit != null &&
+      !contains(github.event.head_commit.message, 'chore: auto-bump CalVer')
 
     permissions:
       contents: write
@@ -22,13 +31,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Detect changed plugins and bump CalVer
         id: bump
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
         run: |
-          # Find changed plugin directories
-          CHANGED=$(git diff --name-only HEAD~1 HEAD -- 'plugins/' 'external_plugins/' 2>/dev/null || true)
+          # Compare against the pre-push ref for reliable diffs across
+          # merge commits, squash merges, and multi-commit pushes.
+          CHANGED=$(git diff --name-only "$BEFORE_SHA" HEAD -- 'plugins/' || true)
 
           if [[ -z "$CHANGED" ]]; then
             echo "No plugin changes detected"
@@ -36,26 +48,28 @@ jobs:
             exit 0
           fi
 
-          # Extract unique plugin dirs
-          PLUGIN_DIRS=$(echo "$CHANGED" | grep -oE '^(plugins|external_plugins)/[^/]+' | sort -u)
+          # Extract unique plugin dirs (e.g. plugins/signoz)
+          PLUGIN_DIRS=$(echo "$CHANGED" | grep -oE '^plugins/[^/]+' | sort -u)
 
           TODAY=$(date -u +%Y.%m.%d)
           BUMPED=""
+          COUNT=0
 
           for PLUGIN_DIR in $PLUGIN_DIRS; do
-            PLUGIN_JSON="$PLUGIN_DIR/.claude-plugin/plugin.json"
-
-            if [[ ! -f "$PLUGIN_JSON" ]]; then
+            # Read current version from the primary manifest
+            CLAUDE_JSON="$PLUGIN_DIR/.claude-plugin/plugin.json"
+            if [[ ! -f "$CLAUDE_JSON" ]]; then
+              echo "WARNING: No .claude-plugin/plugin.json in $PLUGIN_DIR, skipping"
               continue
             fi
 
-            CURRENT=$(grep '"version"' "$PLUGIN_JSON" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?' | head -1)
-
+            CURRENT=$(jq -r '.version // empty' "$CLAUDE_JSON")
             if [[ -z "$CURRENT" ]]; then
+              echo "WARNING: No version field in $CLAUDE_JSON, skipping"
               continue
             fi
 
-            # CalVer bump logic (replicate _calver_bump)
+            # CalVer bump logic
             if [[ "$CURRENT" == "$TODAY" ]]; then
               NEW="${TODAY}.1"
             elif [[ "$CURRENT" == "${TODAY}."* ]]; then
@@ -65,9 +79,30 @@ jobs:
               NEW="$TODAY"
             fi
 
-            sed -i "s/\"version\": \"$CURRENT\"/\"version\": \"$NEW\"/" "$PLUGIN_JSON"
+            # Monotonicity guard — never downgrade the version
+            if [[ "$NEW" < "$CURRENT" ]]; then
+              echo "WARNING: Computed version ($NEW) < current ($CURRENT) for $PLUGIN_DIR, keeping current"
+              continue
+            fi
+
+            # Bump all three plugin manifests using jq
+            for MANIFEST in \
+              "$PLUGIN_DIR/.claude-plugin/plugin.json" \
+              "$PLUGIN_DIR/.codex-plugin/plugin.json" \
+              "$PLUGIN_DIR/.cursor-plugin/plugin.json"; do
+              if [[ -f "$MANIFEST" ]]; then
+                if ! jq --arg v "$NEW" '.version = $v' "$MANIFEST" > "${MANIFEST}.tmp"; then
+                  echo "ERROR: jq failed on $MANIFEST"
+                  rm -f "${MANIFEST}.tmp"
+                  exit 1
+                fi
+                mv "${MANIFEST}.tmp" "$MANIFEST"
+              fi
+            done
+
             PLUGIN_NAME=$(basename "$PLUGIN_DIR")
             BUMPED="$BUMPED $PLUGIN_NAME"
+            COUNT=$((COUNT + 1))
             echo "Bumped $PLUGIN_NAME: $CURRENT -> $NEW"
           done
 
@@ -76,6 +111,7 @@ jobs:
           else
             echo "bumped=true" >> "$GITHUB_OUTPUT"
             echo "names=$BUMPED" >> "$GITHUB_OUTPUT"
+            echo "count=$COUNT" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Commit and push
@@ -83,7 +119,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add '**/.claude-plugin/plugin.json'
-          git commit -m "chore: auto-bump CalVer${{ steps.bump.outputs.names }}"
-          git pull --rebase origin jaine
+          git add plugins/**/.claude-plugin/plugin.json plugins/**/.codex-plugin/plugin.json plugins/**/.cursor-plugin/plugin.json
+          git commit -m "chore: auto-bump CalVer for ${{ steps.bump.outputs.count }} plugin(s)"
+          git pull --rebase origin jaine || { git rebase --abort 2>/dev/null; echo "ERROR: rebase failed"; exit 1; }
           git push

--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -40,6 +40,12 @@ jobs:
         run: |
           # Compare against the pre-push ref for reliable diffs across
           # merge commits, squash merges, and multi-commit pushes.
+          # On the first push to a branch (or some force-pushes),
+          # github.event.before is all zeros — fall back to diffing
+          # against the parent commit.
+          if [[ "$BEFORE_SHA" =~ ^0+$ ]]; then
+            BEFORE_SHA="HEAD~1"
+          fi
           CHANGED=$(git diff --name-only "$BEFORE_SHA" HEAD -- 'plugins/' || true)
 
           if [[ -z "$CHANGED" ]]; then
@@ -79,8 +85,11 @@ jobs:
               NEW="$TODAY"
             fi
 
-            # Monotonicity guard — never downgrade the version
-            if [[ "$NEW" < "$CURRENT" ]]; then
+            # Monotonicity guard — never downgrade the version.
+            # Use version-sort so numeric micro suffixes compare correctly
+            # (e.g. 2026.04.08.10 > 2026.04.08.9).
+            LOWEST=$(printf '%s\n%s\n' "$NEW" "$CURRENT" | sort -V | head -1)
+            if [[ "$LOWEST" == "$NEW" && "$NEW" != "$CURRENT" ]]; then
               echo "WARNING: Computed version ($NEW) < current ($CURRENT) for $PLUGIN_DIR, keeping current"
               continue
             fi

--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -1,6 +1,6 @@
 name: Auto CalVer Bump
 
-# Runs on push to jaine branch — auto-bumps CalVer for changed plugins.
+# Runs on push to main — auto-bumps CalVer for changed plugins.
 # Loop prevention: the commit-message check on the `if` line below is the
 # real safety net. GITHUB_TOKEN's no-retrigger behaviour is not guaranteed
 # across all repository configurations.
@@ -8,11 +8,11 @@ name: Auto CalVer Bump
 on:
   push:
     branches:
-      - 'jaine'
+      - 'main'
 
 # Serialise runs so concurrent pushes don't race each other.
 concurrency:
-  group: auto-bump-jaine
+  group: auto-bump-main
   cancel-in-progress: true
 
 jobs:
@@ -132,5 +132,5 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add plugins/**/.claude-plugin/plugin.json plugins/**/.codex-plugin/plugin.json plugins/**/.cursor-plugin/plugin.json
           git commit -m "chore: auto-bump CalVer for ${{ steps.bump.outputs.count }} plugin(s)"
-          git pull --rebase origin jaine || { git rebase --abort 2>/dev/null; echo "ERROR: rebase failed"; exit 1; }
+          git pull --rebase origin main || { git rebase --abort 2>/dev/null; echo "ERROR: rebase failed"; exit 1; }
           git push

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,3 @@
 # Agent Guidelines
 
-Follow [CONTRIBUTING.md](./CONTRIBUTING.md) for all contribution conventions, including the required plugin version bump when adding or updating skills.
-
-Plugin versions use CalVer (`YYYY.MM.DD`). The auto-bump workflow handles this on merge to `main`.
+Follow [CONTRIBUTING.md](./CONTRIBUTING.md) for all contribution conventions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,4 +2,4 @@
 
 Follow [CONTRIBUTING.md](./CONTRIBUTING.md) for all contribution conventions, including the required plugin version bump when adding or updating skills.
 
-Plugin versions use CalVer (`YYYY.MM.DD`). The auto-bump workflow handles this on the `jaine` branch; bump manually on other branches.
+Plugin versions use CalVer (`YYYY.MM.DD`). The auto-bump workflow handles this on merge to `main`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,5 @@
 # Agent Guidelines
 
 Follow [CONTRIBUTING.md](./CONTRIBUTING.md) for all contribution conventions, including the required plugin version bump when adding or updating skills.
+
+Plugin versions use CalVer (`YYYY.MM.DD`). The auto-bump workflow handles this on the `jaine` branch; bump manually on other branches.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,16 +40,16 @@ Users of Claude Code, Codex, and Cursor receive updates based on these versions.
 
 ### Auto-bump workflow
 
-A GitHub Actions workflow (`.github/workflows/auto-version-bump.yml`) automatically bumps all three manifests on push to the `jaine` branch. It detects which plugins have changed files and sets the version to today's date (or appends a micro suffix for multiple bumps in the same day).
+A GitHub Actions workflow (`.github/workflows/auto-version-bump.yml`) can automatically bump all three manifests on push to configured branches. It detects which plugins have changed files and sets the version to today's date (or appends a micro suffix for multiple bumps in the same day).
 
-**You do not need to manually bump versions when pushing to `jaine`** — the workflow handles it. For other branches or manual releases, bump the version yourself in all three manifests.
+If the auto-bump workflow is enabled for your branch, you do not need to manually bump versions. Otherwise, bump the version yourself in all three manifests before merging.
 
 ## Pull Request Checklist
 
 - [ ] Skill follows the [Agent Skills specification](https://agentskills.io/specification)
 - [ ] `name` in SKILL.md frontmatter matches the directory name
 - [ ] `README.md` updated if a new skill was added
-- [ ] **Plugin versions bumped** in all three manifests (auto-bumped on `jaine`, manual on other branches)
+- [ ] **Plugin versions bumped** in all three manifests (automatic if auto-bump workflow is configured, otherwise manual)
 - [ ] Changes tested locally with the relevant tool (Claude Code, Codex, or Cursor)
 
 ## License

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,16 +40,16 @@ Users of Claude Code, Codex, and Cursor receive updates based on these versions.
 
 ### Auto-bump workflow
 
-A GitHub Actions workflow (`.github/workflows/auto-version-bump.yml`) can automatically bump all three manifests on push to configured branches. It detects which plugins have changed files and sets the version to today's date (or appends a micro suffix for multiple bumps in the same day).
+A GitHub Actions workflow (`.github/workflows/auto-version-bump.yml`) automatically bumps all three manifests on push to `main`. It detects which plugins have changed files and sets the version to today's date (or appends a micro suffix for multiple bumps in the same day).
 
-If the auto-bump workflow is enabled for your branch, you do not need to manually bump versions. Otherwise, bump the version yourself in all three manifests before merging.
+**You do not need to manually bump versions** — the workflow handles it when your PR is merged to `main`.
 
 ## Pull Request Checklist
 
 - [ ] Skill follows the [Agent Skills specification](https://agentskills.io/specification)
 - [ ] `name` in SKILL.md frontmatter matches the directory name
 - [ ] `README.md` updated if a new skill was added
-- [ ] **Plugin versions bumped** in all three manifests (automatic if auto-bump workflow is configured, otherwise manual)
+- [ ] **Plugin versions bumped** in all three manifests (auto-bumped on merge to `main`)
 - [ ] Changes tested locally with the relevant tool (Claude Code, Codex, or Cursor)
 
 ## License

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,30 +28,28 @@ Conventions:
 - Keep `SKILL.md` concise; move deeper reference material into `references/`, `scripts/`, or `assets/` subdirectories.
 - Keep plugin manifests in sync with shipped skills for Codex (`plugins/signoz/.codex-plugin/plugin.json`) and Cursor (`plugins/signoz/.cursor-plugin/plugin.json`) distribution.
 
-## Bumping the Plugin Version
+## Plugin Versioning (CalVer)
 
-**This is required.** Whenever a skill is added or an existing skill is updated, you must bump the `version` field in **all** plugin manifests:
+This repository uses **CalVer** (`YYYY.MM.DD`, with an optional `.N` micro suffix for same-day releases) for plugin versions. The version field lives in three manifests per plugin:
 
 - `plugins/signoz/.claude-plugin/plugin.json`
 - `plugins/signoz/.codex-plugin/plugin.json`
 - `plugins/signoz/.cursor-plugin/plugin.json`
 
-Users of Claude Code, Codex, and Cursor receive updates based on the version in these manifests. If the version is not bumped, downstream users will not pick up the changes.
+Users of Claude Code, Codex, and Cursor receive updates based on these versions. If the version is not bumped, downstream users will not pick up the changes.
 
-Use [semver](https://semver.org/) to decide the bump:
+### Auto-bump workflow
 
-| Change | Bump |
-|--------|------|
-| New skill added | Minor (e.g. `1.0.1` -> `1.1.0`) |
-| Skill content updated (fix, improvement) | Patch (e.g. `1.0.1` -> `1.0.2`) |
-| Breaking change (skill renamed/removed, hook behavior change) | Major (e.g. `1.0.1` -> `2.0.0`) |
+A GitHub Actions workflow (`.github/workflows/auto-version-bump.yml`) automatically bumps all three manifests on push to the `jaine` branch. It detects which plugins have changed files and sets the version to today's date (or appends a micro suffix for multiple bumps in the same day).
+
+**You do not need to manually bump versions when pushing to `jaine`** — the workflow handles it. For other branches or manual releases, bump the version yourself in all three manifests.
 
 ## Pull Request Checklist
 
 - [ ] Skill follows the [Agent Skills specification](https://agentskills.io/specification)
 - [ ] `name` in SKILL.md frontmatter matches the directory name
 - [ ] `README.md` updated if a new skill was added
-- [ ] **Plugin versions bumped** in all three manifests (`plugin.json`)
+- [ ] **Plugin versions bumped** in all three manifests (auto-bumped on `jaine`, manual on other branches)
 - [ ] Changes tested locally with the relevant tool (Claude Code, Codex, or Cursor)
 
 ## License

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ npx skills add SigNoz/agent-skills --skill signoz-clickhouse-query    # specific
 | Marketplace | `signoz-skills` |
 | Plugin | `signoz` |
 | Repository | `SigNoz/agent-skills` |
+| Versioning | CalVer (`YYYY.MM.DD`) — auto-bumped on push to `jaine` |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ npx skills add SigNoz/agent-skills --skill signoz-clickhouse-query    # specific
 | Marketplace | `signoz-skills` |
 | Plugin | `signoz` |
 | Repository | `SigNoz/agent-skills` |
-| Versioning | CalVer (`YYYY.MM.DD`) — auto-bumped on push to `jaine` |
+| Versioning | CalVer (`YYYY.MM.DD`) — auto-bumped |
 
 ## Contributing
 

--- a/plugins/signoz/.claude-plugin/plugin.json
+++ b/plugins/signoz/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "signoz",
-  "version": "2026.04.04",
+  "version": "2026.04.07",
   "description": "Official SigNoz plugin for docs guidance and ClickHouse dashboard queries",
   "author": {
     "name": "SigNoz"

--- a/plugins/signoz/.claude-plugin/plugin.json
+++ b/plugins/signoz/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "signoz",
-  "version": "1.0.1",
+  "version": "2026.04.04",
   "description": "Official SigNoz plugin for docs guidance and ClickHouse dashboard queries",
   "author": {
     "name": "SigNoz"

--- a/plugins/signoz/hooks/scripts/allow-signoz-webfetch.js
+++ b/plugins/signoz/hooks/scripts/allow-signoz-webfetch.js
@@ -50,6 +50,6 @@ process.stdin.on("end", () => {
   }
 
   // Non-SigNoz URL — exit silently (no output = no decision).
-  // Previously returned "ask" which blocked ALL WebFetch calls in bypassPermissions mode.
+  // Previously returned "ask" for non-SigNoz or malformed requests in bypassPermissions mode.
   process.exit(0);
 });

--- a/plugins/signoz/hooks/scripts/allow-signoz-webfetch.js
+++ b/plugins/signoz/hooks/scripts/allow-signoz-webfetch.js
@@ -46,8 +46,10 @@ process.stdin.on("end", () => {
       return;
     }
   } catch {
-    // Fall through to the default ask behavior if the hook input is malformed.
+    // Malformed input — exit silently, let other hooks or default behavior handle it.
   }
 
-  emitDecision("ask", "URL is outside the SigNoz HTTPS allowlist");
+  // Non-SigNoz URL — exit silently (no output = no decision).
+  // Previously returned "ask" which blocked ALL WebFetch calls in bypassPermissions mode.
+  process.exit(0);
 });


### PR DESCRIPTION
## Summary

Builds on the external contribution in #12 (by @whatrwewaitingf0r) and adds security hardening, documentation, and reliability fixes.

### From #12
- Fix PreToolUse hook to exit silently for non-SigNoz URLs instead of emitting `ask`
- Add CalVer auto-bump workflow for the `jaine` branch
- Switch plugin version from semver to CalVer (`YYYY.MM.DD`)

### Security & reliability fixes (this PR)
- **Replace `sed` with `jq`** in the workflow to prevent shell injection via crafted version strings
- **Use `github.event.before`** instead of `HEAD~1` for reliable diffs across merge/squash commits
- **Add concurrency group** to prevent race conditions on concurrent pushes
- **Add error handling** for `git pull --rebase` failures
- **Add null-safe check** for `github.event.head_commit` (force-push safety)
- **Add version monotonicity guard** to prevent CalVer downgrades
- **Bump all three manifests** (`.claude-plugin`, `.codex-plugin`, `.cursor-plugin`), not just one
- **Remove `.gitattributes`** `merge=ours` that silently dropped incoming changes on conflicts
- **Remove dead `external_plugins/`** references
- **Add jq failure handling** and warnings for skipped plugins

### Documentation
- Add `CONTRIBUTING.md` with skill conventions, CalVer versioning, and PR checklist
- Add `CLAUDE.md` (with `AGENTS.md` symlink) pointing agents to the contributing guide
- Streamline `README.md` — move skill creation details to CONTRIBUTING.md, add CalVer note

## Test plan
- [x] Verify workflow YAML is valid (`actionlint` or GitHub dry-run)
- [x] Push a skill change to `jaine` and confirm all three `plugin.json` manifests are bumped
- [x] Confirm the hook still auto-allows `signoz.io` WebFetch and stays silent for other URLs
- [x] Verify `CONTRIBUTING.md`, `CLAUDE.md`, and `AGENTS.md` render correctly on GitHub