### PR TITLE
fix(dashboard-create): write import_template.sh scratch file under cwd

### DIFF
--- a/plugins/signoz/skills/signoz-dashboard-create/tools/import_template.sh
+++ b/plugins/signoz/skills/signoz-dashboard-create/tools/import_template.sh
@@ -29,7 +29,10 @@ PATH_ARG="${1#/}"
 ENCODED="$(jq -rn --arg s "$PATH_ARG" '$s | @uri' | sed 's|%2F|/|g')"
 URL="$BASE_URL/$PINNED_SHA/$ENCODED"
 
-TMP="$(mktemp)"
+# Write the scratch file under cwd (the agent's per-thread config_dir,
+# which is the only writable path in the sandbox). A bare `mktemp` resolves
+# to TMPDIR (on macOS that's /var/folders/<…>/T which the sandbox blocks).
+TMP="$(mktemp "./.import-template.XXXXXX")"
 trap 'rm -f "$TMP"' EXIT
 
 HTTP_CODE="$(curl -sS -o "$TMP" -w '%{http_code}' --max-time "$FETCH_TIMEOUT_SECONDS" "$URL" || true)"


### PR DESCRIPTION
## Summary
- \`import_template.sh\` calls bare \`mktemp\`, which resolves to \`\$TMPDIR\` — on macOS that's the per-uid Darwin temp dir (\`/var/folders/<…>/T\`).
- Agent runtimes that sandbox the Bash tool typically allow writes only to the agent's cwd, so the bare \`mktemp\` fails with \`Operation not permitted\`.
- Pass an explicit \`./\` template so the scratch file lands in cwd; \`trap rm -f\` still cleans it up.

## Test plan
- [x] \`bash import_template.sh "hostmetrics/hostmetrics.json"\` from a writable cwd — returns the JSON, exit 0, no file left behind.
- [ ] End-to-end via the SigNoz AI Assistant agent loop.