### PR TITLE
fix(signoz-managing-views): clarify that delete may be recoverable via host restore

### DIFF
--- a/plugins/signoz/skills/signoz-managing-views/SKILL.md
+++ b/plugins/signoz/skills/signoz-managing-views/SKILL.md
@@ -153,9 +153,13 @@ upstream). Sending a partial body wipes the unspecified fields. The flow:
 
 ### Delete a view
 
-Deletion is permanent — there is no undo, and any team member who had the
-view bookmarked will see it disappear. Treat this like dropping a row from
-a shared table:
+Deletion is destructive and immediately removes the view from the shared
+list — any team member who had the view bookmarked will see it disappear.
+Depending on the host application, the user may be offered a one-click
+restore action shortly after the delete (the SigNoz Assistant captures a
+snapshot and exposes a `restore` action), but treat that as a recovery
+affordance, not a substitute for getting the delete right. Treat this like
+dropping a row from a shared table:
 
 1. **List to locate.** Call `signoz:signoz_list_views` to find the view
    by name. If `sourcePage` is unknown, search all three signals.


### PR DESCRIPTION
## Summary

The skill describes view deletion as *"permanent — there is no undo"*, which overstates the irreversibility for several host applications. The SigNoz AI Assistant, for example, captures a pre-delete snapshot when the user approves a `signoz:signoz_delete_view` call and surfaces a one-click restore action — the operation is therefore recoverable in practice for those users.

When the skill claims irreversibility that doesn't match reality:
- Users get scared away from a flow they could safely use
- A product capability (the restore affordance) goes undiscovered
- The trust gap between what the assistant says and what the UI actually offers erodes confidence

This PR softens the wording without weakening the carefulness guardrails (pre-delete confirmation, name+sourcePage display, explicit consent — all unchanged).

## Diff

```diff
-Deletion is permanent — there is no undo, and any team member who had the
-view bookmarked will see it disappear. Treat this like dropping a row from
-a shared table:
+Deletion is destructive and immediately removes the view from the shared
+list — any team member who had the view bookmarked will see it disappear.
+Depending on the host application, the user may be offered a one-click
+restore action shortly after the delete (the SigNoz Assistant captures a
+snapshot and exposes a \`restore\` action), but treat that as a recovery
+affordance, not a substitute for getting the delete right. Treat this like
+dropping a row from a shared table:
```

## Why mention the host application explicitly

The host name (\`SigNoz Assistant\`) is included as a concrete example because the skill is host-agnostic and Cursor/Claude Code/Codex hosts may not have a restore affordance. The phrasing "Depending on the host application" keeps the door open for hosts that don't, while naming the one host that does so readers know the claim isn't speculative.

## Test plan

- [x] Wording reviewed in context — \"Treat this like dropping a row from a shared table\" framing preserved
- [x] All subsequent step numbering, get-to-confirm requirement, and final delete call remain unchanged
- [ ] Reviewer to confirm the SigNoz Assistant restore behavior description matches its current implementation (it does — \`hooks.py:220\` registers \`(\"view\", \"restore\")\` as a recovery action that maps to \`signoz_create_view\`)

## Notes

- No README update needed
- Plugin version bump is auto-handled on merge