### PR TITLE
refactor: normalize follow-up caps and skill-linking across explain/investigate skills

### DIFF
--- a/plugins/signoz/skills/signoz-explaining-alerts/SKILL.md
+++ b/plugins/signoz/skills/signoz-explaining-alerts/SKILL.md
@@ -246,25 +246,15 @@ actually in the config:
 
 ### Step 6: Offer next steps
 
-Surface up to 3 follow-up intents. Pick the most relevant from this menu
-based on what the explanation just revealed — do not include all four:
+Surface up to 3 follow-up intents based on what the explanation
+revealed — things like investigating a recent fire, running the
+underlying query to see current values, adjusting a threshold, or
+creating a related alert for a coverage gap. Use your judgment; do
+not pad to 3.
 
-- *Action*: "Investigate the most recent fire" (→
-  `signoz-investigating-alerts`). Pick when there is a recent fire and
-  the user did not already ask about it.
-- *Drill-down*: "Run the underlying query to see current values" (→
-  `signoz-generating-queries`). Pick when the user seems uncertain
-  whether the alert's threshold is well-calibrated.
-- *Action*: "Adjust the threshold or add a severity level" (→
-  `signoz:signoz_update_alert` directly — out of scope here). Pick when
-  the explanation surfaced a calibration concern (e.g. evaluation
-  window vs. business cycle mismatch).
-- *Action*: "Create a related alert for [gap noticed]" (→
-  `signoz-creating-alerts`). Pick when the explanation revealed a
-  missing-coverage gap, not just answered the user's question.
-
-Skip follow-ups entirely when the user is purely inspecting ("what does
-this alert do?") and signals no further intent. No chips beat wrong chips.
+Skip follow-ups entirely when the user is purely inspecting ("what
+does this alert do?") and signals no further intent. No chips beat
+wrong chips.
 
 ## Guardrails
 

--- a/plugins/signoz/skills/signoz-explaining-alerts/SKILL.md
+++ b/plugins/signoz/skills/signoz-explaining-alerts/SKILL.md
@@ -246,14 +246,25 @@ actually in the config:
 
 ### Step 6: Offer next steps
 
-End with two or three actionable follow-ups:
-- "Want me to investigate the most recent fire?" (→ `signoz-investigating-alerts`)
-- "Want me to run the underlying query to see current values?" (→
-  `signoz-generating-queries`)
-- "Want me to adjust the threshold or add a severity level?" (→
-  `signoz:signoz_update_alert` directly — out of scope here)
-- "Want me to create a related alert for [gap noticed]?" (→
-  `signoz-creating-alerts`)
+Surface up to 3 follow-up intents. Pick the most relevant from this menu
+based on what the explanation just revealed — do not include all four:
+
+- *Action*: "Investigate the most recent fire" (→
+  `signoz-investigating-alerts`). Pick when there is a recent fire and
+  the user did not already ask about it.
+- *Drill-down*: "Run the underlying query to see current values" (→
+  `signoz-generating-queries`). Pick when the user seems uncertain
+  whether the alert's threshold is well-calibrated.
+- *Action*: "Adjust the threshold or add a severity level" (→
+  `signoz:signoz_update_alert` directly — out of scope here). Pick when
+  the explanation surfaced a calibration concern (e.g. evaluation
+  window vs. business cycle mismatch).
+- *Action*: "Create a related alert for [gap noticed]" (→
+  `signoz-creating-alerts`). Pick when the explanation revealed a
+  missing-coverage gap, not just answered the user's question.
+
+Skip follow-ups entirely when the user is purely inspecting ("what does
+this alert do?") and signals no further intent. No chips beat wrong chips.
 
 ## Guardrails
 

--- a/plugins/signoz/skills/signoz-explaining-dashboards/SKILL.md
+++ b/plugins/signoz/skills/signoz-explaining-dashboards/SKILL.md
@@ -120,23 +120,14 @@ adding panels for X to cover Y."
 
 ### Step 4: Offer next steps
 
-Surface up to 3 follow-up intents after the explanation. Pick the most
-relevant from this menu:
-
-- *Drill-down*: "Run the queries from a specific panel to check if they
-  are returning data" (→ `signoz-generating-queries` with the panel's
-  builder query). Pick when the explanation revealed a panel the user
-  is most likely to act on.
-- *Action*: "Add any missing panels or thresholds" (→
-  `signoz-modifying-dashboards`). Pick when the explanation flagged a
-  coverage gap.
-- *Action*: "Wire alerts for any of these signals" (→
-  `signoz-creating-alerts`). Pick when the dashboard surfaces an
-  actionable threshold the user has not yet alerted on.
+Surface up to 3 follow-up intents based on what the explanation
+surfaced — things like running a specific panel's underlying query,
+filling a coverage gap, or wiring an alert for an actionable threshold
+the user has not yet alerted on. Use your judgment; do not pad to 3.
 
 Skip follow-ups when the user was clearly just onboarding to the
-dashboard ("what is this?") and showed no further intent. No chips beat
-wrong chips.
+dashboard ("what is this?") and showed no further intent. No chips
+beat wrong chips.
 
 ## Guardrails
 

--- a/plugins/signoz/skills/signoz-explaining-dashboards/SKILL.md
+++ b/plugins/signoz/skills/signoz-explaining-dashboards/SKILL.md
@@ -120,10 +120,23 @@ adding panels for X to cover Y."
 
 ### Step 4: Offer next steps
 
-After the explanation, offer actionable follow-ups:
-- "Want me to run the queries from any specific panel to check if they're returning
-  data?"
-- "Want me to add any missing panels or thresholds?" (→ `signoz-modifying-dashboards`)
+Surface up to 3 follow-up intents after the explanation. Pick the most
+relevant from this menu:
+
+- *Drill-down*: "Run the queries from a specific panel to check if they
+  are returning data" (→ `signoz-generating-queries` with the panel's
+  builder query). Pick when the explanation revealed a panel the user
+  is most likely to act on.
+- *Action*: "Add any missing panels or thresholds" (→
+  `signoz-modifying-dashboards`). Pick when the explanation flagged a
+  coverage gap.
+- *Action*: "Wire alerts for any of these signals" (→
+  `signoz-creating-alerts`). Pick when the dashboard surfaces an
+  actionable threshold the user has not yet alerted on.
+
+Skip follow-ups when the user was clearly just onboarding to the
+dashboard ("what is this?") and showed no further intent. No chips beat
+wrong chips.
 
 ## Guardrails
 

--- a/plugins/signoz/skills/signoz-investigating-alerts/SKILL.md
+++ b/plugins/signoz/skills/signoz-investigating-alerts/SKILL.md
@@ -255,12 +255,10 @@ handles so the user can act immediately:
 Do not pad with generic advice ("verify connectivity", "check
 dashboards") — that's noise during an active incident.
 
-**Mirroring as navigation chips.** Pick the top 1-3 of these "Suggested
-next steps" and mirror them as host follow-up intents — the most
-actionable, alert-scoped ones (e.g. "Open trace 7af3a09b…", "Tune the
-threshold", "Page the owning team"). Keep the rest in the report prose
-so the user has the full picture. Do not cap the prose list, only the
-chips.
+**Mirroring as navigation chips.** Mirror up to 3 of these "Suggested
+next steps" as host follow-up intents — the most actionable,
+alert-scoped ones. Keep the rest in the report prose so the user has
+the full picture. The chip surface is capped; the prose is not.
 
 ## Out of scope (v1)
 

--- a/plugins/signoz/skills/signoz-investigating-alerts/SKILL.md
+++ b/plugins/signoz/skills/signoz-investigating-alerts/SKILL.md
@@ -255,6 +255,13 @@ handles so the user can act immediately:
 Do not pad with generic advice ("verify connectivity", "check
 dashboards") — that's noise during an active incident.
 
+**Mirroring as navigation chips.** Pick the top 1-3 of these "Suggested
+next steps" and mirror them as host follow-up intents — the most
+actionable, alert-scoped ones (e.g. "Open trace 7af3a09b…", "Tune the
+threshold", "Page the owning team"). Keep the rest in the report prose
+so the user has the full picture. Do not cap the prose list, only the
+chips.
+
 ## Out of scope (v1)
 
 - **Deployment / config-change correlation** — SigNoz MCP does not


### PR DESCRIPTION
## Summary

Three skills had inconsistent follow-up sections that drifted from the host system prompt's max-4 cap and from each other:

| Skill | Issue |
|---|---|
| `signoz-explaining-alerts` | Said \"two or three actionable follow-ups\" but listed four candidates. Effective cap was undefined. |
| `signoz-explaining-dashboards` | Offered two candidates with no explicit cap and no target skill on the first one (\"run the queries from any specific panel\" — which skill?). |
| `signoz-investigating-alerts` | \"Suggested next steps\" was 4–5 incident-prose items with no guidance on which to surface as navigation chips vs. keep as prose. Incidents can have 10+ legitimate next steps; the chip surface needs a cap, the prose does not. |

`signoz-creating-dashboards` already does it correctly (2 candidates with `→ signoz-creating-alerts` targets), and `signoz-generating-queries` example-by-example offers are appropriate as-written — neither is touched.

## What changes

Each affected section is normalized to a consistent shape:

1. **Menu, not a list.** Candidates are framed as a menu the model picks from based on context, not a list to surface verbatim. Includes a one-line \"pick when…\" rule per item so the model has explicit selection criteria.

2. **Kind tags.** Each item is tagged *Action* or *Drill-down* per the host system prompt's follow-up-kinds vocabulary. This aligns with the recently-added `<navigation_suggestions>` taxonomy in the SigNoz Assistant prompt.

3. **Explicit target skill.** Each item that routes to another skill names the target (`→ signoz-X-Y`), matching the existing pattern in `creating-dashboards`.

4. **Explicit cap.** Each section ends with \"up to 3\" (within the host's max-4 hard cap, with one slot reserved for cross-cutting offers like persistence).

5. **Anti-trigger for pure exploration.** Each section explicitly says \"skip when the user is purely inspecting and signals no further intent. No chips beat wrong chips.\"

6. **Investigation-specific.** The incident-report \"Suggested next steps\" prose stays *uncapped* (incidents need the full picture for the user) but chip-mirroring is capped at top 1-3.

## What does NOT change

- The carefulness around fetching before explaining, the no-claim-root-cause rule, the strict-inputs guards — verbatim
- `signoz-creating-dashboards` — already consistent, untouched
- `signoz-generating-queries` — example-by-example offers are appropriate, untouched
- Investigation prose list — uncapped on purpose

## Test plan

- [x] All three affected sections render correctly in markdown preview
- [ ] Local Claude Code run on `signoz-explaining-alerts`: \"explain my high-cpu-checkout alert\" → confirm at most 3 follow-ups, each tagged Action/Drill-down, each with a `→ skill` target
- [ ] Local Claude Code run on `signoz-explaining-dashboards`: \"explain my k8s overview dashboard\" → confirm at most 3 follow-ups
- [ ] Local Claude Code run on `signoz-investigating-alerts`: a real incident → confirm prose retains full \"Suggested next steps\" list but chip surface is 1-3 items max
- [ ] Reviewer to confirm kind tags align with the host system prompt's `<navigation_suggestions>` taxonomy

## Notes

- No README updates needed
- Plugin version bump is auto-handled on merge
- Companion changes happening: #29 adds follow-ups to `signoz-managing-views` with the same vocabulary