### PR TITLE
refactor(creating-alerts, creating-dashboards): host-agnostic clarification pattern

### DIFF
--- a/plugins/signoz/skills/signoz-creating-alerts/SKILL.md
+++ b/plugins/signoz/skills/signoz-creating-alerts/SKILL.md
@@ -58,21 +58,26 @@ The skill enforces a strict input contract:
 | Severity | inferred from intent | default `warning`; promote to `critical` only if user said "page", "wake up", "critical" |
 | Notification channel | yes | `signoz:signoz_list_notification_channels` + offer "create new" |
 
-If a required input is missing and cannot be discovered, emit a structured
-`needs_input` block and stop **before** calling any write tool:
+If a required input is missing and cannot be discovered, **stop before
+calling any write tool** and ask the user. The host application decides
+how the question is surfaced (a structured clarification tool, inline
+`<assistant_question>` tags, an interactive prompt, etc.) — follow the
+host's UI rendering rules.
 
-```text
-needs_input:
-  missing:
-    - resource_attribute_filter: "no service or host specified — pick one"
-  candidates:
-    service.name: ["frontend", "checkout", "payments", "inventory"]
-    host.name: ["prod-api-1", "prod-api-2", "prod-db-1"]
-```
+What to include in the question:
 
-In interactive mode, the human picks from candidates. In autonomous mode, the
-caller fills the gap from upstream context or escalates. Either way, do not
-proceed to `signoz:signoz_create_alert` with a guessed value.
+- **What is missing** — name the input concretely (e.g. "which
+  resource-attribute filter to use").
+- **Candidate lists** populated from your discovery calls — concrete
+  values per attribute the user can pick from. Example shape:
+  `service.name` → `frontend`, `checkout`, `payments`, `inventory`;
+  `host.name` → `prod-api-1`, `prod-api-2`, `prod-db-1`.
+- **Allow free-form input** so the user can name a value you didn't
+  surface.
+
+In autonomous mode (no human), escalate to the caller or fill the gap
+from upstream context. Either way, do not proceed to
+`signoz:signoz_create_alert` with a guessed value.
 
 ## Workflow
 
@@ -97,7 +102,7 @@ Map signal phrasing to alert type:
 | exception, stack trace, crash | EXCEPTIONS_BASED_ALERT | (clickhouse_sql) |
 
 If resource scope is missing, run discovery (Step 2). If still missing after
-discovery, emit `needs_input` and stop.
+discovery, stop and ask the user (see *Required inputs* above).
 
 ### Step 2: Discover resource attributes and metric names
 
@@ -114,7 +119,8 @@ candidates instead of guessing:
    search term to verify the exact OTel metric name. Wrong names create
    alerts that never fire.
 
-Surface the candidates in the `needs_input` block. Do not pick one.
+Surface the candidates in your clarification request (see *Required
+inputs* above). Do not pick one.
 
 ### Step 2.5: Probe data existence for the chosen filter (fail fast)
 
@@ -137,8 +143,9 @@ Inspect the result:
 
 - **Probe returns rows** → proceed to Step 3.
 - **Probe returns empty** → STOP. Do not build an alert config the user
-  will then be asked to throw away. Emit a `needs_input` block describing
-  what was missing and offer concrete recovery:
+  will then be asked to throw away. Stop and ask the user (see *Required
+  inputs* above), describing what was missing and offering concrete
+  recovery:
   - Service doesn't emit the metric → call
     `signoz:signoz_get_field_values signal=metrics name=service.name metricName=<metric>`
     to list the services that *do* emit it; let the user pick a different
@@ -332,8 +339,8 @@ most common silent failure after bad queries.
    - **Create new inline** — call `signoz:signoz_create_notification_channel` with
      channel parameters the user provides (name, type, type-specific config
      like Slack webhook URL or PagerDuty integration key).
-4. If neither path resolves a channel, emit
-   `needs_input: notification_channel` and stop.
+4. If neither path resolves a channel, stop and ask the user for a
+   notification channel (see *Required inputs* above).
 
 For multi-severity alerts, attach channels per threshold:
 `thresholds.spec[N].channels` is an array — typically warning → Slack only,
@@ -369,7 +376,8 @@ alert have fired a sensible number of times in the last hour?
 
 If Step 2.5 was somehow skipped (e.g. a downstream skill is invoking this
 flow mid-stream), the no-data stop rule applies here too: empty result →
-emit `needs_input` instead of saving an alert that will never fire.
+stop and ask the user (see *Required inputs* above) instead of saving an
+alert that will never fire.
 
 ### Step 7: Preview the prepared config
 
@@ -416,7 +424,7 @@ intervene before Step 8.
 ## Guardrails
 
 - **Strict inputs over guessing.** Resource attribute and channel are
-  required. If missing, emit `needs_input` and stop. Creating an alert on
+  required. If missing, stop and ask the user (see *Required inputs* above). Creating an alert on
   a guessed service is harder to undo than asking.
 - **Always paginate `signoz:signoz_list_alerts`.** Stopping at page 1 misses
   duplicates and produces noise.

--- a/plugins/signoz/skills/signoz-creating-dashboards/SKILL.md
+++ b/plugins/signoz/skills/signoz-creating-dashboards/SKILL.md
@@ -66,23 +66,27 @@ sensible defaults, but a few cannot be guessed:
 | Specific metrics / signals for custom builds | inferred | derive from technology + MCP `signoz://dashboard/*` resources; surface in preview |
 | Default time range, refresh, layout | inferred | apply defaults (see "Defaults" below) |
 
-If a required input is missing and cannot be discovered, emit a
-structured `needs_input` block and stop **before** calling any write
-tool:
+If a required input is missing and cannot be discovered, **stop before
+calling any write tool** and ask the user. The host application decides
+how the question is surfaced (a structured clarification tool, inline
+`<assistant_question>` tags, an interactive prompt, etc.) — follow the
+host's UI rendering rules.
 
-```text
-needs_input:
-  missing:
-    - resource_scope: "no service or cluster specified for the custom build"
-  candidates:
-    service.name: ["frontend", "checkout", "payments", "inventory"]
-    k8s.cluster.name: ["prod-us-east-1", "staging"]
-```
+What to include in the question:
 
-In interactive mode, the human picks. In autonomous mode, the caller
-fills the gap from upstream context or escalates. Either way, do not
-proceed to `signoz:signoz_create_dashboard` /
-`signoz:signoz_import_dashboard` with a guessed value.
+- **What is missing** — name the input concretely (e.g. "no service or
+  cluster specified for the custom build").
+- **Candidate lists** populated from your discovery calls — concrete
+  values per attribute the user can pick from. Example shape:
+  `service.name` → `frontend`, `checkout`, `payments`, `inventory`;
+  `k8s.cluster.name` → `prod-us-east-1`, `staging`.
+- **Allow free-form input** so the user can name a value you didn't
+  surface.
+
+In autonomous mode (no human), escalate to the caller or fill the gap
+from upstream context. Either way, do not proceed to
+`signoz:signoz_create_dashboard` / `signoz:signoz_import_dashboard` with
+a guessed value.
 
 ## Workflow
 
@@ -407,8 +411,9 @@ native JSON — stringifying them produces errors like
 ## Guardrails
 
 - **Strict inputs over guessing.** Resource scope is required for custom
-  builds. If missing, emit `needs_input` and stop. A guessed scope on a
-  shared dashboard is harder to clean up than asking.
+  builds. If missing, stop and ask the user (see *Required inputs*
+  above). A guessed scope on a shared dashboard is harder to clean up
+  than asking.
 - **Always paginate `signoz:signoz_list_dashboards`.** Stopping at page
   1 misses duplicates and produces clutter.
 - **Duplicate check first.** The user's only two upfront options are

--- a/plugins/signoz/skills/signoz-creating-dashboards/evals/evals.json
+++ b/plugins/signoz/skills/signoz-creating-dashboards/evals/evals.json
@@ -46,10 +46,10 @@
       "id": 5,
       "eval_name": "needs-input-missing-scope-custom-build",
       "prompt": "Build me a dashboard for some k8s pods.",
-      "expected_output": "Request is too vague (no cluster, namespace, or pod set). Agent must NOT proceed to signoz_create_dashboard with a guessed scope. Either emits a structured needs_input block listing 'resource_scope' as missing with candidates discovered via signoz_get_field_values, or proposes the k8s catalog template and asks the user to confirm scope before importing. Must explicitly ask the user to clarify cluster/namespace before any write tool.",
+      "expected_output": "Request is too vague (no cluster, namespace, or pod set). Agent must NOT proceed to signoz_create_dashboard with a guessed scope. Either asks the user to clarify scope (using the host's clarification mechanism) with concrete candidates discovered via signoz_get_field_values, or proposes the k8s catalog template and asks the user to confirm scope before importing. Must explicitly ask the user to clarify cluster/namespace before any write tool.",
       "expectations": [
         "Agent does NOT call signoz_create_dashboard or signoz_import_dashboard without first clarifying scope with the user",
-        "Agent either emits a needs_input block or asks a clarifying question about the cluster or namespace",
+        "Agent stops before any write and asks a clarifying question about the cluster or namespace",
         "Agent calls signoz_get_field_values or signoz_list_dashboard_templates to discover candidates before prompting"
       ],
       "files": []


### PR DESCRIPTION
## Summary

`signoz-creating-alerts` and `signoz-creating-dashboards` both prescribe emitting a structured YAML `needs_input` block when a required input is missing — for example, when the user hasn't named a service or cluster:

\`\`\`text
needs_input:
  missing:
    - resource_attribute_filter: \"no service or host specified — pick one\"
  candidates:
    service.name: [\"frontend\", \"checkout\", \"payments\", \"inventory\"]
    host.name: [\"prod-api-1\", \"prod-api-2\", \"prod-db-1\"]
\`\`\`

This format is a skill-local convention with **no rendering support in any published host** (Claude Code, Codex, Cursor, SigNoz Assistant). In every host, the model emits the literal YAML into the chat transcript and the human is left to read it — none of the structured benefits a real clarification mechanism provides are available: typed fields, durable resume state, candidate selection UI, persisted answers across turns.

In the **SigNoz Assistant** specifically, the host registers an in-process clarification MCP tool (`mcp__assistant__assistant_request_clarification`) that produces a structured form with `select` / `multi_select` / `text` / `number` / `boolean` field types and an `AssistantClarification` row the agent can resume against. The host system prompt tells the model to use that tool, but the skill points the opposite direction — and the in-skill instructions usually win because they're loaded later and more specific. Same problem as the `<assistant_question>` mismatch fixed in #24.

## What this PR changes

Removes the YAML block prescription from both skills and replaces it with a **host-agnostic pattern**:

- Stop before any write tool
- Ask the user using the host's clarification mechanism
- Include candidate lists from discovery
- Allow free-form input

Mirror of the pattern landed in #24 (`signoz-generating-queries`). The host decides the mechanism via its own UI rendering rules.

## Edits

**`signoz-creating-alerts/SKILL.md`** — 7 references:
- Required inputs section: full YAML block → host-agnostic instruction (3 bullets: what's missing, candidate lists, allow free-form)
- 6 inline \"emit `needs_input` and stop\" phrases → \"stop and ask the user (see *Required inputs* above)\"

**`signoz-creating-dashboards/SKILL.md`** — 2 references:
- Required inputs section: full YAML block → host-agnostic instruction
- 1 inline Guardrails phrase → \"stop and ask the user (see *Required inputs* above)\"

**`signoz-creating-dashboards/evals/evals.json`** — 1 eval updated to match the new behavior. `eval_name` kept the same since it's an opaque identifier used by the grading infrastructure.

## What does NOT change

- The \"stop before write\" guarantee when required inputs are missing — verbatim
- The carefulness around field discovery before prompting — verbatim
- The list of which inputs are strict (resource scope, channel, etc.) — verbatim
- Eval test cases continue to assert the agent doesn't proceed without clarification

Only the mechanism for asking is now host-agnostic.

## Why the cross-reference to *Required inputs*

Inline phrases used to say \"emit `needs_input` and stop\", which was self-explanatory because the format was defined inline. The new phrasing \"stop and ask the user (see *Required inputs* above)\" points the model back to the canonical pattern description so it doesn't reinvent the YAML format from memory.

## Test plan

- [x] All `needs_input` references in `plugins/signoz/skills/` removed (verified — grep returns nothing)
- [x] No skill SKILL.md still mentions the YAML block format
- [x] Inline \"stop before write\" guarantees preserved everywhere
- [ ] Local Claude Code run: \"create a CPU alert\" (no service named) → confirm the agent stops before write and asks via `<assistant_question>` (Claude Code default)
- [ ] Local SigNoz Assistant run: same prompt → confirm the agent calls `mcp__assistant__assistant_request_clarification` instead
- [ ] Local Claude Code run: \"build me a dashboard for some k8s pods\" → confirm the agent stops, discovers candidates, asks clarifying question (eval id=5 scenario)

## Notes

- Mirrors PR #24 pattern; same review approach should apply
- Plugin version bump is auto-handled on merge
- README untouched (skills retain the same names and descriptions)