### PR TITLE
feat: add signoz-managing-views skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Official SigNoz skills for Claude Code, Codex, Cursor, and the [skills.sh](https
 | [signoz-generating-queries](plugins/signoz/skills/signoz-generating-queries/SKILL.md) | Generate queries against SigNoz observability data (traces, logs, metrics). |
 | [signoz-writing-clickhouse-queries](plugins/signoz/skills/signoz-writing-clickhouse-queries/SKILL.md) | Optimized ClickHouse queries for SigNoz OpenTelemetry traces and logs. |
 | [signoz-searching-docs](plugins/signoz/skills/signoz-searching-docs/SKILL.md) | SigNoz docs guidance for instrumentation, setup, querying, alerts, and APIs. |
+| [signoz-managing-views](plugins/signoz/skills/signoz-managing-views/SKILL.md) | Create, list, inspect, update, or delete SigNoz saved Explorer views (logs, traces, metrics) via the SigNoz MCP server. |
 
 ## Installation
 
@@ -75,7 +76,8 @@ npx skills add SigNoz/agent-skills --skill signoz-writing-clickhouse-queries    
 │       ├── signoz-explaining-dashboards/
 │       ├── signoz-modifying-dashboards/
 │       ├── signoz-searching-docs/
-│       └── signoz-generating-queries/
+│       ├── signoz-generating-queries/
+│       └── signoz-managing-views/
 └── README.md
 ```
 

--- a/plugins/signoz/skills/signoz-managing-views/SKILL.md
+++ b/plugins/signoz/skills/signoz-managing-views/SKILL.md
@@ -57,11 +57,11 @@ Do NOT use when the user wants to:
 - Run an ad-hoc Explorer query without saving it → `signoz-generating-queries`.
 - Create or change an alert rule → `signoz-creating-alerts`.
 
-## Schema is in the MCP resources, not here
+## Schema reference
 
 The authoritative SavedView schema lives on the MCP server. Read these
-**before** composing any create or update payload — do not transcribe schema
-from memory:
+**before** composing any create or update payload using `ReadMcpResourceTool`
+(not `signoz_fetch_doc` — these are MCP resources, not HTTP URLs):
 
 - `signoz://view/instructions` — SavedView field reference, `sourcePage`
   rules, the GET-then-PUT update flow, the minimal create body.
@@ -92,10 +92,13 @@ HTTP 400 on legacy v3/v4 fields (`builder`, `promql`, `unit`, top-level
    single number. List views set `stepInterval: 0`; graphs typically `60`.
 4. **Enforce `signal == sourcePage`** in every `builder_query` spec. A
    `sourcePage:"traces"` view with `signal:"logs"` is a server-side error.
-5. **Preview before writing.** Show the user the name, sourcePage, panel
-   type, filter expression, and any tags/category. For a human in the
-   loop, wait for confirmation. For an autonomous agent, proceed but log
-   the preview in your reply so it shows up in the transcript.
+5. **Preview before writing — this step is not optional.** Before calling
+   `signoz_create_view`, show the user a summary of what will be created:
+   name, sourcePage, panelType, and the full filter expression. Do this
+   even in autonomous mode — it surfaces filter mistakes (e.g. wrong
+   service name, wrong status value) before they become a saved view that
+   needs to be deleted. For a human in the loop, wait for confirmation.
+   For an autonomous agent, log the preview in the reply and proceed.
 6. Call `signoz:signoz_create_view`. The server populates `id`,
    `createdAt/By`, `updatedAt/By` — never send those.
 
@@ -133,10 +136,12 @@ upstream). Sending a partial body wipes the unspecified fields. The flow:
 3. Modify only the field(s) the user asked to change. For pure metadata
    tweaks (rename, retag, recategorize), do not touch `compositeQuery` —
    re-serializing it risks dropping a nested field.
-4. Show the user a diff-style preview ("rename `slow-checkout` →
-   `slow-checkout-p99`; tags unchanged"). Wait for confirmation on any
-   change to `compositeQuery`, since that changes what the view actually
-   shows.
+4. **Show a diff-style preview before writing.** One line per changed
+   field: `name: "slow-checkout" → "slow-checkout-p99"`. Explicitly note
+   any fields that are unchanged (e.g. "compositeQuery: unchanged"). This
+   prevents silent mistakes and gives the user a chance to catch a wrong
+   target view. Wait for confirmation on any change to `compositeQuery`,
+   since that changes what the view actually shows.
 5. Call `signoz:signoz_update_view` with `{ "viewId": "<id>", "view": <modified data> }`.
 
 If the user asks for a structural change to the query (new filter,

--- a/plugins/signoz/skills/signoz-managing-views/SKILL.md
+++ b/plugins/signoz/skills/signoz-managing-views/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: signoz-managing-views
 description: >
-  Create, list, get, update, rename, retag, or delete a SigNoz saved Explorer
+  Create, list, get, update, rename, or delete a SigNoz saved Explorer
   view (the reusable filter/panel snapshots that live on the Logs, Traces, and
   Metrics Explorer pages). Make sure to use this skill whenever the user says
   "save this query as a view", "save this filter", "bookmark this search",
   "list my saved views", "show me views for traces/logs/metrics", "rename the
-  X view", "add a tag to that view", "update my saved view to also filter Y",
+  X view", "update my saved view to also filter Y",
   "delete the X view", or otherwise asks to manage Explorer saved views — even
   if they don't say the word "view" explicitly. Also use it when someone wants
   to share a recurring Explorer query with their team and asks how to "save"
@@ -45,8 +45,8 @@ Use this skill when the user wants to:
 
 - **Create** a saved view from a current or described Explorer query.
 - **List / find** existing views (by `sourcePage`, name, or category).
-- **Inspect** a single view's filter, panel type, or tags.
-- **Update** a view — rename, retag, recategorize, or change its filter,
+- **Inspect** a single view's filter or panel type.
+- **Update** a view — rename, recategorize, or change its filter,
   panel type, or aggregations.
 - **Delete** a view that is no longer useful.
 
@@ -129,7 +129,7 @@ upstream). Sending a partial body wipes the unspecified fields. The flow:
    strips them for you, but omitting them up front makes the diff
    readable.
 3. Modify only the field(s) the user asked to change. For pure metadata
-   tweaks (rename, retag, recategorize), do not touch `compositeQuery` —
+   tweaks (rename, recategorize), do not touch `compositeQuery` —
    re-serializing it risks dropping a nested field.
 4. **Show a diff-style preview before writing.** One line per changed
    field: `name: "slow-checkout" → "slow-checkout-p99"`. Explicitly note
@@ -140,9 +140,11 @@ upstream). Sending a partial body wipes the unspecified fields. The flow:
 5. Call `signoz:signoz_update_view` with `{ "viewId": "<id>", "view": <modified data> }`.
 
 If the user asks for a structural change to the query (new filter,
-different panel type, different aggregation), re-read `signoz://view/instructions`
-before composing — the same `signal == sourcePage` rule applies, and
-`panelType` changes often imply a `stepInterval` change too.
+different panel type, different aggregation), invoke the
+`signoz-generating-queries` skill to build and validate the new
+`compositeQuery` before writing it back — the same `signal == sourcePage`
+rule applies, and `panelType` changes often imply a `stepInterval` change
+too.
 
 ### Delete a view
 
@@ -155,8 +157,8 @@ a shared table:
    without a confirming `signoz:signoz_get_view` showing the matching
    name and `sourcePage` — paste errors happen, and the wrong UUID deletes
    the wrong view silently.
-2. Show the user the resolved view's name, `sourcePage`, category, and
-   tags, and explicitly ask for confirmation. Do **not** auto-confirm
+2. Show the user the resolved view's name, `sourcePage`, and category,
+   and explicitly ask for confirmation. Do **not** auto-confirm
    based on the original prompt, even an emphatic one — destructive
    operations get a fresh confirmation against the resolved target.
 3. Call `signoz:signoz_delete_view`. Report success with the deleted
@@ -194,5 +196,5 @@ After any write (create / update / delete), include in your reply:
 - For deletes, an explicit "deleted" confirmation with the name.
 
 Read-only operations (list, get) should report concisely — name, id,
-sourcePage, filter expression, panel type, tags — and stop. Don't narrate
+sourcePage, filter expression, panel type — and stop. Don't narrate
 the schema back to the user.

--- a/plugins/signoz/skills/signoz-managing-views/SKILL.md
+++ b/plugins/signoz/skills/signoz-managing-views/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: signoz-managing-views
+description: >
+  Create, list, get, update, rename, retag, or delete a SigNoz saved Explorer
+  view (the reusable filter/panel snapshots that live on the Logs, Traces, and
+  Metrics Explorer pages). Make sure to use this skill whenever the user says
+  "save this query as a view", "save this filter", "bookmark this search",
+  "list my saved views", "show me views for traces/logs/metrics", "rename the
+  X view", "add a tag to that view", "update my saved view to also filter Y",
+  "delete the X view", or otherwise asks to manage Explorer saved views — even
+  if they don't say the word "view" explicitly. Also use it when someone wants
+  to share a recurring Explorer query with their team and asks how to "save"
+  or "bookmark" it.
+argument-hint: <natural-language view request>
+---
+
+# Managing Saved Views
+
+Create, read, update, and delete SigNoz **saved Explorer views** via the
+SigNoz MCP server. A saved view is a reusable snapshot of an Explorer query
+on the Logs, Traces, or Metrics page — name + filters + panel type, scoped
+to one `sourcePage`. They are not dashboards and not alerts.
+
+This skill covers the full CRUD surface in one place because the operations
+share the same schema, the same identity model (UUID per view), and the same
+prerequisite resources. The only operation with real blast radius is delete,
+and update has a sharp edge (full-body replace) — both get explicit guards
+below.
+
+## Prerequisites
+
+This skill calls SigNoz MCP server tools (`signoz:signoz_create_view`,
+`signoz:signoz_list_views`, `signoz:signoz_get_view`,
+`signoz:signoz_update_view`, `signoz:signoz_delete_view`,
+`signoz:signoz_get_field_keys`, `signoz:signoz_get_field_values`). Before
+running the workflow, confirm the `signoz:signoz_*` tools are available. If
+they are not, the SigNoz MCP server is not installed or configured — stop
+and direct the user to set it up:
+<https://signoz.io/docs/ai/signoz-mcp-server/>. Do not fall back to raw HTTP
+calls or fabricate view payloads without the MCP tools.
+
+## When to use
+
+Use this skill when the user wants to:
+
+- **Create** a saved view from a current or described Explorer query.
+- **List / find** existing views (by `sourcePage`, name, or category).
+- **Inspect** a single view's filter, panel type, or tags.
+- **Update** a view — rename, retag, recategorize, or change its filter,
+  panel type, or aggregations.
+- **Delete** a view that is no longer useful.
+
+Do NOT use when the user wants to:
+
+- Build a dashboard panel → `signoz-creating-dashboards` /
+  `signoz-modifying-dashboards`.
+- Run an ad-hoc Explorer query without saving it → `signoz-generating-queries`.
+- Create or change an alert rule → `signoz-creating-alerts`.
+
+## Schema is in the MCP resources, not here
+
+The authoritative SavedView schema lives on the MCP server. Read these
+**before** composing any create or update payload — do not transcribe schema
+from memory:
+
+- `signoz://view/instructions` — SavedView field reference, `sourcePage`
+  rules, the GET-then-PUT update flow, the minimal create body.
+- `signoz://view/examples` — three round-tripped payloads (traces list, logs
+  list, metrics graph) you can adapt verbatim.
+
+Both `signoz:signoz_create_view` and `signoz:signoz_update_view` repeat this
+requirement in their tool descriptions for a reason: the server returns
+HTTP 400 on legacy v3/v4 fields (`builder`, `promql`, `unit`, top-level
+`id`, `queryFormulas`) and the failure mode is silent for the user.
+
+## Operation flows
+
+### Create a view
+
+1. **Resolve `sourcePage`** — must be exactly one of `traces`, `logs`,
+   `metrics`. If the user's intent is ambiguous ("save this query"), ask
+   which Explorer they mean. It cannot be inferred from filter strings alone.
+2. **Compose the filter expression.** Prefer a **resource attribute** in the
+   filter (`service.name`, `k8s.namespace.name`, `host.name`) — the SigNoz
+   backend uses these as primary indices, and a view without one tends to
+   be slow and noisy when reopened. If the user did not name a resource
+   attribute, call `signoz:signoz_get_field_keys` (with
+   `fieldContext=resource` and the matching `signal`) to surface options,
+   then ask the user to pick one. Do not invent attribute names.
+3. **Pick `panelType`** to match intent: `list` for tabular spans/logs,
+   `graph` for time-series, `table` for grouped tables, `value` for a
+   single number. List views set `stepInterval: 0`; graphs typically `60`.
+4. **Enforce `signal == sourcePage`** in every `builder_query` spec. A
+   `sourcePage:"traces"` view with `signal:"logs"` is a server-side error.
+5. **Preview before writing.** Show the user the name, sourcePage, panel
+   type, filter expression, and any tags/category. For a human in the
+   loop, wait for confirmation. For an autonomous agent, proceed but log
+   the preview in your reply so it shows up in the transcript.
+6. Call `signoz:signoz_create_view`. The server populates `id`,
+   `createdAt/By`, `updatedAt/By` — never send those.
+
+### List or find views
+
+`signoz:signoz_list_views` requires a `sourcePage`. If the user did not
+specify one and is searching by name, call it once per signal (traces,
+logs, metrics) and merge — do not guess. Use the `name` and `category`
+parameters for server-side partial-match filtering when the user gives a
+substring; do not fetch everything and grep client-side.
+
+The response paginates. **Always check `pagination.hasMore`** before
+concluding a view does not exist. Default page size is 50; pass `offset =
+pagination.nextOffset` to continue. Ten pages of misses is still a real
+miss; one page of misses is not.
+
+### Get a single view
+
+Use `signoz:signoz_get_view` with the UUID. The returned `data` object is
+the canonical SavedView shape — it is what you pass back to
+`signoz:signoz_update_view`. Treat that data as the source of truth, not
+whatever the user described from memory.
+
+### Update a view (GET-then-PUT)
+
+`signoz:signoz_update_view` is a **full-body replace** (HTTP PUT
+upstream). Sending a partial body wipes the unspecified fields. The flow:
+
+1. `signoz:signoz_get_view` with the view's `id` → returns
+   `{ "status": "success", "data": { ...SavedView... } }`.
+2. Take the `data` object. Strip server-populated fields (`id`,
+   `createdAt`, `createdBy`, `updatedAt`, `updatedBy`) — the MCP server
+   strips them for you, but omitting them up front makes the diff
+   readable.
+3. Modify only the field(s) the user asked to change. For pure metadata
+   tweaks (rename, retag, recategorize), do not touch `compositeQuery` —
+   re-serializing it risks dropping a nested field.
+4. Show the user a diff-style preview ("rename `slow-checkout` →
+   `slow-checkout-p99`; tags unchanged"). Wait for confirmation on any
+   change to `compositeQuery`, since that changes what the view actually
+   shows.
+5. Call `signoz:signoz_update_view` with `{ "viewId": "<id>", "view": <modified data> }`.
+
+If the user asks for a structural change to the query (new filter,
+different panel type, different aggregation), re-read `signoz://view/instructions`
+before composing — the same `signal == sourcePage` rule applies, and
+`panelType` changes often imply a `stepInterval` change too.
+
+### Delete a view
+
+Deletion is permanent — there is no undo, and any team member who had the
+view bookmarked will see it disappear. Treat this like dropping a row from
+a shared table:
+
+1. Resolve the view by UUID (via list or by exact name → list result).
+   Never call `signoz:signoz_delete_view` on a UUID the user pasted
+   without a confirming `signoz:signoz_get_view` showing the matching
+   name and `sourcePage` — paste errors happen, and the wrong UUID deletes
+   the wrong view silently.
+2. Show the user the resolved view's name, `sourcePage`, category, and
+   tags, and explicitly ask for confirmation. Do **not** auto-confirm
+   based on the original prompt, even an emphatic one — destructive
+   operations get a fresh confirmation against the resolved target.
+3. Call `signoz:signoz_delete_view`. Report success with the deleted
+   view's name (not just the UUID), so the user can recognize it.
+
+For autonomous agents without a human in the loop: refuse delete unless
+the calling context has been explicitly authorized for destructive
+operations on saved views, and log the resolved view metadata before the
+call.
+
+## Common pitfalls
+
+- **Wrong sourcePage.** `traces` vs `logs` vs `metrics` — case-sensitive,
+  no plural. A typo here is a 400.
+- **Sending legacy fields.** `builder`, `promql`, `clickhouse_sql`,
+  top-level `id`, `unit`, `queryFormulas`, `queryTraceOperator` are all
+  rejected. Read `signoz://view/instructions` if unsure.
+- **PromQL / raw ClickHouse in a view.** Not supported for Explorer
+  saved views — only `queryType: "builder"` works. Tell the user and
+  offer a dashboard panel instead (see `signoz-creating-dashboards`).
+- **Partial update body.** Always go GET → modify → PUT. Do not hand-
+  compose an update body from the user's description.
+- **Skipping `pagination.hasMore`.** A "no such view" answer based on
+  page 1 alone is worth nothing on a busy tenant.
+
+## Reporting back
+
+After any write (create / update / delete), include in your reply:
+- The view's name and UUID.
+- The `sourcePage`.
+- A direct link if you can construct one
+  (`<base>/saved-views?sourcepage=<traces|logs|metrics>` is a reasonable
+  fallback when the deep link is not known).
+- For updates, what changed (one-line diff).
+- For deletes, an explicit "deleted" confirmation with the name.
+
+Read-only operations (list, get) should report concisely — name, id,
+sourcePage, filter expression, panel type, tags — and stop. Don't narrate
+the schema back to the user.

--- a/plugins/signoz/skills/signoz-managing-views/SKILL.md
+++ b/plugins/signoz/skills/signoz-managing-views/SKILL.md
@@ -128,23 +128,21 @@ upstream). Sending a partial body wipes the unspecified fields. The flow:
    `createdAt`, `createdBy`, `updatedAt`, `updatedBy`) — the MCP server
    strips them for you, but omitting them up front makes the diff
    readable.
-3. Modify only the field(s) the user asked to change. For pure metadata
-   tweaks (rename, recategorize), do not touch `compositeQuery` —
-   re-serializing it risks dropping a nested field.
-4. **Show a diff-style preview before writing.** One line per changed
+3. **If the update changes `compositeQuery`** (new filter, different panel
+   type, different aggregation), invoke `signoz-generating-queries` to
+   build and validate the new query before proceeding. Do not hand-edit
+   `compositeQuery` from the user's description — the same
+   `signal == sourcePage` rule applies, and `panelType` changes often
+   imply a `stepInterval` change too. For pure metadata tweaks (rename,
+   recategorize), skip this step and do not touch `compositeQuery`.
+4. Modify only the field(s) the user asked to change.
+5. **Show a diff-style preview before writing.** One line per changed
    field: `name: "slow-checkout" → "slow-checkout-p99"`. Explicitly note
    any fields that are unchanged (e.g. "compositeQuery: unchanged"). This
    prevents silent mistakes and gives the user a chance to catch a wrong
    target view. Wait for confirmation on any change to `compositeQuery`,
    since that changes what the view actually shows.
-5. Call `signoz:signoz_update_view` with `{ "viewId": "<id>", "view": <modified data> }`.
-
-If the user asks for a structural change to the query (new filter,
-different panel type, different aggregation), invoke the
-`signoz-generating-queries` skill to build and validate the new
-`compositeQuery` before writing it back — the same `signal == sourcePage`
-rule applies, and `panelType` changes often imply a `stepInterval` change
-too.
+6. Call `signoz:signoz_update_view` with `{ "viewId": "<id>", "view": <modified data> }`.
 
 ### Delete a view
 
@@ -173,6 +171,10 @@ call.
 
 - **Wrong sourcePage.** `traces` vs `logs` vs `metrics` — case-sensitive,
   no plural. A typo here is a 400.
+- **`signal` ≠ `sourcePage` in a builder query.** Every `builder_query`
+  inside a view's `compositeQuery` must have `signal` equal to the view's
+  `sourcePage`. A `sourcePage:"traces"` view with `signal:"logs"` is a
+  server-side error. This applies to both create and update.
 - **Sending legacy fields.** `builder`, `promql`, `clickhouse_sql`,
   top-level `id`, `unit`, `queryFormulas`, `queryTraceOperator` are all
   rejected. Read `signoz://view/instructions` if unsure.
@@ -183,6 +185,9 @@ call.
   compose an update body from the user's description.
 - **Skipping `pagination.hasMore`.** A "no such view" answer based on
   page 1 alone is worth nothing on a busy tenant.
+- **`category` is a free-form string.** There is no server-enforced enum
+  for `category` — pass whatever label the user provides. Omit it (empty
+  string or absent) if the user does not specify one.
 
 ## Reporting back
 

--- a/plugins/signoz/skills/signoz-managing-views/SKILL.md
+++ b/plugins/signoz/skills/signoz-managing-views/SKILL.md
@@ -80,26 +80,21 @@ HTTP 400 on legacy v3/v4 fields (`builder`, `promql`, `unit`, top-level
 1. **Resolve `sourcePage`** — must be exactly one of `traces`, `logs`,
    `metrics`. If the user's intent is ambiguous ("save this query"), ask
    which Explorer they mean. It cannot be inferred from filter strings alone.
-2. **Compose the filter expression.** Prefer a **resource attribute** in the
-   filter (`service.name`, `k8s.namespace.name`, `host.name`) — the SigNoz
-   backend uses these as primary indices, and a view without one tends to
-   be slow and noisy when reopened. If the user did not name a resource
-   attribute, call `signoz:signoz_get_field_keys` (with
-   `fieldContext=resource` and the matching `signal`) to surface options,
-   then ask the user to pick one. Do not invent attribute names.
-3. **Pick `panelType`** to match intent: `list` for tabular spans/logs,
-   `graph` for time-series, `table` for grouped tables, `value` for a
-   single number. List views set `stepInterval: 0`; graphs typically `60`.
-4. **Enforce `signal == sourcePage`** in every `builder_query` spec. A
+2. **Build the query using `signoz-generating-queries`.** Invoke the
+   `signoz-generating-queries` skill to construct and validate the
+   `compositeQuery` before saving it as a view. This ensures the query
+   actually returns data and surfaces filter mistakes (e.g. wrong service
+   name, wrong attribute key) before they become a saved view that needs to
+   be deleted. Do not hand-compose a `compositeQuery` from the user's
+   description alone.
+3. **Enforce `signal == sourcePage`** in every `builder_query` spec. A
    `sourcePage:"traces"` view with `signal:"logs"` is a server-side error.
-5. **Preview before writing — this step is not optional.** Before calling
+4. **Preview before writing — this step is not optional.** Before calling
    `signoz_create_view`, show the user a summary of what will be created:
-   name, sourcePage, panelType, and the full filter expression. Do this
-   even in autonomous mode — it surfaces filter mistakes (e.g. wrong
-   service name, wrong status value) before they become a saved view that
-   needs to be deleted. For a human in the loop, wait for confirmation.
-   For an autonomous agent, log the preview in the reply and proceed.
-6. Call `signoz:signoz_create_view`. The server populates `id`,
+   name, sourcePage, panelType, and the full filter expression. For a human
+   in the loop, wait for confirmation. For an autonomous agent, log the
+   preview in the reply and proceed.
+5. Call `signoz:signoz_create_view`. The server populates `id`,
    `createdAt/By`, `updatedAt/By` — never send those.
 
 ### List or find views

--- a/plugins/signoz/skills/signoz-managing-views/SKILL.md
+++ b/plugins/signoz/skills/signoz-managing-views/SKILL.md
@@ -1,16 +1,14 @@
 ---
 name: signoz-managing-views
 description: >
-  Create, list, get, update, rename, or delete a SigNoz saved Explorer
-  view (the reusable filter/panel snapshots that live on the Logs, Traces, and
-  Metrics Explorer pages). Make sure to use this skill whenever the user says
-  "save this query as a view", "save this filter", "bookmark this search",
-  "list my saved views", "show me views for traces/logs/metrics", "rename the
-  X view", "update my saved view to also filter Y",
-  "delete the X view", or otherwise asks to manage Explorer saved views — even
-  if they don't say the word "view" explicitly. Also use it when someone wants
-  to share a recurring Explorer query with their team and asks how to "save"
-  or "bookmark" it.
+  Use when the user wants to create, list, get, update, rename, or delete a
+  SigNoz saved Explorer view. Trigger on phrases like "save this query as a
+  view", "save this filter", "bookmark this search", "list my saved views",
+  "show me views for traces/logs/metrics", "rename the X view", "update my
+  saved view to also filter Y", "delete the X view", or any request to manage
+  Explorer saved views — even if they don't say "view" explicitly. Also use
+  when someone wants to share a recurring Explorer query with their team and
+  asks how to "save" or "bookmark" it.
 argument-hint: <natural-language view request>
 ---
 
@@ -59,19 +57,27 @@ Do NOT use when the user wants to:
 
 ## Schema reference
 
-The authoritative SavedView schema lives on the MCP server. Read these
-**before** composing any create or update payload using `ReadMcpResourceTool`
-(not `signoz_fetch_doc` — these are MCP resources, not HTTP URLs):
+**Read both resources BEFORE composing any create or update payload.** Do not
+hand-compose a `compositeQuery` from memory — the correct schema is not the
+legacy `builder.queryData` format; it is the v5 spec described in these
+resources. Sending a legacy payload causes a silent HTTP 400.
+
+Call `ReadMcpResourceTool` with each URI to load them:
+
+```
+ReadMcpResourceTool(uri="signoz://view/instructions")
+ReadMcpResourceTool(uri="signoz://view/examples")
+```
 
 - `signoz://view/instructions` — SavedView field reference, `sourcePage`
   rules, the GET-then-PUT update flow, the minimal create body.
 - `signoz://view/examples` — three round-tripped payloads (traces list, logs
   list, metrics graph) you can adapt verbatim.
 
-Both `signoz:signoz_create_view` and `signoz:signoz_update_view` repeat this
-requirement in their tool descriptions for a reason: the server returns
-HTTP 400 on legacy v3/v4 fields (`builder`, `promql`, `unit`, top-level
-`id`, `queryFormulas`) and the failure mode is silent for the user.
+The server returns HTTP 400 on legacy v3/v4 fields (`builder`, `promql`,
+`unit`, top-level `id`, `queryFormulas`, `queryTraceOperator`) — the failure
+mode is silent for the user, so reading the resources first is mandatory, not
+optional.
 
 ## Operation flows
 
@@ -80,21 +86,22 @@ HTTP 400 on legacy v3/v4 fields (`builder`, `promql`, `unit`, top-level
 1. **Resolve `sourcePage`** — must be exactly one of `traces`, `logs`,
    `metrics`. If the user's intent is ambiguous ("save this query"), ask
    which Explorer they mean. It cannot be inferred from filter strings alone.
-2. **Build the query using `signoz-generating-queries`.** Invoke the
-   `signoz-generating-queries` skill to construct and validate the
-   `compositeQuery` before saving it as a view. This ensures the query
-   actually returns data and surfaces filter mistakes (e.g. wrong service
-   name, wrong attribute key) before they become a saved view that needs to
-   be deleted. Do not hand-compose a `compositeQuery` from the user's
-   description alone.
-3. **Enforce `signal == sourcePage`** in every `builder_query` spec. A
+2. **Read the schema resources.** Call `ReadMcpResourceTool` for both
+   `signoz://view/instructions` and `signoz://view/examples` before composing
+   any payload. Do not skip this step even if you think you know the schema —
+   the legacy `builder.queryData` format is rejected with HTTP 400.
+3. **Build the query using `signoz-generating-queries` — mandatory.** Invoke
+   the `signoz-generating-queries` skill to construct and validate the
+   `compositeQuery`. Do not hand-compose a `compositeQuery` from the user's
+   description alone. This surfaces filter mistakes before they become a
+   saved view that needs to be deleted.
+4. **Enforce `signal == sourcePage`** in every `builder_query` spec. A
    `sourcePage:"traces"` view with `signal:"logs"` is a server-side error.
-4. **Preview before writing — this step is not optional.** Before calling
-   `signoz_create_view`, show the user a summary of what will be created:
-   name, sourcePage, panelType, and the full filter expression. For a human
-   in the loop, wait for confirmation. For an autonomous agent, log the
-   preview in the reply and proceed.
-5. Call `signoz:signoz_create_view`. The server populates `id`,
+5. **Preview before writing — this step is not optional.** Before calling
+   `signoz_create_view`, show the user a summary: name, sourcePage,
+   panelType, and the full filter expression. For a human in the loop, wait
+   for confirmation. For an autonomous agent, log the preview and proceed.
+6. Call `signoz:signoz_create_view`. The server populates `id`,
    `createdAt/By`, `updatedAt/By` — never send those.
 
 ### List or find views
@@ -150,16 +157,20 @@ Deletion is permanent — there is no undo, and any team member who had the
 view bookmarked will see it disappear. Treat this like dropping a row from
 a shared table:
 
-1. Resolve the view by UUID (via list or by exact name → list result).
-   Never call `signoz:signoz_delete_view` on a UUID the user pasted
-   without a confirming `signoz:signoz_get_view` showing the matching
-   name and `sourcePage` — paste errors happen, and the wrong UUID deletes
-   the wrong view silently.
-2. Show the user the resolved view's name, `sourcePage`, and category,
-   and explicitly ask for confirmation. Do **not** auto-confirm
+1. **List to locate.** Call `signoz:signoz_list_views` to find the view
+   by name. If `sourcePage` is unknown, search all three signals.
+2. **Get to confirm — mandatory.** Call `signoz:signoz_get_view` with the
+   UUID from step 1. Do NOT skip this step even when you got the UUID from
+   a list result that looks correct. List results are paginated and a name
+   match is not a UUID guarantee — `signoz_get_view` is the confirmation
+   that the UUID maps to the view the user named.
+   Never call `signoz:signoz_delete_view` on a UUID without a prior
+   `signoz:signoz_get_view` confirming the matching name and `sourcePage`.
+3. **Show and ask.** Present the resolved view's name, `sourcePage`, and
+   category, and explicitly ask for confirmation. Do **not** auto-confirm
    based on the original prompt, even an emphatic one — destructive
    operations get a fresh confirmation against the resolved target.
-3. Call `signoz:signoz_delete_view`. Report success with the deleted
+4. Call `signoz:signoz_delete_view`. Report success with the deleted
    view's name (not just the UUID), so the user can recognize it.
 
 For autonomous agents without a human in the loop: refuse delete unless
@@ -167,27 +178,28 @@ the calling context has been explicitly authorized for destructive
 operations on saved views, and log the resolved view metadata before the
 call.
 
-## Common pitfalls
+## Quick reference
 
-- **Wrong sourcePage.** `traces` vs `logs` vs `metrics` — case-sensitive,
-  no plural. A typo here is a 400.
-- **`signal` ≠ `sourcePage` in a builder query.** Every `builder_query`
-  inside a view's `compositeQuery` must have `signal` equal to the view's
-  `sourcePage`. A `sourcePage:"traces"` view with `signal:"logs"` is a
-  server-side error. This applies to both create and update.
-- **Sending legacy fields.** `builder`, `promql`, `clickhouse_sql`,
-  top-level `id`, `unit`, `queryFormulas`, `queryTraceOperator` are all
-  rejected. Read `signoz://view/instructions` if unsure.
-- **PromQL / raw ClickHouse in a view.** Not supported for Explorer
-  saved views — only `queryType: "builder"` works. Tell the user and
-  offer a dashboard panel instead (see `signoz-creating-dashboards`).
-- **Partial update body.** Always go GET → modify → PUT. Do not hand-
-  compose an update body from the user's description.
-- **Skipping `pagination.hasMore`.** A "no such view" answer based on
-  page 1 alone is worth nothing on a busy tenant.
-- **`category` is a free-form string.** There is no server-enforced enum
-  for `category` — pass whatever label the user provides. Omit it (empty
-  string or absent) if the user does not specify one.
+| Operation | Tools called | Key guard |
+|-----------|-------------|-----------|
+| Create | `ReadMcpResourceTool` × 2 → `signoz-generating-queries` → preview → `signoz_create_view` | Preview before write; no legacy fields |
+| List | `signoz_list_views` (× 3 if no sourcePage given) | Check `pagination.hasMore` |
+| Get | `signoz_get_view(viewId)` | Returns canonical body for update |
+| Update | `signoz_get_view` → modify → preview → `signoz_update_view` | Full-body replace; diff preview required |
+| Delete | `signoz_list_views` → `signoz_get_view` → confirm → `signoz_delete_view` | Get-before-delete mandatory; fresh confirmation |
+
+## Common mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Hand-composing `compositeQuery` using legacy `builder.queryData` format | Read `signoz://view/instructions` first; use `signoz-generating-queries` to build the query |
+| Skipping `signoz_get_view` before delete (relying on list UUID alone) | Always call `signoz_get_view` to confirm name+sourcePage before `signoz_delete_view` |
+| Sending legacy fields: `builder`, `promql`, `unit`, top-level `id`, `queryFormulas` | Read schema resources; server returns HTTP 400 silently |
+| `signal` ≠ `sourcePage` in builder query | Every `builder_query.signal` must equal the view's `sourcePage` |
+| Partial update body (omitting unchanged fields) | GET full body first → modify only changed fields → PUT entire body |
+| Declaring "no such view" after only page 1 | Check `pagination.hasMore`; continue with `offset = pagination.nextOffset` |
+| Using PromQL or raw ClickHouse in a view | Only `queryType: "builder"` is supported; offer a dashboard panel instead |
+| Setting `category` to an enum value | `category` is free-form string; omit if user doesn't specify |
 
 ## Reporting back
 

--- a/plugins/signoz/skills/signoz-managing-views/SKILL.md
+++ b/plugins/signoz/skills/signoz-managing-views/SKILL.md
@@ -90,11 +90,15 @@ optional.
    `signoz://view/instructions` and `signoz://view/examples` before composing
    any payload. Do not skip this step even if you think you know the schema —
    the legacy `builder.queryData` format is rejected with HTTP 400.
-3. **Build the query using `signoz-generating-queries` — mandatory.** Invoke
-   the `signoz-generating-queries` skill to construct and validate the
-   `compositeQuery`. Do not hand-compose a `compositeQuery` from the user's
-   description alone. This surfaces filter mistakes before they become a
-   saved view that needs to be deleted.
+3. **Build the query using `signoz-generating-queries` — mandatory.** Use
+   the `Skill` tool to invoke `signoz-generating-queries`. This is the only
+   way to satisfy this step — reading `signoz://view/examples` and adapting
+   an example payload does NOT count, and calling `signoz_search_traces`
+   directly for validation does NOT count. The sub-skill runs field
+   discovery, builds the `compositeQuery` spec, and validates it against
+   the live data before you write anything. Skipping it means a malformed
+   filter becomes a permanent saved view that needs to be deleted and
+   recreated.
 4. **Enforce `signal == sourcePage`** in every `builder_query` spec. A
    `sourcePage:"traces"` view with `signal:"logs"` is a server-side error.
 5. **Preview before writing — this step is not optional.** Before calling
@@ -192,7 +196,7 @@ call.
 
 | Mistake | Fix |
 |---------|-----|
-| Hand-composing `compositeQuery` using legacy `builder.queryData` format | Read `signoz://view/instructions` first; use `signoz-generating-queries` to build the query |
+| Hand-composing `compositeQuery` from examples or memory (even after reading `signoz://view/examples`) | Use the `Skill` tool to invoke `signoz-generating-queries` — reading examples and validating with `signoz_search_traces` is not a substitute |
 | Skipping `signoz_get_view` before delete (relying on list UUID alone) | Always call `signoz_get_view` to confirm name+sourcePage before `signoz_delete_view` |
 | Sending legacy fields: `builder`, `promql`, `unit`, top-level `id`, `queryFormulas` | Read schema resources; server returns HTTP 400 silently |
 | `signal` ≠ `sourcePage` in builder query | Every `builder_query.signal` must equal the view's `sourcePage` |

--- a/plugins/signoz/skills/signoz-managing-views/SKILL.md
+++ b/plugins/signoz/skills/signoz-managing-views/SKILL.md
@@ -62,12 +62,7 @@ hand-compose a `compositeQuery` from memory — the correct schema is not the
 legacy `builder.queryData` format; it is the v5 spec described in these
 resources. Sending a legacy payload causes a silent HTTP 400.
 
-Call `ReadMcpResourceTool` with each URI to load them:
-
-```
-ReadMcpResourceTool(uri="signoz://view/instructions")
-ReadMcpResourceTool(uri="signoz://view/examples")
-```
+Read both MCP resources by URI using your client's resource-read mechanism:
 
 - `signoz://view/instructions` — SavedView field reference, `sourcePage`
   rules, the GET-then-PUT update flow, the minimal create body.
@@ -86,10 +81,11 @@ optional.
 1. **Resolve `sourcePage`** — must be exactly one of `traces`, `logs`,
    `metrics`. If the user's intent is ambiguous ("save this query"), ask
    which Explorer they mean. It cannot be inferred from filter strings alone.
-2. **Read the schema resources.** Call `ReadMcpResourceTool` for both
-   `signoz://view/instructions` and `signoz://view/examples` before composing
-   any payload. Do not skip this step even if you think you know the schema —
-   the legacy `builder.queryData` format is rejected with HTTP 400.
+2. **Read the schema resources.** Read both `signoz://view/instructions`
+   and `signoz://view/examples` using your client's resource-read mechanism
+   before composing any payload. Do not skip this step even if you think
+   you know the schema — the legacy `builder.queryData` format is rejected
+   with HTTP 400.
 3. **Build the query using `signoz-generating-queries` — mandatory.** Use
    the `Skill` tool to invoke `signoz-generating-queries`. This is the only
    way to satisfy this step — reading `signoz://view/examples` and adapting
@@ -102,7 +98,7 @@ optional.
 4. **Enforce `signal == sourcePage`** in every `builder_query` spec. A
    `sourcePage:"traces"` view with `signal:"logs"` is a server-side error.
 5. **Preview before writing — this step is not optional.** Before calling
-   `signoz_create_view`, show the user a summary: name, sourcePage,
+   `signoz:signoz_create_view`, show the user a summary: name, sourcePage,
    panelType, and the full filter expression. For a human in the loop, wait
    for confirmation. For an autonomous agent, log the preview and proceed.
 6. Call `signoz:signoz_create_view`. The server populates `id`,
@@ -118,8 +114,9 @@ substring; do not fetch everything and grep client-side.
 
 The response paginates. **Always check `pagination.hasMore`** before
 concluding a view does not exist. Default page size is 50; pass `offset =
-pagination.nextOffset` to continue. Ten pages of misses is still a real
-miss; one page of misses is not.
+pagination.nextOffset` to continue. A view is only confirmed missing for a
+given `sourcePage` once you have walked pages until `hasMore = false`. As
+long as `hasMore = true`, keep paginating — there is no page-count cap.
 
 ### Get a single view
 
@@ -166,7 +163,7 @@ a shared table:
 2. **Get to confirm — mandatory.** Call `signoz:signoz_get_view` with the
    UUID from step 1. Do NOT skip this step even when you got the UUID from
    a list result that looks correct. List results are paginated and a name
-   match is not a UUID guarantee — `signoz_get_view` is the confirmation
+   match is not a UUID guarantee — `signoz:signoz_get_view` is the confirmation
    that the UUID maps to the view the user named.
    Never call `signoz:signoz_delete_view` on a UUID without a prior
    `signoz:signoz_get_view` confirming the matching name and `sourcePage`.
@@ -186,18 +183,18 @@ call.
 
 | Operation | Tools called | Key guard |
 |-----------|-------------|-----------|
-| Create | `ReadMcpResourceTool` × 2 → `signoz-generating-queries` → preview → `signoz_create_view` | Preview before write; no legacy fields |
-| List | `signoz_list_views` (× 3 if no sourcePage given) | Check `pagination.hasMore` |
-| Get | `signoz_get_view(viewId)` | Returns canonical body for update |
-| Update | `signoz_get_view` → modify → preview → `signoz_update_view` | Full-body replace; diff preview required |
-| Delete | `signoz_list_views` → `signoz_get_view` → confirm → `signoz_delete_view` | Get-before-delete mandatory; fresh confirmation |
+| Create | read `signoz://view/instructions` + `signoz://view/examples` → `signoz-generating-queries` → preview → `signoz:signoz_create_view` | Preview before write; no legacy fields |
+| List | `signoz:signoz_list_views` (× 3 if no sourcePage given) | Check `pagination.hasMore` |
+| Get | `signoz:signoz_get_view(viewId)` | Returns canonical body for update |
+| Update | `signoz:signoz_get_view` → modify → preview → `signoz:signoz_update_view` | Full-body replace; diff preview required |
+| Delete | `signoz:signoz_list_views` → `signoz:signoz_get_view` → confirm → `signoz:signoz_delete_view` | Get-before-delete mandatory; fresh confirmation |
 
 ## Common mistakes
 
 | Mistake | Fix |
 |---------|-----|
-| Hand-composing `compositeQuery` from examples or memory (even after reading `signoz://view/examples`) | Use the `Skill` tool to invoke `signoz-generating-queries` — reading examples and validating with `signoz_search_traces` is not a substitute |
-| Skipping `signoz_get_view` before delete (relying on list UUID alone) | Always call `signoz_get_view` to confirm name+sourcePage before `signoz_delete_view` |
+| Hand-composing `compositeQuery` from examples or memory (even after reading `signoz://view/examples`) | Use the `Skill` tool to invoke `signoz-generating-queries` — reading examples and validating with `signoz:signoz_search_traces` is not a substitute |
+| Skipping `signoz:signoz_get_view` before delete (relying on list UUID alone) | Always call `signoz:signoz_get_view` to confirm name+sourcePage before `signoz:signoz_delete_view` |
 | Sending legacy fields: `builder`, `promql`, `unit`, top-level `id`, `queryFormulas` | Read schema resources; server returns HTTP 400 silently |
 | `signal` ≠ `sourcePage` in builder query | Every `builder_query.signal` must equal the view's `sourcePage` |
 | Partial update body (omitting unchanged fields) | GET full body first → modify only changed fields → PUT entire body |
@@ -210,9 +207,10 @@ call.
 After any write (create / update / delete), include in your reply:
 - The view's name and UUID.
 - The `sourcePage`.
-- A direct link if you can construct one
-  (`<base>/saved-views?sourcepage=<traces|logs|metrics>` is a reasonable
-  fallback when the deep link is not known).
+- A direct link **only** if the MCP response or SigNoz frontend provides a
+  canonical URL, or the user explicitly asks for one. Do not fabricate
+  frontend routes — saved-view paths differ per signal and change over
+  time. When in doubt, omit the link and report the UUID + `sourcePage`.
 - For updates, what changed (one-line diff).
 - For deletes, an explicit "deleted" confirmation with the name.
 

--- a/plugins/signoz/skills/signoz-managing-views/SKILL.md
+++ b/plugins/signoz/skills/signoz-managing-views/SKILL.md
@@ -87,14 +87,13 @@ optional.
    you know the schema — the legacy `builder.queryData` format is rejected
    with HTTP 400.
 3. **Build the query using `signoz-generating-queries` — mandatory.** Use
-   the `Skill` tool to invoke `signoz-generating-queries`. This is the only
-   way to satisfy this step — reading `signoz://view/examples` and adapting
-   an example payload does NOT count, and calling `signoz_search_traces`
-   directly for validation does NOT count. The sub-skill runs field
-   discovery, builds the `compositeQuery` spec, and validates it against
-   the live data before you write anything. Skipping it means a malformed
-   filter becomes a permanent saved view that needs to be deleted and
-   recreated.
+   the `Skill` tool to invoke `signoz-generating-queries`. The sub-skill
+   handles field discovery, type checking, and live-data validation in one
+   pass — adapting an example payload from `signoz://view/examples` or
+   running a bare `signoz:signoz_search_traces` call skips the field-type
+   checks and service-name resolution that catch silent 400s before they
+   become permanent bad views. Skipping it means a malformed filter becomes
+   a saved view that must be deleted and recreated.
 4. **Enforce `signal == sourcePage`** in every `builder_query` spec. A
    `sourcePage:"traces"` view with `signal:"logs"` is a server-side error.
 5. **Preview before writing — this step is not optional.** Before calling

--- a/plugins/signoz/skills/signoz-managing-views/SKILL.md
+++ b/plugins/signoz/skills/signoz-managing-views/SKILL.md
@@ -9,7 +9,7 @@ description: >
   Explorer saved views — even if they don't say "view" explicitly. Also use
   when someone wants to share a recurring Explorer query with their team and
   asks how to "save" or "bookmark" it.
-argument-hint: <natural-language view request>
+argument-hint: <view name, sourcePage (traces/logs/metrics), and filter intent>
 ---
 
 # Managing Saved Views

--- a/plugins/signoz/skills/signoz-managing-views/evals/evals.json
+++ b/plugins/signoz/skills/signoz-managing-views/evals/evals.json
@@ -79,6 +79,64 @@
           "description": "The rename must actually be written back"
         }
       ]
+    },
+    {
+      "id": 3,
+      "name": "delete-view-by-name",
+      "prompt": "Delete the 'checkout-errors' view.",
+      "expected_output": "Agent calls signoz_list_views to find the view by name, then calls signoz_get_view to confirm the UUID maps to a view named 'checkout-errors' with the expected sourcePage. Shows the resolved name, sourcePage, and category to the user and asks for explicit confirmation. Only after confirmation calls signoz_delete_view. Reports 'deleted' with the view name, not just the UUID.",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Agent calls signoz_list_views to locate the view by name before acting",
+          "description": "Must resolve name to UUID via listing; do not call delete on a guessed or user-pasted UUID without lookup"
+        },
+        {
+          "text": "Agent calls signoz_get_view to confirm the resolved UUID before deleting",
+          "description": "Paste errors happen; the get-before-delete guard prevents deleting the wrong view"
+        },
+        {
+          "text": "Agent shows the resolved view's name, sourcePage, and category and asks for explicit confirmation",
+          "description": "Delete is permanent; skill requires fresh confirmation against the resolved target, not just the original prompt"
+        },
+        {
+          "text": "Agent calls signoz_delete_view only after confirmation",
+          "description": "Must not auto-confirm based on original prompt"
+        },
+        {
+          "text": "Final reply confirms deletion by view name, not just UUID",
+          "description": "User should recognize what was deleted"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "name": "update-view-filter",
+      "prompt": "Update the 'checkout-errors' view to also show WARN spans, not just ERROR.",
+      "expected_output": "Agent calls signoz_list_views to find the view, then signoz_get_view to fetch full body. Recognizes this is a compositeQuery change and invokes signoz-generating-queries skill to build a new query with status IN (ERROR, WARN). Shows a diff preview with old vs new filter expression and notes compositeQuery is changing. Waits for confirmation, then calls signoz_update_view with the validated compositeQuery. Reports back UUID, name, and what changed.",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Agent calls signoz_get_view to fetch the full body before composing update (GET-then-PUT)",
+          "description": "Full-body replace; not fetching first risks wiping fields"
+        },
+        {
+          "text": "Agent invokes signoz-generating-queries skill to build the new compositeQuery",
+          "description": "Query changes must go through signoz-generating-queries for validation; hand-editing compositeQuery risks malformed payloads"
+        },
+        {
+          "text": "Agent shows a diff-style preview before writing, explicitly calling out the compositeQuery change",
+          "description": "Skill requires confirmation for compositeQuery changes; user must see what is changing"
+        },
+        {
+          "text": "Agent calls signoz_update_view with the validated compositeQuery",
+          "description": "The filter change must actually be written back"
+        },
+        {
+          "text": "signal in every builder_query matches the view's sourcePage",
+          "description": "signal != sourcePage is a server-side error"
+        }
+      ]
     }
   ]
 }

--- a/plugins/signoz/skills/signoz-managing-views/evals/evals.json
+++ b/plugins/signoz/skills/signoz-managing-views/evals/evals.json
@@ -1,0 +1,84 @@
+{
+  "skill_name": "signoz-managing-views",
+  "evals": [
+    {
+      "id": 0,
+      "name": "create-trace-view-for-service",
+      "prompt": "Save the current traces query as a view called 'checkout-errors' for the checkout service. I want to see only ERROR spans from service.name = checkout.",
+      "expected_output": "Agent resolves sourcePage=traces, builds a builder_query with filter service.name=checkout and status=error, sets panelType=list, shows a preview with name/sourcePage/filter, confirms, and calls signoz_create_view. Reports back the name, UUID, and sourcePage.",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Agent calls signoz_create_view",
+          "description": "The primary write operation must be called"
+        },
+        {
+          "text": "sourcePage is set to 'traces' (not logs or metrics)",
+          "description": "sourcePage must match the user's intent; wrong value is a 400"
+        },
+        {
+          "text": "Filter includes service.name = checkout and status/error condition",
+          "description": "View must capture the user's stated filter criteria"
+        },
+        {
+          "text": "Agent shows a preview (name, sourcePage, filter) before calling create",
+          "description": "Skill requires a preview step; without it user cannot catch errors"
+        },
+        {
+          "text": "Final reply includes the UUID returned by the server",
+          "description": "User needs UUID for future get/update/delete operations"
+        }
+      ]
+    },
+    {
+      "id": 1,
+      "name": "list-views-no-sourcepage",
+      "prompt": "Show me all my saved views.",
+      "expected_output": "Agent recognizes no sourcePage was given, calls signoz_list_views three times (once for each of traces, logs, metrics), merges results, and presents them organized by sourcePage. Checks pagination.hasMore for each signal before concluding.",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Agent calls signoz_list_views for all three signals: traces, logs, and metrics",
+          "description": "Without a sourcePage the agent must query all three"
+        },
+        {
+          "text": "Agent checks pagination.hasMore before concluding the list is complete",
+          "description": "A single page is not a complete list"
+        },
+        {
+          "text": "Results are organized/labeled by sourcePage in the reply",
+          "description": "Grouping by signal helps user find what they need"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "name": "rename-existing-view",
+      "prompt": "Rename the 'slow-checkout' view to 'slow-checkout-p99'.",
+      "expected_output": "Agent calls signoz_list_views to find the view by name, then signoz_get_view to fetch full body, shows diff preview (rename only, compositeQuery untouched), waits for confirmation, then calls signoz_update_view with the modified name only. Reports UUID, old name, new name.",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Agent calls signoz_list_views (or signoz_get_view) to resolve the view before updating",
+          "description": "Blind update without lookup risks wrong UUID"
+        },
+        {
+          "text": "Agent calls signoz_get_view to fetch the full body before composing update (GET-then-PUT)",
+          "description": "signoz_update_view is full-body replace; not fetching first risks wiping fields"
+        },
+        {
+          "text": "compositeQuery is not modified for a pure rename",
+          "description": "Touching compositeQuery for metadata-only change risks data loss"
+        },
+        {
+          "text": "Agent shows a diff-style preview before calling update",
+          "description": "Skill requires showing what will change"
+        },
+        {
+          "text": "Agent calls signoz_update_view with the modified name",
+          "description": "The rename must actually be written back"
+        }
+      ]
+    }
+  ]
+}

--- a/plugins/signoz/skills/signoz-managing-views/evals/evals.json
+++ b/plugins/signoz/skills/signoz-managing-views/evals/evals.json
@@ -5,11 +5,11 @@
       "id": 0,
       "name": "create-trace-view-for-service",
       "prompt": "Save the current traces query as a view called 'checkout-errors' for the checkout service. I want to see only ERROR spans from service.name = checkout.",
-      "expected_output": "Agent resolves sourcePage=traces, builds a builder_query with filter service.name=checkout and status=error, sets panelType=list, shows a preview with name/sourcePage/filter, confirms, and calls signoz_create_view. Reports back the name, UUID, and sourcePage.",
+      "expected_output": "Agent resolves sourcePage=traces, builds a builder_query with filter service.name=checkout and status=error, sets panelType=list, shows a preview with name/sourcePage/filter, confirms, and calls signoz:signoz_create_view. Reports back the name, UUID, and sourcePage.",
       "files": [],
       "assertions": [
         {
-          "text": "Agent calls signoz_create_view",
+          "text": "Agent calls signoz:signoz_create_view",
           "description": "The primary write operation must be called"
         },
         {
@@ -34,11 +34,11 @@
       "id": 1,
       "name": "list-views-no-sourcepage",
       "prompt": "Show me all my saved views.",
-      "expected_output": "Agent recognizes no sourcePage was given, calls signoz_list_views three times (once for each of traces, logs, metrics), merges results, and presents them organized by sourcePage. Checks pagination.hasMore for each signal before concluding.",
+      "expected_output": "Agent recognizes no sourcePage was given, calls signoz:signoz_list_views three times (once for each of traces, logs, metrics), merges results, and presents them organized by sourcePage. Checks pagination.hasMore for each signal before concluding.",
       "files": [],
       "assertions": [
         {
-          "text": "Agent calls signoz_list_views for all three signals: traces, logs, and metrics",
+          "text": "Agent calls signoz:signoz_list_views for all three signals: traces, logs, and metrics",
           "description": "Without a sourcePage the agent must query all three"
         },
         {
@@ -55,16 +55,16 @@
       "id": 2,
       "name": "rename-existing-view",
       "prompt": "Rename the 'slow-checkout' view to 'slow-checkout-p99'.",
-      "expected_output": "Agent calls signoz_list_views to find the view by name, then signoz_get_view to fetch full body, shows diff preview (rename only, compositeQuery untouched), waits for confirmation, then calls signoz_update_view with the modified name only. Reports UUID, old name, new name.",
+      "expected_output": "Agent calls signoz:signoz_list_views to find the view by name, then signoz:signoz_get_view to fetch full body, shows diff preview (rename only, compositeQuery untouched), waits for confirmation, then calls signoz:signoz_update_view with the modified name only. Reports UUID, old name, new name.",
       "files": [],
       "assertions": [
         {
-          "text": "Agent calls signoz_list_views (or signoz_get_view) to resolve the view before updating",
+          "text": "Agent calls signoz:signoz_list_views (or signoz:signoz_get_view) to resolve the view before updating",
           "description": "Blind update without lookup risks wrong UUID"
         },
         {
-          "text": "Agent calls signoz_get_view to fetch the full body before composing update (GET-then-PUT)",
-          "description": "signoz_update_view is full-body replace; not fetching first risks wiping fields"
+          "text": "Agent calls signoz:signoz_get_view to fetch the full body before composing update (GET-then-PUT)",
+          "description": "signoz:signoz_update_view is full-body replace; not fetching first risks wiping fields"
         },
         {
           "text": "compositeQuery is not modified for a pure rename",
@@ -75,7 +75,7 @@
           "description": "Skill requires showing what will change"
         },
         {
-          "text": "Agent calls signoz_update_view with the modified name",
+          "text": "Agent calls signoz:signoz_update_view with the modified name",
           "description": "The rename must actually be written back"
         }
       ]
@@ -84,15 +84,15 @@
       "id": 3,
       "name": "delete-view-by-name",
       "prompt": "Delete the 'checkout-errors' view.",
-      "expected_output": "Agent calls signoz_list_views to find the view by name, then calls signoz_get_view to confirm the UUID maps to a view named 'checkout-errors' with the expected sourcePage. Shows the resolved name, sourcePage, and category to the user and asks for explicit confirmation. Only after confirmation calls signoz_delete_view. Reports 'deleted' with the view name, not just the UUID.",
+      "expected_output": "Agent calls signoz:signoz_list_views to find the view by name, then calls signoz:signoz_get_view to confirm the UUID maps to a view named 'checkout-errors' with the expected sourcePage. Shows the resolved name, sourcePage, and category to the user and asks for explicit confirmation. Only after confirmation calls signoz:signoz_delete_view. Reports 'deleted' with the view name, not just the UUID.",
       "files": [],
       "assertions": [
         {
-          "text": "Agent calls signoz_list_views to locate the view by name before acting",
+          "text": "Agent calls signoz:signoz_list_views to locate the view by name before acting",
           "description": "Must resolve name to UUID via listing; do not call delete on a guessed or user-pasted UUID without lookup"
         },
         {
-          "text": "Agent calls signoz_get_view to confirm the resolved UUID before deleting",
+          "text": "Agent calls signoz:signoz_get_view to confirm the resolved UUID before deleting",
           "description": "Paste errors happen; the get-before-delete guard prevents deleting the wrong view"
         },
         {
@@ -100,7 +100,7 @@
           "description": "Delete is permanent; skill requires fresh confirmation against the resolved target, not just the original prompt"
         },
         {
-          "text": "Agent calls signoz_delete_view only after confirmation",
+          "text": "Agent calls signoz:signoz_delete_view only after confirmation",
           "description": "Must not auto-confirm based on original prompt"
         },
         {
@@ -113,11 +113,11 @@
       "id": 4,
       "name": "update-view-filter",
       "prompt": "Update the 'checkout-errors' view to also show WARN spans, not just ERROR.",
-      "expected_output": "Agent calls signoz_list_views to find the view, then signoz_get_view to fetch full body. Recognizes this is a compositeQuery change and invokes signoz-generating-queries skill to build a new query with status IN (ERROR, WARN). Shows a diff preview with old vs new filter expression and notes compositeQuery is changing. Waits for confirmation, then calls signoz_update_view with the validated compositeQuery. Reports back UUID, name, and what changed.",
+      "expected_output": "Agent calls signoz:signoz_list_views to find the view, then signoz:signoz_get_view to fetch full body. Recognizes this is a compositeQuery change and invokes signoz-generating-queries skill to build a new query with status IN (ERROR, WARN). Shows a diff preview with old vs new filter expression and notes compositeQuery is changing. Waits for confirmation, then calls signoz:signoz_update_view with the validated compositeQuery. Reports back UUID, name, and what changed.",
       "files": [],
       "assertions": [
         {
-          "text": "Agent calls signoz_get_view to fetch the full body before composing update (GET-then-PUT)",
+          "text": "Agent calls signoz:signoz_get_view to fetch the full body before composing update (GET-then-PUT)",
           "description": "Full-body replace; not fetching first risks wiping fields"
         },
         {
@@ -129,7 +129,7 @@
           "description": "Skill requires confirmation for compositeQuery changes; user must see what is changing"
         },
         {
-          "text": "Agent calls signoz_update_view with the validated compositeQuery",
+          "text": "Agent calls signoz:signoz_update_view with the validated compositeQuery",
           "description": "The filter change must actually be written back"
         },
         {


### PR DESCRIPTION
## Summary
- New `signoz-managing-views` skill covering full CRUD (create / list / get / update / delete) for SigNoz saved Explorer views — logs, traces, and metrics — via the SigNoz MCP server.
- Defers SavedView schema to the MCP resources (`signoz://view/instructions`, `signoz://view/examples`) instead of transcribing it, so it stays in sync with the server.
- Enforces the GET-then-PUT update flow (`signoz_update_view` is a full-body replace) and guards delete with explicit re-confirmation against the resolved view's name + sourcePage to prevent paste-error deletions.
- README.md table and directory tree updated.

## Test plan
- [ ] Skill description triggers on phrases like "save this query as a view", "list my saved views", "delete the X view".
- [x] Create flow against a live SigNoz instance: produces a valid view for each `sourcePage` (traces / logs / metrics).
- [x] Update flow round-trips a `signoz_get_view` → modify → `signoz_update_view` without dropping fields.
- [x] Delete flow refuses to act without resolved-view confirmation.
- [x] No regression in sibling skills' triggering (creating-alerts, modifying-dashboards, generating-queries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)