### PR TITLE
fix(signoz-generating-queries): make clarification mechanism host-agnostic

### DIFF
--- a/plugins/signoz/skills/signoz-generating-queries/SKILL.md
+++ b/plugins/signoz/skills/signoz-generating-queries/SKILL.md
@@ -54,7 +54,10 @@ Map the user's intent to the right signal:
 | Infrastructure metrics (CPU, memory, disk, network) | **metrics** | Always metrics for resource utilization. |
 | "How many X per Y" (count/rate grouped by dimension) | **traces** or **logs** (aggregate) | Use `signoz:signoz_aggregate_traces` or `signoz:signoz_aggregate_logs` for grouped counts. |
 
-If the signal is genuinely ambiguous, ask using `<assistant_question>`.
+If the signal is genuinely ambiguous, ask the user before proceeding. The
+host application decides how the question is surfaced (e.g. a structured
+clarification tool or an inline `<assistant_question>` tag) — follow the
+host's UI rendering rules.
 
 ### Step 2: Discover available data
 


### PR DESCRIPTION
## Summary

`signoz-generating-queries/SKILL.md:57` hard-codes `<assistant_question>` as the clarification mechanism when the signal type is ambiguous. That tag is the Claude Code default and is not rendered by every host.

In particular, the [SigNoz AI Assistant](https://github.com/SigNoz/signoz-ai-assistant) routes clarifications through a dedicated MCP tool (`mcp__assistant__assistant_request_clarification`) and its system prompt explicitly tells the model **not** to emit `<assistant_question>` tags — they render as literal text in the sidebar and bypass the structured clarification flow (no field-type validation, no persisted `AssistantClarification` row, no resume path).

This PR drops the prescriptive tag reference and defers the *how* of asking to the host's UI rendering rules, so the skill stays portable across Claude Code, the SigNoz Assistant, Codex, and Cursor.

## Diff

```diff
-If the signal is genuinely ambiguous, ask using `<assistant_question>`.
+If the signal is genuinely ambiguous, ask the user before proceeding. The
+host application decides how the question is surfaced (e.g. a structured
+clarification tool or an inline `<assistant_question>` tag) — follow the
+host's UI rendering rules.
```

## Why this is the right shape (vs. dual-mechanism instructions)

Per [Anthropic's skill best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices), skills should describe **what** to do, not **how** to do it when the *how* is host-specific. The host's system prompt is the authoritative source for UI rendering — having a skill override it creates cross-layer contradictions that are hard to debug.

## Test plan

- [x] `signoz-generating-queries` skill still triggers correctly on ambiguous queries
- [x] In SigNoz AI Assistant: model invokes `mcp__assistant__assistant_request_clarification` (matches the host system prompt)
- [x] In Claude Code default: model emits `<assistant_question>` (matches Claude Code's default behavior)
- [x] Reviewer to confirm no other skills reference `<assistant_question>` (verified locally — only this one)

## Notes

- No README update needed (skill remains in the table with the same name/description)
- Plugin version bump is auto-handled on merge by `.github/workflows/auto-version-bump.yml`