### PR TITLE
fix(signoz-creating-alerts): never echo channel secrets in chat output

### DIFF
--- a/plugins/signoz/skills/signoz-creating-alerts/SKILL.md
+++ b/plugins/signoz/skills/signoz-creating-alerts/SKILL.md
@@ -339,6 +339,33 @@ For multi-severity alerts, attach channels per threshold:
 `thresholds.spec[N].channels` is an array — typically warning → Slack only,
 critical → Slack + PagerDuty.
 
+#### Handling secret-bearing channel config
+
+Slack webhook URLs, PagerDuty integration keys, and similar webhook tokens
+are secrets. When the user supplies them inline, treat them as opaque
+inputs and follow these rules:
+
+- **Do not echo the secret back.** Never include the webhook URL,
+  integration key, or any password-like token in chat output, previews,
+  confirmation messages, summaries, or the `<navigation_suggestions>`
+  payload. Refer to the channel by its `name` only ("Slack channel
+  `slack-infra` created") and omit the value entirely.
+- **Do not stash secrets in clarification context.** If you need to ask the
+  user a follow-up question after they pasted a secret, do not include
+  the secret value in the clarification `message`, `discovered_context`,
+  or any other field that the host may persist for resume. Refer to it
+  symbolically (e.g. "the webhook you just provided").
+- **One-pass only.** Pass the secret directly to
+  `signoz:signoz_create_notification_channel` and do not retain it in any
+  intermediate prose. After the create call succeeds, refer to the
+  channel by name; after a failure, ask the user to re-paste rather than
+  echoing what they sent.
+- **If the user instead asks "how do I set up a Slack channel?"** — that
+  is a docs question, not a create-channel request. Answer with the docs
+  flow (the SigNoz UI's Notification Channels page) and do not solicit
+  the secret in chat at all. Prefer the UI path when the user seems
+  uncertain about exposing the token.
+
 ### Step 6: Validate the threshold (would-have-fired count)
 
 Step 2.5 already confirmed the underlying data exists. Step 6 is about
@@ -432,6 +459,13 @@ intervene before Step 8.
   is rejected.
 - **Channels must exist.** Use names from `signoz:signoz_list_notification_channels`
   exactly, or create the channel inline first.
+- **Never echo channel secrets.** Slack webhook URLs, PagerDuty integration
+  keys, and similar webhook tokens are secrets. Pass them to
+  `signoz:signoz_create_notification_channel` once and never repeat the
+  value in chat output, previews, confirmations, summaries, clarification
+  payloads, or navigation suggestions. Refer to the channel by name only
+  after creation; ask the user to re-paste on failure rather than
+  reproducing what they sent.
 - **Scope boundary.** This skill only creates new rules. Modifications use
   `signoz:signoz_update_alert` directly.
 


### PR DESCRIPTION
## Summary

Notification channel creation (Step 5 of `signoz-creating-alerts`) collects **secret-bearing config**:

- Slack webhook URLs (`https://hooks.slack.com/services/T.../B.../...`)
- PagerDuty integration keys (32-char routing keys)
- Generic webhook tokens / Bearer headers

The skill today treats these as ordinary parameters with no handling guidance. That conflicts with host-level secret-decline policies (e.g. the SigNoz Assistant system prompt declines API keys, tokens, secrets, credentials) and risks the agent reproducing the secret value in:

- Preview / confirmation messages before the create call
- Success summaries (\"created channel with URL https://hooks.slack.com/...\")
- Clarification payloads if a follow-up question is needed after the user pastes the secret
- `navigation_suggestions` followup intents that echo prior context

Once a secret appears in chat output it lands in conversation logs, session storage, telemetry, and any analytics layer that captures user-visible content — well after the user forgot they pasted it. This is the same class of risk as logging passwords; the right policy is **never echo**, not \"be careful\".

## What this PR adds

A new sub-section inside Step 5 (\"Handling secret-bearing channel config\") with four rules:

1. **Do not echo the secret back** in any chat output, preview, summary, or navigation suggestion. Refer to the channel by `name` only.
2. **Do not stash secrets in clarification context.** Symbolic references only (\"the webhook you just provided\").
3. **One-pass only.** Pass directly to `signoz:signoz_create_notification_channel` and ask the user to re-paste on failure rather than echoing.
4. **Doc-question carve-out.** If the user is asking *how* to set up a channel rather than asking the assistant to create one, route them to the SigNoz UI's Notification Channels page — don't solicit the secret in chat at all.

Mirrored as a one-line entry in the Guardrails section so it's enforced even if the model takes a non-linear path.

## Why include the doc-question carve-out

Users uncertain about exposing webhook URLs in a chat-style UI often phrase their question as \"how do I add a Slack channel?\" That is a docs intent, not a create-channel intent. Steering those users to the SigNoz UI avoids the chat-paste path entirely — which is the safest outcome.

## Test plan

- [ ] Local Claude Code run: \"create a CPU alert on checkout, notify slack-infra at this webhook https://hooks.slack.com/services/T999/B999/abc\" → confirm the agent creates the channel and the success message refers to the channel by name without the URL
- [ ] Local Claude Code run: \"how do I set up Slack notifications in SigNoz?\" → confirm the agent answers with the UI flow and does NOT prompt for a webhook URL
- [ ] Failure path: pass an obviously bad webhook URL → confirm the agent asks the user to re-paste without echoing the bad value

## Notes

- No README update needed
- Plugin version bump is auto-handled on merge
- Companion docs PR (in `signoz-ai-assistant`) may follow to align the host prompt's secret-decline policy with this skill's exception scope — out of scope here