### PR TITLE
feat: add SigNoz MCP plugin setup

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "signoz-skills",
   "metadata": {
-    "description": "Official SigNoz marketplace for Claude Code skills"
+    "description": "Official SigNoz marketplace for Claude Code skills and MCP"
   },
   "owner": {
     "name": "SigNoz"
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "signoz",
-      "description": "Official SigNoz plugin for docs guidance and ClickHouse dashboard queries",
+      "description": "Official SigNoz plugin for MCP, docs, queries, dashboards, and alerts",
       "author": {
         "name": "SigNoz"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "signoz",
-      "description": "Official SigNoz plugin for MCP, docs, queries, dashboards, and alerts",
+      "description": "Official SigNoz plugin for MCP setup, docs, queries, dashboards, and alerts",
       "author": {
         "name": "SigNoz"
       },

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "SigNoz"
   },
   "metadata": {
-    "description": "Official SigNoz Cursor plugin repository",
+    "description": "Official SigNoz Cursor plugin repository for skills and MCP",
     "version": "1.0.0",
     "pluginRoot": "plugins"
   },
@@ -12,7 +12,7 @@
     {
       "name": "signoz",
       "source": "signoz",
-      "description": "Official SigNoz plugin for docs guidance and ClickHouse dashboard queries"
+      "description": "Official SigNoz plugin for MCP, docs, queries, dashboards, and alerts"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "signoz",
       "source": "signoz",
-      "description": "Official SigNoz plugin for MCP, docs, queries, dashboards, and alerts"
+      "description": "Official SigNoz plugin for MCP setup, docs, queries, dashboards, and alerts"
     }
   ]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ npx skills add https://github.com/anthropics/skills --skill skill-creator
 
 ### Conventions
 
-- **Skill naming.** Gerund form (verb-ing + plural noun) prefixed with `signoz-`, lowercase with hyphens — e.g. `signoz-creating-alerts`, `signoz-modifying-dashboards`, `signoz-investigating-alerts`. Both Anthropic's best-practices doc and the SigNoz Skills/MCP spec recommend this form. The `name` in SKILL.md frontmatter must exactly match the directory name.
+- **Skill naming.** Domain action skills use gerund form prefixed with `signoz-`, lowercase with hyphens — e.g. `signoz-creating-alerts`, `signoz-modifying-dashboards`, `signoz-investigating-alerts`. Setup/maintenance skills may use precise object-action names such as `signoz-mcp-setup`; avoid broad command names like `signoz-setup`. Both Anthropic's best-practices doc and the SigNoz Skills/MCP spec recommend gerund form for action skills. The `name` in SKILL.md frontmatter must exactly match the directory name.
 - **Descriptions.** Imperative, pushy, and third-person. State both what the skill does and when to trigger it, with explicit user-phrase examples and an "even if they don't say X explicitly" clause. Aim well under the 1024-char limit.
 - **"Do NOT use" lists.** Only mention sibling skills that are genuinely similar or competing — i.e. ones a user could plausibly invoke instead. Don't enumerate every other skill in the plugin; rotting cross-references erode trust faster than any clarity they add.
 - **MCP tool references.** Use the fully qualified `signoz:<tool_name>` form (e.g. `` `signoz:signoz_get_alert` ``) in skill bodies. Bare names break when multiple MCP servers are loaded.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ plus an MCP setup skill so users do not have to hand-edit MCP configuration.
 After installing, run `signoz-mcp-setup` once if the MCP server is not already
 connected. It accepts a SigNoz Cloud region such as `us`, `us2`, `eu`, `eu2`,
 `in`, or `in2`, any hosted MCP URL, or a self-hosted HTTP `/mcp` endpoint.
+Plugin updates can reset bundled MCP registration files to the placeholder; if
+that happens, rerun `signoz-mcp-setup`.
 
 See the full setup guide in the [SigNoz MCP Server docs](https://signoz.io/docs/ai/signoz-mcp-server/).
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # SigNoz Agent Skills
 
-Official SigNoz skills for Claude Code, Codex, Cursor, and the [skills.sh](https://skills.sh) ecosystem.
+Official SigNoz skills and MCP configuration for Claude Code, Codex, Cursor, and the [skills.sh](https://skills.sh) ecosystem.
 
 ## Skills
 
 | Skill | Description |
 |-------|-------------|
+| [signoz-mcp-setup](plugins/signoz/skills/signoz-mcp-setup/SKILL.md) | Initialize or repair the SigNoz MCP server configuration for Claude Code, Codex, or Cursor. |
 | [signoz-creating-alerts](plugins/signoz/skills/signoz-creating-alerts/SKILL.md) | Create SigNoz alert rules for threshold breaches, error rates, latency, anomaly detection, and absent-data conditions across metrics, logs, and traces. |
 | [signoz-explaining-alerts](plugins/signoz/skills/signoz-explaining-alerts/SKILL.md) | Explain and interpret an existing SigNoz alert rule's configuration, evaluation behavior, notification routing, and recent fire frequency. |
 | [signoz-investigating-alerts](plugins/signoz/skills/signoz-investigating-alerts/SKILL.md) | Diagnose why a SigNoz alert fired by correlating its signal with neighbor metrics, traces, and logs around the fire window, and ranking likely causes. |
@@ -19,12 +20,23 @@ Official SigNoz skills for Claude Code, Codex, Cursor, and the [skills.sh](https
 
 ## Installation
 
+The plugin ships with an MCP setup skill so users do not have to hand-edit MCP
+configuration. After installing, run `signoz-mcp-setup`
+once if the MCP server is not already connected. It accepts a SigNoz Cloud
+region such as `us`, `us2`, `eu`, `eu2`, `in`, or `in2`, any hosted MCP URL,
+or a self-hosted HTTP `/mcp` endpoint.
+
+See the full setup guide in the [SigNoz MCP Server docs](https://signoz.io/docs/ai/signoz-mcp-server/).
+
 ### Claude Code
 
 ```sh
 /plugin marketplace add SigNoz/agent-skills
 /plugin install signoz@signoz-skills
 ```
+
+Then run `/mcp`, select the `signoz` server, and complete the authentication flow.
+If the server is not connected yet, ask Claude Code to run `signoz-mcp-setup` first.
 
 Update:
 
@@ -39,6 +51,8 @@ Update:
 
 1. Open the repository in Codex (restart if already running).
 2. Run `/plugins` and install `signoz` from the `SigNoz` marketplace.
+3. Ask Codex to run `signoz-mcp-setup` if the MCP server is not connected yet.
+4. Run `codex mcp login signoz`, then `/mcp` to verify the connection.
 
 To use in another repo, copy `plugins/signoz` into the target repo's `plugins/` directory and add a marketplace entry in `$REPO_ROOT/.agents/plugins/marketplace.json`.
 
@@ -48,6 +62,15 @@ Not yet on the public Cursor Marketplace. Install via a Team Marketplace:
 
 1. Add `https://github.com/SigNoz/agent-skills` as a team marketplace in `Settings -> Plugins`.
 2. Install the `signoz` plugin from the marketplace panel.
+3. Enter the MCP URL for your SigNoz Cloud region when prompted, such as
+   `https://mcp.us2.signoz.cloud/mcp`. For self-hosted HTTP mode, enter your
+   server's `/mcp` URL, such as `http://localhost:8000/mcp`.
+4. Open Cursor's MCP settings and complete authentication for the `signoz` server if prompted.
+
+If you skipped the prompt, picked the wrong region, or need to change a
+self-hosted HTTP MCP endpoint, run `/signoz-mcp-setup` in an agent chat
+window. If Cursor keeps using the install-time URL, clear the SigNoz MCP URL
+plugin setting and reload.
 
 ### skills.sh
 
@@ -68,8 +91,11 @@ npx skills add SigNoz/agent-skills --skill signoz-writing-clickhouse-queries    
 │   ├── .codex-plugin/plugin.json           # Codex plugin manifest
 │   ├── .claude-plugin/plugin.json          # Claude Code plugin manifest
 │   ├── .cursor-plugin/plugin.json          # Cursor plugin manifest
+│   ├── .mcp.json                           # Claude Code and Codex MCP config
+│   ├── mcp.json                            # Cursor MCP config
 │   ├── hooks/                              # Auto-allow hooks
 │   └── skills/
+│       ├── signoz-mcp-setup/
 │       ├── signoz-creating-alerts/
 │       ├── signoz-explaining-alerts/
 │       ├── signoz-investigating-alerts/

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # SigNoz Agent Skills
 
-Official SigNoz skills and MCP configuration for Claude Code, Codex, Cursor, and the [skills.sh](https://skills.sh) ecosystem.
+Official SigNoz skills and MCP configuration for Claude Code, Codex, Cursor, and the [skills.sh](https://skills.sh) ecosystem. The MCP setup skill also includes client-specific recipes for VS Code/GitHub Copilot, Claude Desktop, Gemini CLI, Windsurf, Zed, Antigravity, OpenCode, and generic HTTP MCP clients.
 
 ## Skills
 
 | Skill | Description |
 |-------|-------------|
-| [signoz-mcp-setup](plugins/signoz/skills/signoz-mcp-setup/SKILL.md) | Initialize or repair the SigNoz MCP server configuration for Claude Code, Codex, or Cursor. |
+| [signoz-mcp-setup](plugins/signoz/skills/signoz-mcp-setup/SKILL.md) | Initialize or repair the SigNoz MCP server configuration for Claude Code, Codex, Cursor, VS Code/GitHub Copilot, Claude Desktop, Gemini CLI, Windsurf, Zed, Antigravity, OpenCode, or another MCP client. |
 | [signoz-creating-alerts](plugins/signoz/skills/signoz-creating-alerts/SKILL.md) | Create SigNoz alert rules for threshold breaches, error rates, latency, anomaly detection, and absent-data conditions across metrics, logs, and traces. |
 | [signoz-explaining-alerts](plugins/signoz/skills/signoz-explaining-alerts/SKILL.md) | Explain and interpret an existing SigNoz alert rule's configuration, evaluation behavior, notification routing, and recent fire frequency. |
 | [signoz-investigating-alerts](plugins/signoz/skills/signoz-investigating-alerts/SKILL.md) | Diagnose why a SigNoz alert fired by correlating its signal with neighbor metrics, traces, and logs around the fire window, and ranking likely causes. |
@@ -72,6 +72,18 @@ self-hosted HTTP MCP endpoint, run `/signoz-mcp-setup` in an agent chat
 window. If Cursor keeps using the install-time URL, clear the SigNoz MCP URL
 plugin setting and reload.
 
+### Other MCP Clients
+
+The setup skill includes native config recipes for VS Code/GitHub Copilot,
+Claude Desktop, Gemini CLI, Windsurf, Zed, Antigravity, OpenCode, and generic
+HTTP MCP clients. These clients do not all consume this plugin automatically;
+install or copy the skill where your client supports skills, or use the
+client-specific setup snippets in the skill as a reference.
+
+For SigNoz Cloud, prefer the hosted MCP URL and client OAuth flow. For
+self-hosted SigNoz, the skill supports HTTP `/mcp` endpoints and stdio
+local-binary recipes. It avoids writing API keys into tracked project files.
+
 ### skills.sh
 
 ```sh
@@ -96,6 +108,7 @@ npx skills add SigNoz/agent-skills --skill signoz-writing-clickhouse-queries    
 │   ├── hooks/                              # Auto-allow hooks
 │   └── skills/
 │       ├── signoz-mcp-setup/
+│       │   └── references/
 │       ├── signoz-creating-alerts/
 │       ├── signoz-explaining-alerts/
 │       ├── signoz-investigating-alerts/

--- a/README.md
+++ b/README.md
@@ -75,15 +75,15 @@ Not yet on the public Cursor Marketplace. Install via a Team Marketplace:
 
 1. Add `https://github.com/SigNoz/agent-skills` as a team marketplace in `Settings -> Plugins`.
 2. Install the `signoz` plugin from the marketplace panel.
-3. Enter the MCP URL for your SigNoz Cloud region when prompted, such as
-   `https://mcp.us2.signoz.cloud/mcp`. For self-hosted HTTP mode, enter your
-   server's `/mcp` URL, such as `http://localhost:8000/mcp`.
-4. Open Cursor's MCP settings and complete authentication for the `signoz` server if prompted.
+3. Run `/signoz-mcp-setup` in an agent chat with your SigNoz Cloud region or
+   self-hosted HTTP MCP URL. This updates the bundled `mcp.json` placeholder
+   used by the Cursor plugin.
+4. Reload Cursor, then open MCP settings and complete authentication for the
+   `signoz` server if prompted.
 
-If you skipped the prompt, picked the wrong region, or need to change a
-self-hosted HTTP MCP endpoint, run `/signoz-mcp-setup` in an agent chat
-window. If Cursor keeps using the install-time URL, clear the SigNoz MCP URL
-plugin setting and reload.
+If you picked the wrong region or need to change a self-hosted HTTP MCP
+endpoint, run `/signoz-mcp-setup` again with the correct region or URL and
+reload Cursor.
 
 ### Other MCP Clients
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # SigNoz Agent Skills
 
-Official SigNoz skills and MCP configuration for Claude Code, Codex, Cursor, and the [skills.sh](https://skills.sh) ecosystem. The MCP setup skill also includes client-specific recipes for VS Code/GitHub Copilot, Claude Desktop, Gemini CLI, Windsurf, Zed, Antigravity, OpenCode, and generic HTTP MCP clients.
+Official SigNoz skills and MCP configuration for Claude Code, Codex, Cursor,
+and the [skills.sh](https://skills.sh) ecosystem. The MCP setup skill also
+includes client-specific recipes for VS Code/GitHub Copilot, Claude Desktop,
+Gemini CLI, Windsurf, Zed, Antigravity, OpenCode, and generic HTTP MCP
+clients.
 
 ## Skills
 
@@ -20,11 +24,11 @@ Official SigNoz skills and MCP configuration for Claude Code, Codex, Cursor, and
 
 ## Installation
 
-The plugin ships with an MCP setup skill so users do not have to hand-edit MCP
-configuration. After installing, run `signoz-mcp-setup`
-once if the MCP server is not already connected. It accepts a SigNoz Cloud
-region such as `us`, `us2`, `eu`, `eu2`, `in`, or `in2`, any hosted MCP URL,
-or a self-hosted HTTP `/mcp` endpoint.
+The Claude Code, Codex, and Cursor plugins ship with MCP registration files
+plus an MCP setup skill so users do not have to hand-edit MCP configuration.
+After installing, run `signoz-mcp-setup` once if the MCP server is not already
+connected. It accepts a SigNoz Cloud region such as `us`, `us2`, `eu`, `eu2`,
+`in`, or `in2`, any hosted MCP URL, or a self-hosted HTTP `/mcp` endpoint.
 
 See the full setup guide in the [SigNoz MCP Server docs](https://signoz.io/docs/ai/signoz-mcp-server/).
 
@@ -51,10 +55,17 @@ Update:
 
 1. Open the repository in Codex (restart if already running).
 2. Run `/plugins` and install `signoz` from the `SigNoz` marketplace.
-3. Ask Codex to run `signoz-mcp-setup` if the MCP server is not connected yet.
-4. Run `codex mcp login signoz`, then `/mcp` to verify the connection.
+3. Ask Codex to run `signoz-mcp-setup` with your SigNoz Cloud region or
+   self-hosted HTTP MCP URL. This updates the bundled `.mcp.json` placeholder
+   used by the Codex plugin.
+4. Restart Codex if the `signoz` MCP server does not appear.
+5. Run `codex mcp login signoz`, then `/mcp` to verify the connection.
 
-To use in another repo, copy `plugins/signoz` into the target repo's `plugins/` directory and add a marketplace entry in `$REPO_ROOT/.agents/plugins/marketplace.json`.
+The Codex plugin already declares `mcpServers: "./.mcp.json"`, so normal plugin
+installs do not need a separate native Codex MCP entry. To use in another repo,
+copy `plugins/signoz` into the target repo's `plugins/` directory, add a
+marketplace entry in `$REPO_ROOT/.agents/plugins/marketplace.json`, and repeat
+the setup step for that workspace.
 
 ### Cursor
 
@@ -108,7 +119,7 @@ npx skills add SigNoz/agent-skills --skill signoz-writing-clickhouse-queries    
 │   ├── hooks/                              # Auto-allow hooks
 │   └── skills/
 │       ├── signoz-mcp-setup/
-│       │   └── references/
+│       │   └── references/                 # Endpoint mapping and client recipes
 │       ├── signoz-creating-alerts/
 │       ├── signoz-explaining-alerts/
 │       ├── signoz-investigating-alerts/

--- a/plugins/signoz/.claude-plugin/plugin.json
+++ b/plugins/signoz/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "signoz",
   "version": "2026.05.15.6",
-  "description": "Official SigNoz plugin for MCP, docs, queries, dashboards, and alerts",
+  "description": "Official SigNoz plugin for MCP setup, docs, queries, dashboards, and alerts",
   "author": {
     "name": "SigNoz"
   },

--- a/plugins/signoz/.claude-plugin/plugin.json
+++ b/plugins/signoz/.claude-plugin/plugin.json
@@ -1,10 +1,11 @@
 {
   "name": "signoz",
   "version": "2026.05.15.6",
-  "description": "Official SigNoz plugin for docs, queries, dashboards, and alerts",
+  "description": "Official SigNoz plugin for MCP, docs, queries, dashboards, and alerts",
   "author": {
     "name": "SigNoz"
   },
   "repository": "https://github.com/SigNoz/agent-skills",
-  "license": "MIT"
+  "license": "MIT",
+  "mcpServers": "./.mcp.json"
 }

--- a/plugins/signoz/.codex-plugin/plugin.json
+++ b/plugins/signoz/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "signoz",
   "version": "2026.05.15.6",
-  "description": "Official SigNoz plugin for docs, queries, dashboards, and alerts",
+  "description": "Official SigNoz plugin for MCP, docs, queries, dashboards, and alerts",
   "author": {
     "name": "SigNoz",
     "url": "https://signoz.io"
@@ -13,15 +13,17 @@
     "signoz",
     "opentelemetry",
     "observability",
+    "mcp",
     "clickhouse",
     "tracing",
     "logging"
   ],
+  "mcpServers": "./.mcp.json",
   "skills": "./skills/",
   "interface": {
     "displayName": "SigNoz",
-    "shortDescription": "Official SigNoz skills for docs, queries, dashboards, and alerts",
-    "longDescription": "Installs the official SigNoz skills for using SigNoz docs, writing ClickHouse queries, generating observability queries, and creating, explaining, and modifying dashboards and alerts in Codex.",
+    "shortDescription": "Official SigNoz MCP and skills for docs, queries, dashboards, and alerts",
+    "longDescription": "Installs the official SigNoz MCP server configuration and skills for using SigNoz docs, writing ClickHouse queries, generating observability queries, and creating, explaining, and modifying dashboards and alerts in Codex.",
     "developerName": "SigNoz",
     "category": "Productivity",
     "capabilities": [
@@ -30,6 +32,7 @@
     ],
     "websiteURL": "https://signoz.io",
     "defaultPrompt": [
+      "Use signoz-mcp-setup to configure the SigNoz MCP server for my region.",
       "Use SigNoz to help me find the right docs page for OpenTelemetry instrumentation.",
       "Use SigNoz to write a ClickHouse query for a SigNoz dashboard panel over traces or logs.",
       "Use SigNoz to create a dashboard for monitoring my service.",

--- a/plugins/signoz/.codex-plugin/plugin.json
+++ b/plugins/signoz/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "signoz",
   "version": "2026.05.15.6",
-  "description": "Official SigNoz plugin for MCP, docs, queries, dashboards, and alerts",
+  "description": "Official SigNoz plugin for MCP setup, docs, queries, dashboards, and alerts",
   "author": {
     "name": "SigNoz",
     "url": "https://signoz.io"
@@ -22,8 +22,8 @@
   "skills": "./skills/",
   "interface": {
     "displayName": "SigNoz",
-    "shortDescription": "Official SigNoz MCP and skills for docs, queries, dashboards, and alerts",
-    "longDescription": "Installs the official SigNoz MCP server configuration and skills for using SigNoz docs, writing ClickHouse queries, generating observability queries, and creating, explaining, and modifying dashboards and alerts in Codex.",
+    "shortDescription": "Official SigNoz MCP setup and skills for docs, queries, dashboards, and alerts",
+    "longDescription": "Installs the official SigNoz skills and a bundled MCP server registration for Codex. Use signoz-mcp-setup to configure a SigNoz Cloud region, hosted MCP URL, or self-hosted HTTP endpoint before running docs, query, dashboard, alert, and view workflows.",
     "developerName": "SigNoz",
     "category": "Productivity",
     "capabilities": [
@@ -32,7 +32,7 @@
     ],
     "websiteURL": "https://signoz.io",
     "defaultPrompt": [
-      "Connect this workspace to SigNoz Cloud.",
+      "Set up SigNoz MCP for my SigNoz Cloud region.",
       "Investigate checkout errors across logs, traces, and metrics.",
       "Create a checkout dashboard and 5xx alert."
     ]

--- a/plugins/signoz/.codex-plugin/plugin.json
+++ b/plugins/signoz/.codex-plugin/plugin.json
@@ -32,11 +32,9 @@
     ],
     "websiteURL": "https://signoz.io",
     "defaultPrompt": [
-      "Use signoz-mcp-setup to configure the SigNoz MCP server for my region.",
-      "Use SigNoz to help me find the right docs page for OpenTelemetry instrumentation.",
-      "Use SigNoz to write a ClickHouse query for a SigNoz dashboard panel over traces or logs.",
-      "Use SigNoz to create a dashboard for monitoring my service.",
-      "Use SigNoz to set up an alert when error rate exceeds a threshold."
+      "Connect this workspace to SigNoz Cloud.",
+      "Investigate checkout errors across logs, traces, and metrics.",
+      "Create a checkout dashboard and 5xx alert."
     ]
   }
 }

--- a/plugins/signoz/.cursor-plugin/plugin.json
+++ b/plugins/signoz/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "signoz",
   "displayName": "SigNoz",
   "version": "2026.05.15.6",
-  "description": "Official SigNoz plugin for docs, queries, dashboards, and alerts",
+  "description": "Official SigNoz plugin for MCP, docs, queries, dashboards, and alerts",
   "author": {
     "name": "SigNoz"
   },
@@ -12,9 +12,33 @@
     "signoz",
     "opentelemetry",
     "observability",
+    "mcp",
     "clickhouse",
     "tracing",
     "logging"
   ],
+  "variables": {
+    "type": "object",
+    "properties": {
+      "SIGNOZ_MCP_URL": {
+        "type": "string",
+        "title": "SigNoz MCP URL",
+        "description": "Enter https://mcp.<region>.signoz.cloud/mcp for SigNoz Cloud, using the region shown under Settings -> Ingestion. For self-hosted HTTP mode, enter your server's /mcp URL, for example http://localhost:8000/mcp.",
+        "examples": [
+          "https://mcp.us.signoz.cloud/mcp",
+          "https://mcp.us2.signoz.cloud/mcp",
+          "https://mcp.eu.signoz.cloud/mcp",
+          "https://mcp.eu2.signoz.cloud/mcp",
+          "https://mcp.in.signoz.cloud/mcp",
+          "https://mcp.in2.signoz.cloud/mcp",
+          "http://localhost:8000/mcp"
+        ],
+        "pattern": "^https?://.+/mcp/?$"
+      }
+    },
+    "required": [
+      "SIGNOZ_MCP_URL"
+    ]
+  },
   "skills": "./skills/"
 }

--- a/plugins/signoz/.cursor-plugin/plugin.json
+++ b/plugins/signoz/.cursor-plugin/plugin.json
@@ -17,28 +17,5 @@
     "tracing",
     "logging"
   ],
-  "variables": {
-    "type": "object",
-    "properties": {
-      "SIGNOZ_MCP_URL": {
-        "type": "string",
-        "title": "SigNoz MCP URL",
-        "description": "Enter https://mcp.<region>.signoz.cloud/mcp for SigNoz Cloud, using the region shown under Settings -> Ingestion. For self-hosted HTTP mode, enter your server's /mcp URL, for example http://localhost:8000/mcp.",
-        "examples": [
-          "https://mcp.us.signoz.cloud/mcp",
-          "https://mcp.us2.signoz.cloud/mcp",
-          "https://mcp.eu.signoz.cloud/mcp",
-          "https://mcp.eu2.signoz.cloud/mcp",
-          "https://mcp.in.signoz.cloud/mcp",
-          "https://mcp.in2.signoz.cloud/mcp",
-          "http://localhost:8000/mcp"
-        ],
-        "pattern": "^https?://.+/mcp/?$"
-      }
-    },
-    "required": [
-      "SIGNOZ_MCP_URL"
-    ]
-  },
   "skills": "./skills/"
 }

--- a/plugins/signoz/.cursor-plugin/plugin.json
+++ b/plugins/signoz/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "signoz",
   "displayName": "SigNoz",
   "version": "2026.05.15.6",
-  "description": "Official SigNoz plugin for MCP, docs, queries, dashboards, and alerts",
+  "description": "Official SigNoz plugin for MCP setup, docs, queries, dashboards, and alerts",
   "author": {
     "name": "SigNoz"
   },

--- a/plugins/signoz/.mcp.json
+++ b/plugins/signoz/.mcp.json
@@ -1,0 +1,7 @@
+{
+  "mcpServers": {
+    "signoz": {
+      "url": "${SIGNOZ_MCP_URL:-https://not-setup/mcp}"
+    }
+  }
+}

--- a/plugins/signoz/.mcp.json
+++ b/plugins/signoz/.mcp.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "signoz": {
-      "url": "${SIGNOZ_MCP_URL:-https://not-setup/mcp}"
+      "url": "https://not-setup/mcp"
     }
   }
 }

--- a/plugins/signoz/mcp.json
+++ b/plugins/signoz/mcp.json
@@ -1,0 +1,7 @@
+{
+  "mcpServers": {
+    "signoz": {
+      "url": "${SIGNOZ_MCP_URL:-https://not-setup/mcp}"
+    }
+  }
+}

--- a/plugins/signoz/mcp.json
+++ b/plugins/signoz/mcp.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "signoz": {
-      "url": "${SIGNOZ_MCP_URL:-https://not-setup/mcp}"
+      "url": "https://not-setup/mcp"
     }
   }
 }

--- a/plugins/signoz/skills/signoz-creating-alerts/SKILL.md
+++ b/plugins/signoz/skills/signoz-creating-alerts/SKILL.md
@@ -24,10 +24,9 @@ the same flow — the human just gets a chance to intervene at the preview step.
 This skill calls SigNoz MCP server tools (`signoz:signoz_create_alert`,
 `signoz:signoz_list_alert_rules`, `signoz:signoz_get_field_keys`, etc.). Before running the
 workflow, confirm the `signoz:signoz_*` tools are available. If they are not,
-the SigNoz MCP server is not installed or configured — stop and direct
-the user to set it up:
-<https://signoz.io/docs/ai/signoz-mcp-server/>. Do not try to fall back
-to raw HTTP calls or fabricate alert configs without the MCP tools.
+run `signoz-mcp-setup` first to initialize or repair the MCP connection. Do not
+try to fall back to raw HTTP calls or fabricate alert configs without the MCP
+tools.
 
 ## When to use
 

--- a/plugins/signoz/skills/signoz-creating-dashboards/SKILL.md
+++ b/plugins/signoz/skills/signoz-creating-dashboards/SKILL.md
@@ -32,9 +32,9 @@ This skill calls SigNoz MCP server tools (`signoz:signoz_create_dashboard`,
 `signoz:signoz_aggregate_logs`, `signoz:signoz_aggregate_traces`, etc.).
 Before running the workflow, confirm the `signoz:signoz_*` tools are
 available. If they are not, the SigNoz MCP server is not installed or
-configured — stop and direct the user to set it up:
-<https://signoz.io/docs/ai/signoz-mcp-server/>. Do not fall back to raw
-HTTP calls or fabricate dashboard JSON without the MCP tools.
+configured — run `signoz-mcp-setup` first to initialize or repair the MCP
+connection. Do not fall back to raw HTTP calls or fabricate dashboard JSON
+without the MCP tools.
 
 ## When to use
 

--- a/plugins/signoz/skills/signoz-explaining-alerts/SKILL.md
+++ b/plugins/signoz/skills/signoz-explaining-alerts/SKILL.md
@@ -27,10 +27,8 @@ this skill does **not** investigate any specific fire — that is
 This skill calls SigNoz MCP server tools (`signoz:signoz_get_alert`,
 `signoz:signoz_list_alert_rules`, `signoz:signoz_get_alert_history`). Before running
 the workflow, confirm the `signoz:signoz_*` tools are available. If they are
-not, the SigNoz MCP server is not installed or configured — stop and
-direct the user to set it up:
-<https://signoz.io/docs/ai/signoz-mcp-server/>. Do not guess at alert
-configuration from the rule name alone.
+not, run `signoz-mcp-setup` first to initialize or repair the MCP connection.
+Do not guess at alert configuration from the rule name alone.
 
 ## When to use
 

--- a/plugins/signoz/skills/signoz-explaining-dashboards/SKILL.md
+++ b/plugins/signoz/skills/signoz-explaining-dashboards/SKILL.md
@@ -19,9 +19,9 @@ description: >
 This skill calls SigNoz MCP server tools (`signoz:signoz_get_dashboard`,
 `signoz:signoz_list_dashboards`). Before running the workflow, confirm the
 `signoz:signoz_*` tools are available. If they are not, the SigNoz MCP server
-is not installed or configured — stop and direct the user to set it up:
-<https://signoz.io/docs/ai/signoz-mcp-server/>. Do not guess at a
-dashboard's contents from its title alone.
+is not installed or configured — run `signoz-mcp-setup` first to initialize or
+repair the MCP connection. Do not guess at a dashboard's contents from its
+title alone.
 
 ## When to use
 

--- a/plugins/signoz/skills/signoz-generating-queries/SKILL.md
+++ b/plugins/signoz/skills/signoz-generating-queries/SKILL.md
@@ -21,10 +21,9 @@ This skill calls SigNoz MCP server tools heavily (`signoz:signoz_execute_builder
 `signoz:signoz_get_field_values`, `signoz:signoz_list_metrics`, `signoz:signoz_list_services`,
 `signoz:signoz_get_service_top_operations`, `signoz:signoz_get_trace_details`). Before
 running the workflow, confirm the `signoz:signoz_*` tools are available. If they
-are not, the SigNoz MCP server is not installed or configured — stop and
-direct the user to set it up: <https://signoz.io/docs/ai/signoz-mcp-server/>.
-Do not fall back to raw HTTP calls or fabricate query results without the
-MCP tools.
+are not, run `signoz-mcp-setup` first to initialize or repair the MCP connection.
+Do not fall back to raw HTTP calls or fabricate query results without the MCP
+tools.
 
 ## When to use
 

--- a/plugins/signoz/skills/signoz-investigating-alerts/SKILL.md
+++ b/plugins/signoz/skills/signoz-investigating-alerts/SKILL.md
@@ -28,10 +28,10 @@ This skill calls SigNoz MCP server tools heavily (`signoz:signoz_get_alert`,
 `signoz:signoz_query_metrics`, `signoz:signoz_search_traces`, `signoz:signoz_search_logs`,
 `signoz:signoz_get_trace_details`, etc.). Before running the workflow,
 confirm the `signoz:signoz_*` tools are available. If they are not, the
-SigNoz MCP server is not installed or configured — stop and direct
-the user to set it up: <https://signoz.io/docs/ai/signoz-mcp-server/>.
-The investigation depends on correlating multiple MCP queries; without
-the server there is no way to ground the analysis.
+SigNoz MCP server is not installed or configured — run `signoz-mcp-setup` first
+to initialize or repair the MCP connection. The investigation depends on
+correlating multiple MCP queries; without the server there is no way to ground
+the analysis.
 
 ## When to use
 

--- a/plugins/signoz/skills/signoz-managing-views/SKILL.md
+++ b/plugins/signoz/skills/signoz-managing-views/SKILL.md
@@ -32,10 +32,9 @@ This skill calls SigNoz MCP server tools (`signoz:signoz_create_view`,
 `signoz:signoz_update_view`, `signoz:signoz_delete_view`,
 `signoz:signoz_get_field_keys`, `signoz:signoz_get_field_values`). Before
 running the workflow, confirm the `signoz:signoz_*` tools are available. If
-they are not, the SigNoz MCP server is not installed or configured — stop
-and direct the user to set it up:
-<https://signoz.io/docs/ai/signoz-mcp-server/>. Do not fall back to raw HTTP
-calls or fabricate view payloads without the MCP tools.
+they are not, run `signoz-mcp-setup` first to initialize or repair the MCP
+connection. Do not fall back to raw HTTP calls or fabricate view payloads
+without the MCP tools.
 
 ## When to use
 

--- a/plugins/signoz/skills/signoz-mcp-setup/SKILL.md
+++ b/plugins/signoz/skills/signoz-mcp-setup/SKILL.md
@@ -42,7 +42,7 @@ Silently determine the SigNoz MCP server state using the reference flow:
   run Step 2. Otherwise tell them the SigNoz MCP server is configured but not
   connected, then ask for the SigNoz Cloud region or MCP URL to repair it. If
   they believe the endpoint is already correct, tell them to complete the
-  client authentication step in Step 4.
+  client authentication step in Step 5.
 
 Do not fall back to raw HTTP calls for SigNoz data when MCP is unavailable.
 The MCP server is the supported API surface for this plugin's live SigNoz
@@ -89,15 +89,28 @@ cannot complete interactive OAuth, use the header-based fallback in
 
 ### Step 4: Apply the endpoint
 
-For Claude Code, Codex, and Cursor plugin installs, edit the bundled plugin MCP
-registration files using the reference editing rule:
+For bundled Claude Code, Codex, and Cursor plugin installs, edit the registration
+files using the reference editing rules:
 
-1. Replace only the default value inside the `SIGNOZ_MCP_URL` template.
-2. Preserve the variable wrapper so users can still override the endpoint from
-   client settings when they need to.
-3. Update every SigNoz plugin registration file that exists in the plugin root.
+1. In `.mcp.json` for Claude Code and Codex, replace the full `url` value with
+   the resolved MCP endpoint. Do not use shell-style environment defaults here.
+2. In `mcp.json` for Cursor, replace only the default value inside the
+   `SIGNOZ_MCP_URL` template when that wrapper exists.
+3. Preserve unrelated MCP servers and settings.
 
-Example target shape:
+Claude Code and Codex target shape:
+
+```json
+{
+  "mcpServers": {
+    "signoz": {
+      "url": "https://mcp.us.signoz.cloud/mcp"
+    }
+  }
+}
+```
+
+Cursor target shape:
 
 ```json
 {
@@ -109,9 +122,13 @@ Example target shape:
 }
 ```
 
-If a registration file still uses the legacy no-default form
-`${SIGNOZ_MCP_URL}`, convert it to the target shape with the resolved endpoint
-as the default.
+If `.mcp.json` still uses any `SIGNOZ_MCP_URL` wrapper from an older version,
+replace it with the concrete resolved URL. If `mcp.json` lacks a
+`SIGNOZ_MCP_URL` wrapper, replace the concrete `url` value instead.
+
+Bundled registration files live inside the installed plugin. Plugin updates can
+reset them to the placeholder; if that happens, rerun this setup skill. For a
+more durable native-client setup, use the relevant recipe in `client-configs.md`.
 
 For native client setup, use `client-configs.md`:
 

--- a/plugins/signoz/skills/signoz-mcp-setup/SKILL.md
+++ b/plugins/signoz/skills/signoz-mcp-setup/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: signoz-mcp-setup
 description: >
-  Initialize or repair the SigNoz MCP server configuration for Claude Code,
-  Codex, or Cursor. Use this skill before any SigNoz docs, query, dashboard,
-  alert, or view workflow when `signoz:signoz_*` tools are unavailable, or when
-  the user says "setup SigNoz MCP", "configure SigNoz plugin", "wrong region",
-  "change SigNoz region", "MCP auth failed", or asks to connect SigNoz Cloud or
-  a self-hosted MCP endpoint, even if they do not mention the plugin.
-argument-hint: <SigNoz Cloud region, MCP URL, or self-hosted /mcp URL>
+  Initialize or repair SigNoz MCP server configuration for Claude Code, Codex,
+  Cursor, VS Code/GitHub Copilot, Claude Desktop, Gemini CLI, Windsurf, Zed,
+  Antigravity, OpenCode, or another MCP client. Use this skill before any
+  SigNoz docs, query, dashboard, alert, or view workflow when
+  `signoz:signoz_*` tools are unavailable, or when the user says "setup SigNoz
+  MCP", "configure SigNoz plugin", "wrong region", "change SigNoz region",
+  "MCP auth failed", or asks to connect SigNoz Cloud or a self-hosted MCP
+  endpoint, even if they do not mention the plugin.
+argument-hint: <client, SigNoz Cloud region, MCP URL, or self-hosted /mcp URL>
 ---
 
 # SigNoz MCP Setup
@@ -22,6 +24,11 @@ Read [references/mcp-settings.md](references/mcp-settings.md) before checking
 state, mapping user input, or editing registration files. It contains the
 server-state check, registration file locations, editing rules, and region
 mapping used by this procedure.
+
+Read [references/client-configs.md](references/client-configs.md) when the
+user names a client other than the bundled Claude Code, Codex, or Cursor
+plugin path, when a native client config already exists, or when self-hosted
+stdio/local-binary setup is requested.
 
 ## Configuration procedure
 
@@ -41,7 +48,23 @@ Do not fall back to raw HTTP calls for SigNoz data when MCP is unavailable.
 The MCP server is the supported API surface for this plugin's live SigNoz
 workflows.
 
-### Step 2: Resolve the endpoint
+### Step 2: Identify the client
+
+Use the client named in `$ARGUMENTS` or the user's latest message. If no
+client is named, infer it only when the active environment is obvious:
+
+- Claude Code, Codex, or Cursor plugin install: use the bundled plugin
+  registration files.
+- VS Code / GitHub Copilot, Claude Desktop, Gemini CLI, Windsurf, Zed,
+  Antigravity, or OpenCode: use the matching native client recipe in
+  `client-configs.md`.
+- Unknown or unsupported client: use the generic HTTP MCP recipe and point the
+  user to the SigNoz MCP Server docs for their client's exact config surface.
+
+If you need to edit a native client config and the client is still ambiguous,
+ask which client they want to configure.
+
+### Step 3: Resolve the endpoint
 
 Use `$ARGUMENTS` or the user's latest message if it already contains a region
 or URL. Otherwise ask for one of:
@@ -56,16 +79,18 @@ workspace URL such as `https://your-instance.signoz.cloud`, do not guess the
 region from it. Ask them to check **Settings -> Ingestion** in SigNoz and
 provide the region.
 
-Do not ask for an API key during plugin setup. For SigNoz Cloud, OAuth asks for
-the instance URL and service account API key after the MCP URL is configured.
-For self-hosted SigNoz, this plugin configuration path supports HTTP MCP mode.
-If the user wants stdio/local-binary mode instead, tell them to register the
-SigNoz MCP server separately as `signoz`; these skills will work once
-`signoz:signoz_*` tools are available.
+Do not ask for an API key for SigNoz Cloud setup. OAuth asks for the instance
+URL and service account API key after the hosted MCP URL is configured. For
+self-hosted SigNoz, prefer HTTP mode when the user gives an `/mcp` endpoint.
+For stdio/local-binary mode, collect the binary path, SigNoz URL, and API key
+only if the user explicitly asks you to configure that mode. For clients that
+cannot complete interactive OAuth, use the header-based fallback in
+`client-configs.md` only when the user asks for it or the client requires it.
 
-### Step 3: Apply the endpoint
+### Step 4: Apply the endpoint
 
-Edit the plugin MCP registration files using the reference editing rule:
+For Claude Code, Codex, and Cursor plugin installs, edit the bundled plugin MCP
+registration files using the reference editing rule:
 
 1. Replace only the default value inside the `SIGNOZ_MCP_URL` template.
 2. Preserve the variable wrapper so users can still override the endpoint from
@@ -88,17 +113,42 @@ If a registration file still uses the legacy no-default form
 `${SIGNOZ_MCP_URL}`, convert it to the target shape with the resolved endpoint
 as the default.
 
-### Step 4: Tell the user how to finish
+For native client setup, use `client-configs.md`:
+
+- Edit an existing native client config only when the user named that client or
+  the target file is clearly the active config for the task.
+- Create a new native client config only when the user asks for that client to
+  be configured.
+- Never write service account API keys, bearer tokens, or header-based auth
+  values into tracked project files. Prefer client OAuth for SigNoz Cloud,
+  user-level config, environment-variable references, or short commands the
+  user can run locally.
+- Preserve unrelated MCP servers and existing client settings.
+- Keep the server name `signoz`.
+
+### Step 5: Tell the user how to finish
 
 Tell the user that the SigNoz MCP endpoint has been configured, then give the
 client-specific authentication step:
 
 - **Cursor** — reload the window, then authenticate the `signoz` MCP server in
   Tools & MCP if prompted.
+- **VS Code / GitHub Copilot** — open Copilot Chat in Agent mode, approve the
+  `signoz` server if prompted, then complete the authentication flow.
 - **Codex** — restart Codex if the server does not appear, then run
   `codex mcp login signoz` and verify with `/mcp`.
 - **Claude Code** — restart Claude Code if the server does not appear, then run
   `/mcp`, select `signoz`, and complete authentication.
+- **Claude Desktop** — restart Claude Desktop or reconnect the custom
+  connector, then complete authentication when prompted.
+- **Gemini CLI** — restart Gemini CLI if needed, then run `/mcp auth signoz`.
+- **Windsurf** — reload Windsurf and complete authentication when prompted.
+- **Zed** — reload Zed after config changes; self-hosted stdio mode reads the
+  configured environment from the context server entry.
+- **Antigravity** — reload the agent window and complete OAuth when prompted.
+  If authentication is stuck, clear cached dynamic auth providers and retry.
+- **OpenCode** — run `opencode mcp auth signoz` if authentication does not
+  start automatically, then verify with `opencode mcp list`.
 
 Keep the response short. Do not expose registration file paths, placeholder
 values, environment variable names, API keys, tokens, or file contents unless

--- a/plugins/signoz/skills/signoz-mcp-setup/SKILL.md
+++ b/plugins/signoz/skills/signoz-mcp-setup/SKILL.md
@@ -93,9 +93,9 @@ For bundled Claude Code, Codex, and Cursor plugin installs, edit the registratio
 files using the reference editing rules:
 
 1. In `.mcp.json` for Claude Code and Codex, replace the full `url` value with
-   the resolved MCP endpoint. Do not use shell-style environment defaults here.
-2. In `mcp.json` for Cursor, replace only the default value inside the
-   `SIGNOZ_MCP_URL` template when that wrapper exists.
+   the resolved MCP endpoint.
+2. In `mcp.json` for Cursor, replace the full `url` value with the resolved MCP
+   endpoint.
 3. Preserve unrelated MCP servers and settings.
 
 Claude Code and Codex target shape:
@@ -116,15 +116,14 @@ Cursor target shape:
 {
   "mcpServers": {
     "signoz": {
-      "url": "${SIGNOZ_MCP_URL:-https://mcp.us.signoz.cloud/mcp}"
+      "url": "https://mcp.us.signoz.cloud/mcp"
     }
   }
 }
 ```
 
-If `.mcp.json` still uses any `SIGNOZ_MCP_URL` wrapper from an older version,
-replace it with the concrete resolved URL. If `mcp.json` lacks a
-`SIGNOZ_MCP_URL` wrapper, replace the concrete `url` value instead.
+If either bundled file still uses any `SIGNOZ_MCP_URL` wrapper from an older
+version, replace it with the concrete resolved URL.
 
 Bundled registration files live inside the installed plugin. Plugin updates can
 reset them to the placeholder; if that happens, rerun this setup skill. For a

--- a/plugins/signoz/skills/signoz-mcp-setup/SKILL.md
+++ b/plugins/signoz/skills/signoz-mcp-setup/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: signoz-mcp-setup
+description: >
+  Initialize or repair the SigNoz MCP server configuration for Claude Code,
+  Codex, or Cursor. Use this skill before any SigNoz docs, query, dashboard,
+  alert, or view workflow when `signoz:signoz_*` tools are unavailable, or when
+  the user says "setup SigNoz MCP", "configure SigNoz plugin", "wrong region",
+  "change SigNoz region", "MCP auth failed", or asks to connect SigNoz Cloud or
+  a self-hosted MCP endpoint, even if they do not mention the plugin.
+argument-hint: <SigNoz Cloud region, MCP URL, or self-hosted /mcp URL>
+---
+
+# SigNoz MCP Setup
+
+Initialize or repair the SigNoz MCP server registration shipped with this
+plugin. The target state is one working `signoz` MCP server. Do not create a
+duplicate server unless the user explicitly asks for a separate configuration.
+
+## Shared reference
+
+Read [references/mcp-settings.md](references/mcp-settings.md) before checking
+state, mapping user input, or editing registration files. It contains the
+server-state check, registration file locations, editing rules, and region
+mapping used by this procedure.
+
+## Configuration procedure
+
+### Step 1: Check state
+
+Silently determine the SigNoz MCP server state using the reference flow:
+
+- **working** — continue with the user's original SigNoz request.
+- **not-setup** — run Step 2.
+- **configured-but-not-working** — if the user provided a new region or MCP URL,
+  run Step 2. Otherwise tell them the SigNoz MCP server is configured but not
+  connected, then ask for the SigNoz Cloud region or MCP URL to repair it. If
+  they believe the endpoint is already correct, tell them to complete the
+  client authentication step in Step 4.
+
+Do not fall back to raw HTTP calls for SigNoz data when MCP is unavailable.
+The MCP server is the supported API surface for this plugin's live SigNoz
+workflows.
+
+### Step 2: Resolve the endpoint
+
+Use `$ARGUMENTS` or the user's latest message if it already contains a region
+or URL. Otherwise ask for one of:
+
+- SigNoz Cloud region: `us`, `us2`, `eu`, `eu2`, `in`, `in2`, or a newer
+  region code
+- SigNoz Cloud MCP URL, such as `https://mcp.us.signoz.cloud/mcp`
+- Self-hosted HTTP MCP URL, such as `http://localhost:8000/mcp`
+
+Map the response using `mcp-settings.md`. If the user gives only a SigNoz
+workspace URL such as `https://your-instance.signoz.cloud`, do not guess the
+region from it. Ask them to check **Settings -> Ingestion** in SigNoz and
+provide the region.
+
+Do not ask for an API key during plugin setup. For SigNoz Cloud, OAuth asks for
+the instance URL and service account API key after the MCP URL is configured.
+For self-hosted SigNoz, this plugin configuration path supports HTTP MCP mode.
+If the user wants stdio/local-binary mode instead, tell them to register the
+SigNoz MCP server separately as `signoz`; these skills will work once
+`signoz:signoz_*` tools are available.
+
+### Step 3: Apply the endpoint
+
+Edit the plugin MCP registration files using the reference editing rule:
+
+1. Replace only the default value inside the `SIGNOZ_MCP_URL` template.
+2. Preserve the variable wrapper so users can still override the endpoint from
+   client settings when they need to.
+3. Update every SigNoz plugin registration file that exists in the plugin root.
+
+Example target shape:
+
+```json
+{
+  "mcpServers": {
+    "signoz": {
+      "url": "${SIGNOZ_MCP_URL:-https://mcp.us.signoz.cloud/mcp}"
+    }
+  }
+}
+```
+
+If a registration file still uses the legacy no-default form
+`${SIGNOZ_MCP_URL}`, convert it to the target shape with the resolved endpoint
+as the default.
+
+### Step 4: Tell the user how to finish
+
+Tell the user that the SigNoz MCP endpoint has been configured, then give the
+client-specific authentication step:
+
+- **Cursor** — reload the window, then authenticate the `signoz` MCP server in
+  Tools & MCP if prompted.
+- **Codex** — restart Codex if the server does not appear, then run
+  `codex mcp login signoz` and verify with `/mcp`.
+- **Claude Code** — restart Claude Code if the server does not appear, then run
+  `/mcp`, select `signoz`, and complete authentication.
+
+Keep the response short. Do not expose registration file paths, placeholder
+values, environment variable names, API keys, tokens, or file contents unless
+the user explicitly asks for implementation details.

--- a/plugins/signoz/skills/signoz-mcp-setup/references/client-configs.md
+++ b/plugins/signoz/skills/signoz-mcp-setup/references/client-configs.md
@@ -35,14 +35,15 @@ Use these shapes for SigNoz Cloud hosted MCP URLs such as
 
 ### Bundled Claude Code and Codex plugin
 
-Update `.mcp.json` in the SigNoz plugin root using the `SIGNOZ_MCP_URL`
-template rule from `mcp-settings.md`.
+Update `.mcp.json` in the SigNoz plugin root using the concrete URL rule from
+`mcp-settings.md`. Codex does not reliably expand shell-style environment
+defaults in plugin MCP URLs.
 
 ```json
 {
   "mcpServers": {
     "signoz": {
-      "url": "${SIGNOZ_MCP_URL:-https://mcp.us.signoz.cloud/mcp}"
+      "url": "https://mcp.us.signoz.cloud/mcp"
     }
   }
 }
@@ -51,7 +52,8 @@ template rule from `mcp-settings.md`.
 ### Bundled Cursor plugin
 
 Update `mcp.json` in the SigNoz plugin root using the `SIGNOZ_MCP_URL`
-template rule from `mcp-settings.md`.
+template rule from `mcp-settings.md`. Cursor plugin installs can prompt for the
+URL and use that value in the bundled MCP config.
 
 ```json
 {

--- a/plugins/signoz/skills/signoz-mcp-setup/references/client-configs.md
+++ b/plugins/signoz/skills/signoz-mcp-setup/references/client-configs.md
@@ -1,0 +1,384 @@
+# SigNoz MCP Client Config Reference
+
+Use this reference after resolving the SigNoz MCP endpoint in
+[mcp-settings.md](mcp-settings.md). It mirrors the client setup patterns in the
+SigNoz MCP Server docs and adds OpenCode's native config shape.
+
+## Contents
+
+- [Safety Rules](#safety-rules)
+- [Cloud or Self-Hosted HTTP](#cloud-or-self-hosted-http)
+- [Header-Based Auth Fallback](#header-based-auth-fallback)
+- [Self-Hosted Stdio](#self-hosted-stdio)
+- [Authentication Finish Steps](#authentication-finish-steps)
+
+## Safety Rules
+
+- Keep the MCP server name `signoz`.
+- Prefer SigNoz Cloud OAuth over header-based auth whenever the client supports
+  interactive OAuth.
+- Do not write service account API keys, bearer tokens, or header-based auth
+  values into tracked project files.
+- If secrets are needed for self-hosted stdio, prefer user-level config,
+  environment-variable references, or a command the user can run.
+- When editing JSON, TOML, or JSONC, preserve unrelated settings and other MCP
+  servers. Update only the `signoz` server entry.
+- If the client supports both project and user/global config, prefer the scope
+  the user requested. If they did not choose, prefer user/global for secrets
+  and project scope for non-secret hosted MCP URLs.
+
+## Cloud or Self-Hosted HTTP
+
+Use these shapes for SigNoz Cloud hosted MCP URLs such as
+`https://mcp.us.signoz.cloud/mcp` and self-hosted HTTP MCP URLs such as
+`http://localhost:8000/mcp`.
+
+### Bundled Claude Code and Codex plugin
+
+Update `.mcp.json` in the SigNoz plugin root using the `SIGNOZ_MCP_URL`
+template rule from `mcp-settings.md`.
+
+```json
+{
+  "mcpServers": {
+    "signoz": {
+      "url": "${SIGNOZ_MCP_URL:-https://mcp.us.signoz.cloud/mcp}"
+    }
+  }
+}
+```
+
+### Bundled Cursor plugin
+
+Update `mcp.json` in the SigNoz plugin root using the `SIGNOZ_MCP_URL`
+template rule from `mcp-settings.md`.
+
+```json
+{
+  "mcpServers": {
+    "signoz": {
+      "url": "${SIGNOZ_MCP_URL:-https://mcp.us.signoz.cloud/mcp}"
+    }
+  }
+}
+```
+
+### Cursor native config
+
+Use `.cursor/mcp.json` in the project root.
+
+```json
+{
+  "mcpServers": {
+    "signoz": {
+      "url": "https://mcp.us.signoz.cloud/mcp"
+    }
+  }
+}
+```
+
+### VS Code / GitHub Copilot
+
+Use `.vscode/mcp.json` in the workspace, or the user-level MCP config opened
+by the `MCP: Open User Configuration` command.
+
+```json
+{
+  "servers": {
+    "signoz": {
+      "type": "http",
+      "url": "https://mcp.us.signoz.cloud/mcp"
+    }
+  }
+}
+```
+
+### Claude Desktop
+
+Claude Desktop can add SigNoz Cloud as a custom connector from Settings. If
+the user asks for raw config, add the `signoz` entry to
+`claude_desktop_config.json`.
+
+```json
+{
+  "mcpServers": {
+    "signoz": {
+      "url": "https://mcp.us.signoz.cloud/mcp"
+    }
+  }
+}
+```
+
+### Claude Code native CLI
+
+For user scope:
+
+```sh
+claude mcp add --scope user --transport http signoz https://mcp.us.signoz.cloud/mcp
+```
+
+For project scope, use `--scope project` instead of `--scope user`.
+
+### Codex native CLI or TOML
+
+CLI:
+
+```sh
+codex mcp add signoz --url https://mcp.us.signoz.cloud/mcp
+```
+
+TOML:
+
+```toml
+[mcp_servers.signoz]
+url = "https://mcp.us.signoz.cloud/mcp"
+```
+
+### Gemini CLI
+
+CLI:
+
+```sh
+gemini mcp add -t http signoz https://mcp.us.signoz.cloud/mcp
+```
+
+Or edit `~/.gemini/settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "signoz": {
+      "httpUrl": "https://mcp.us.signoz.cloud/mcp"
+    }
+  }
+}
+```
+
+### Windsurf
+
+Edit `~/.codeium/windsurf/mcp_config.json`.
+
+```json
+{
+  "mcpServers": {
+    "signoz": {
+      "serverUrl": "https://mcp.us.signoz.cloud/mcp"
+    }
+  }
+}
+```
+
+### Antigravity
+
+Edit `mcp_config.json` from the agent panel's MCP server manager.
+
+```json
+{
+  "mcpServers": {
+    "signoz": {
+      "serverUrl": "https://mcp.us.signoz.cloud/mcp"
+    }
+  }
+}
+```
+
+### OpenCode
+
+Edit `opencode.json` or `opencode.jsonc`.
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "signoz": {
+      "type": "remote",
+      "url": "https://mcp.us.signoz.cloud/mcp",
+      "enabled": true
+    }
+  }
+}
+```
+
+### Generic HTTP MCP client
+
+If the client is not listed, use its native remote or HTTP MCP shape with:
+
+- server name: `signoz`
+- transport/type: HTTP, remote, or streamable HTTP
+- URL: the resolved SigNoz MCP endpoint
+
+## Header-Based Auth Fallback
+
+Use header-based auth only when the MCP client cannot complete interactive
+OAuth, or when the user explicitly asks for a non-OAuth setup. SigNoz Cloud
+needs both headers:
+
+- `SIGNOZ-API-KEY`: service account API key
+- `X-SigNoz-URL`: SigNoz instance URL, such as `https://your-instance.signoz.cloud`
+
+Prefer environment-variable references if the client supports them. Do not
+write real header values into tracked project files.
+
+Generic shape:
+
+```json
+{
+  "mcpServers": {
+    "signoz": {
+      "url": "https://mcp.us.signoz.cloud/mcp",
+      "headers": {
+        "SIGNOZ-API-KEY": "<your-api-key>",
+        "X-SigNoz-URL": "<your-signoz-instance-url>"
+      }
+    }
+  }
+}
+```
+
+## Self-Hosted Stdio
+
+Use stdio/local-binary mode only when the user explicitly requests it or the
+client cannot use HTTP. Collect:
+
+- absolute path to the `signoz-mcp-server` binary
+- SigNoz instance URL
+- service account API key
+
+Prefer placeholders or environment-variable references when writing examples.
+Avoid storing real API keys in tracked project files.
+
+### JSON clients using `mcpServers`
+
+Cursor, Claude Desktop, Windsurf, Gemini CLI, and Antigravity can use this
+basic stdio shape, with client-specific file locations from the HTTP section.
+
+```json
+{
+  "mcpServers": {
+    "signoz": {
+      "command": "<path-to-binary>/signoz-mcp-server",
+      "args": [],
+      "env": {
+        "SIGNOZ_URL": "<your-signoz-url>",
+        "SIGNOZ_API_KEY": "<your-api-key>",
+        "LOG_LEVEL": "info"
+      }
+    }
+  }
+}
+```
+
+### VS Code / GitHub Copilot stdio
+
+```json
+{
+  "servers": {
+    "signoz": {
+      "type": "stdio",
+      "command": "<path-to-binary>/signoz-mcp-server",
+      "args": [],
+      "env": {
+        "SIGNOZ_URL": "<your-signoz-url>",
+        "SIGNOZ_API_KEY": "<your-api-key>",
+        "LOG_LEVEL": "info"
+      }
+    }
+  }
+}
+```
+
+### Claude Code stdio
+
+```sh
+claude mcp add --scope user signoz "<path-to-binary>/signoz-mcp-server" \
+  -e SIGNOZ_URL="<your-signoz-url>" \
+  -e SIGNOZ_API_KEY="<your-api-key>" \
+  -e LOG_LEVEL=info
+```
+
+### Codex stdio
+
+CLI:
+
+```sh
+codex mcp add signoz \
+  --env SIGNOZ_URL="<your-signoz-url>" \
+  --env SIGNOZ_API_KEY="<your-api-key>" \
+  --env LOG_LEVEL=info \
+  -- "<path-to-binary>/signoz-mcp-server"
+```
+
+TOML:
+
+```toml
+[mcp_servers.signoz]
+command = "<path-to-binary>/signoz-mcp-server"
+args = []
+
+[mcp_servers.signoz.env]
+SIGNOZ_URL = "<your-signoz-url>"
+SIGNOZ_API_KEY = "<your-api-key>"
+LOG_LEVEL = "info"
+```
+
+### Zed
+
+Edit Zed settings.
+
+```json
+{
+  "context_servers": {
+    "signoz": {
+      "command": "<path-to-binary>/signoz-mcp-server",
+      "args": [],
+      "env": {
+        "SIGNOZ_URL": "<your-signoz-url>",
+        "SIGNOZ_API_KEY": "<your-api-key>",
+        "LOG_LEVEL": "info"
+      }
+    }
+  }
+}
+```
+
+### OpenCode local
+
+Edit `opencode.json` or `opencode.jsonc`.
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "signoz": {
+      "type": "local",
+      "command": ["<path-to-binary>/signoz-mcp-server"],
+      "environment": {
+        "SIGNOZ_URL": "<your-signoz-url>",
+        "SIGNOZ_API_KEY": "<your-api-key>",
+        "LOG_LEVEL": "info"
+      },
+      "enabled": true
+    }
+  }
+}
+```
+
+## Authentication Finish Steps
+
+- Cursor: reload the window, then authenticate the `signoz` MCP server in
+  Tools & MCP if prompted.
+- VS Code / GitHub Copilot: open Copilot Chat in Agent mode, approve the
+  `signoz` server, and complete authentication.
+- Claude Desktop: restart or reconnect the custom connector, then complete
+  authentication.
+- Claude Code: run `/mcp`, select `signoz`, and complete authentication.
+- Codex: run `codex mcp login signoz`, then verify with `/mcp`.
+- Gemini CLI: run `/mcp auth signoz`.
+- Windsurf: reload and complete authentication when prompted.
+- Zed: reload after stdio config changes.
+- Antigravity: reload the agent window and complete OAuth. If auth is stuck,
+  clear dynamic authentication providers and retry.
+- OpenCode: run `opencode mcp auth signoz` if auth does not start
+  automatically, then verify with `opencode mcp list`.
+- Header-based auth: no OAuth step is expected; verify the `signoz` tools after
+  the client reloads.

--- a/plugins/signoz/skills/signoz-mcp-setup/references/client-configs.md
+++ b/plugins/signoz/skills/signoz-mcp-setup/references/client-configs.md
@@ -51,15 +51,15 @@ defaults in plugin MCP URLs.
 
 ### Bundled Cursor plugin
 
-Update `mcp.json` in the SigNoz plugin root using the `SIGNOZ_MCP_URL`
-template rule from `mcp-settings.md`. Cursor plugin installs can prompt for the
-URL and use that value in the bundled MCP config.
+Update `mcp.json` in the SigNoz plugin root using the concrete URL rule from
+`mcp-settings.md`. Do not rely on shell-style environment defaults in Cursor
+plugin MCP URLs.
 
 ```json
 {
   "mcpServers": {
     "signoz": {
-      "url": "${SIGNOZ_MCP_URL:-https://mcp.us.signoz.cloud/mcp}"
+      "url": "https://mcp.us.signoz.cloud/mcp"
     }
   }
 }

--- a/plugins/signoz/skills/signoz-mcp-setup/references/mcp-settings.md
+++ b/plugins/signoz/skills/signoz-mcp-setup/references/mcp-settings.md
@@ -4,6 +4,17 @@ Use this reference when checking the SigNoz MCP server state, locating plugin
 registration files, editing the endpoint default, or mapping user input to a
 hosted SigNoz Cloud MCP URL.
 
+For native client config shapes such as VS Code, Gemini CLI, Windsurf, Zed,
+Antigravity, or OpenCode, read
+[client-configs.md](client-configs.md) after resolving the endpoint.
+
+## Contents
+
+- [State Check](#state-check)
+- [Registration Files](#registration-files)
+- [Editing Rule](#editing-rule)
+- [Endpoint Mapping](#endpoint-mapping)
+
 ## State Check
 
 Silently determine `signoz-server-state`:
@@ -22,7 +33,7 @@ only the plain outcome: working, not set up, or configured but not connected.
 
 ## Registration Files
 
-The SigNoz plugin may ship both registration files in the plugin root:
+The SigNoz plugin may ship both bundled registration files in the plugin root:
 
 - `.mcp.json` for Claude Code and Codex
 - `mcp.json` for Cursor
@@ -57,10 +68,9 @@ If a file contains the legacy no-default form `${SIGNOZ_MCP_URL}`, replace it
 with `${SIGNOZ_MCP_URL:-<resolved-mcp-url>}`.
 
 If the user's client has an explicit plugin setting or environment override
-for the endpoint, that value can override this default. If the MCP
-MCP setup skill updates the default but the client still connects to the
-old endpoint, tell the user to clear the explicit plugin setting and reload
-the client.
+for the endpoint, that value can override this default. If the MCP setup skill
+updates the default but the client still connects to the old endpoint, tell
+the user to clear the explicit plugin setting and reload the client.
 
 ## Endpoint Mapping
 
@@ -97,7 +107,9 @@ Mapping rules:
   `https://mcp.<region>.signoz.cloud/mcp`. New SigNoz Cloud regions may exist
   before this skill is updated.
 
-Do not ask for API keys in this MCP setup skill. SigNoz Cloud authentication
-happens after endpoint setup through the MCP client's OAuth flow. Self-hosted
-HTTP mode expects the user to run the MCP server with its SigNoz URL and API
-key configured on that server process.
+Do not ask for API keys for SigNoz Cloud endpoint setup. SigNoz Cloud
+authentication happens after endpoint setup through the MCP client's OAuth
+flow. Self-hosted HTTP mode expects the user to run the MCP server with its
+SigNoz URL and API key configured on that server process. For self-hosted
+stdio/local-binary mode, read `client-configs.md` and collect secrets only when
+the user explicitly asks you to configure that mode.

--- a/plugins/signoz/skills/signoz-mcp-setup/references/mcp-settings.md
+++ b/plugins/signoz/skills/signoz-mcp-setup/references/mcp-settings.md
@@ -1,0 +1,103 @@
+# SigNoz MCP Registration Reference
+
+Use this reference when checking the SigNoz MCP server state, locating plugin
+registration files, editing the endpoint default, or mapping user input to a
+hosted SigNoz Cloud MCP URL.
+
+## State Check
+
+Silently determine `signoz-server-state`:
+
+1. If `signoz:signoz_*` MCP tools are available, try a lightweight read-only
+   call such as `signoz:signoz_search_docs` for `mcp setup` or
+   `signoz:signoz_list_services` with a small lookback.
+2. If the call returns SigNoz-specific content, state is **working**.
+3. If the call fails, returns no tools, or only generic/empty content, read the
+   plugin registration files below.
+4. If any registration file contains `not-setup`, state is **not-setup**.
+5. Otherwise state is **configured-but-not-working**.
+
+Do not tell the user which checks ran or what file contents were found. Explain
+only the plain outcome: working, not set up, or configured but not connected.
+
+## Registration Files
+
+The SigNoz plugin may ship both registration files in the plugin root:
+
+- `.mcp.json` for Claude Code and Codex
+- `mcp.json` for Cursor
+
+This reference file lives at `skills/signoz-mcp-setup/references/mcp-settings.md`,
+so the plugin root is two directories up from `skills/signoz-mcp-setup/`.
+
+Update every registration file that exists. Do not create duplicate MCP server
+entries, and do not rename the `signoz` server.
+
+## Editing Rule
+
+The URL should use this template shape:
+
+```json
+"url": "${SIGNOZ_MCP_URL:-https://mcp.us.signoz.cloud/mcp}"
+```
+
+The variable has the form `${NAME:-default}`. Replace only the default value,
+which is the text between `:-` and the closing `}`. Keep `${`, the variable
+name, `:-`, and `}` intact.
+
+Examples:
+
+```text
+${SIGNOZ_MCP_URL:-https://not-setup/mcp}
+${SIGNOZ_MCP_URL:-https://mcp.eu.signoz.cloud/mcp}
+${SIGNOZ_MCP_URL:-http://localhost:8000/mcp}
+```
+
+If a file contains the legacy no-default form `${SIGNOZ_MCP_URL}`, replace it
+with `${SIGNOZ_MCP_URL:-<resolved-mcp-url>}`.
+
+If the user's client has an explicit plugin setting or environment override
+for the endpoint, that value can override this default. If the MCP
+MCP setup skill updates the default but the client still connects to the
+old endpoint, tell the user to clear the explicit plugin setting and reload
+the client.
+
+## Endpoint Mapping
+
+SigNoz Cloud hosted MCP URLs use the same region code shown in
+**Settings -> Ingestion** and documented in the SigNoz Cloud region reference.
+
+| User input | MCP URL |
+|---|---|
+| `us`, `US`, United States, `ingest.us.signoz.cloud` | `https://mcp.us.signoz.cloud/mcp` |
+| `us2`, `US2`, `ingest.us2.signoz.cloud` | `https://mcp.us2.signoz.cloud/mcp` |
+| `eu`, `EU`, Europe, `ingest.eu.signoz.cloud` | `https://mcp.eu.signoz.cloud/mcp` |
+| `eu2`, `EU2`, `ingest.eu2.signoz.cloud` | `https://mcp.eu2.signoz.cloud/mcp` |
+| `in`, `IN`, India, `ingest.in.signoz.cloud` | `https://mcp.in.signoz.cloud/mcp` |
+| `in2`, `IN2`, `ingest.in2.signoz.cloud` | `https://mcp.in2.signoz.cloud/mcp` |
+
+Mapping rules:
+
+- **Known region code** — map `us`, `us2`, `eu`, `eu2`, `in`, or `in2`
+  case-insensitively.
+- **Hosted MCP URL** — accept `https://mcp.<region>.signoz.cloud/mcp` as-is
+  after normalizing the region to lowercase.
+- **Hosted MCP host only** — add `https://` and `/mcp`.
+- **Ingestion endpoint** — map `ingest.<region>.signoz.cloud` to the matching
+  hosted MCP URL.
+- **Self-hosted HTTP MCP URL** — accept any `http://.../mcp` or
+  `https://.../mcp` URL that is not a SigNoz Cloud workspace URL. This plugin
+  configuration path configures URL-based HTTP MCP. For stdio/local-binary
+  mode, tell the user to register the SigNoz MCP server separately as
+  `signoz`.
+- **SigNoz workspace URL** — do not infer the region from
+  `https://<workspace>.signoz.cloud`. Ask the user for the region from
+  **Settings -> Ingestion**.
+- **Unknown hosted region code** — ask for confirmation before using
+  `https://mcp.<region>.signoz.cloud/mcp`. New SigNoz Cloud regions may exist
+  before this skill is updated.
+
+Do not ask for API keys in this MCP setup skill. SigNoz Cloud authentication
+happens after endpoint setup through the MCP client's OAuth flow. Self-hosted
+HTTP mode expects the user to run the MCP server with its SigNoz URL and API
+key configured on that server process.

--- a/plugins/signoz/skills/signoz-mcp-setup/references/mcp-settings.md
+++ b/plugins/signoz/skills/signoz-mcp-setup/references/mcp-settings.md
@@ -12,7 +12,7 @@ Antigravity, or OpenCode, read
 
 - [State Check](#state-check)
 - [Registration Files](#registration-files)
-- [Editing Rule](#editing-rule)
+- [Editing Rules](#editing-rules)
 - [Endpoint Mapping](#endpoint-mapping)
 
 ## State Check
@@ -44,9 +44,34 @@ so the plugin root is two directories up from `skills/signoz-mcp-setup/`.
 Update every registration file that exists. Do not create duplicate MCP server
 entries, and do not rename the `signoz` server.
 
-## Editing Rule
+## Editing Rules
 
-The URL should use this template shape:
+Use the client-specific shape for the registration file you are editing.
+
+### Claude Code and Codex `.mcp.json`
+
+The URL should use a concrete endpoint:
+
+```json
+"url": "https://mcp.us.signoz.cloud/mcp"
+```
+
+Replace the entire `url` value with the resolved MCP endpoint. Do not keep
+`${SIGNOZ_MCP_URL:-...}` in `.mcp.json`; Codex treats that as a literal URL.
+
+If `.mcp.json` contains any legacy `SIGNOZ_MCP_URL` wrapper, replace the full
+value with the concrete resolved URL.
+
+Examples:
+
+```text
+https://mcp.eu.signoz.cloud/mcp
+http://localhost:8000/mcp
+```
+
+### Cursor `mcp.json`
+
+Cursor plugin config should use the template shape:
 
 ```json
 "url": "${SIGNOZ_MCP_URL:-https://mcp.us.signoz.cloud/mcp}"
@@ -64,13 +89,22 @@ ${SIGNOZ_MCP_URL:-https://mcp.eu.signoz.cloud/mcp}
 ${SIGNOZ_MCP_URL:-http://localhost:8000/mcp}
 ```
 
-If a file contains the legacy no-default form `${SIGNOZ_MCP_URL}`, replace it
-with `${SIGNOZ_MCP_URL:-<resolved-mcp-url>}`.
+If `mcp.json` contains the legacy no-default form `${SIGNOZ_MCP_URL}`, replace
+it with `${SIGNOZ_MCP_URL:-<resolved-mcp-url>}`. If `mcp.json` contains a
+concrete placeholder URL from a prior edit, replace it with the concrete
+resolved URL.
 
-If the user's client has an explicit plugin setting or environment override
-for the endpoint, that value can override this default. If the MCP setup skill
-updates the default but the client still connects to the old endpoint, tell
-the user to clear the explicit plugin setting and reload the client.
+If the user's client has an explicit plugin setting or environment override for
+the endpoint, that value can override this default. If this setup skill updates
+the default but the client still connects to the old endpoint, tell the user to
+clear the explicit plugin setting and reload the client.
+
+### Update behavior
+
+These bundled files live inside the installed plugin. Plugin updates can reset
+them to the placeholder. If the `signoz` server returns to **not-setup** after
+an update, rerun `signoz-mcp-setup`. For durable native client configuration,
+use the client-specific recipes in `client-configs.md`.
 
 ## Endpoint Mapping
 

--- a/plugins/signoz/skills/signoz-mcp-setup/references/mcp-settings.md
+++ b/plugins/signoz/skills/signoz-mcp-setup/references/mcp-settings.md
@@ -48,19 +48,24 @@ entries, and do not rename the `signoz` server.
 
 Use the client-specific shape for the registration file you are editing.
 
-### Claude Code and Codex `.mcp.json`
+### Bundled plugin MCP files
 
-The URL should use a concrete endpoint:
+The URL should use a concrete endpoint in both bundled registration files:
+
+- `.mcp.json` for Claude Code and Codex
+- `mcp.json` for Cursor
 
 ```json
 "url": "https://mcp.us.signoz.cloud/mcp"
 ```
 
 Replace the entire `url` value with the resolved MCP endpoint. Do not keep
-`${SIGNOZ_MCP_URL:-...}` in `.mcp.json`; Codex treats that as a literal URL.
+`${SIGNOZ_MCP_URL:-...}` in bundled plugin MCP files; Codex treats it as a
+literal URL, and Cursor documents interpolation syntax that does not include
+shell-style defaults.
 
-If `.mcp.json` contains any legacy `SIGNOZ_MCP_URL` wrapper, replace the full
-value with the concrete resolved URL.
+If either bundled file contains any legacy `SIGNOZ_MCP_URL` wrapper, replace
+the full value with the concrete resolved URL.
 
 Examples:
 
@@ -68,31 +73,6 @@ Examples:
 https://mcp.eu.signoz.cloud/mcp
 http://localhost:8000/mcp
 ```
-
-### Cursor `mcp.json`
-
-Cursor plugin config should use the template shape:
-
-```json
-"url": "${SIGNOZ_MCP_URL:-https://mcp.us.signoz.cloud/mcp}"
-```
-
-The variable has the form `${NAME:-default}`. Replace only the default value,
-which is the text between `:-` and the closing `}`. Keep `${`, the variable
-name, `:-`, and `}` intact.
-
-Examples:
-
-```text
-${SIGNOZ_MCP_URL:-https://not-setup/mcp}
-${SIGNOZ_MCP_URL:-https://mcp.eu.signoz.cloud/mcp}
-${SIGNOZ_MCP_URL:-http://localhost:8000/mcp}
-```
-
-If `mcp.json` contains the legacy no-default form `${SIGNOZ_MCP_URL}`, replace
-it with `${SIGNOZ_MCP_URL:-<resolved-mcp-url>}`. If `mcp.json` contains a
-concrete placeholder URL from a prior edit, replace it with the concrete
-resolved URL.
 
 If the user's client has an explicit plugin setting or environment override for
 the endpoint, that value can override this default. If this setup skill updates

--- a/plugins/signoz/skills/signoz-modifying-dashboards/SKILL.md
+++ b/plugins/signoz/skills/signoz-modifying-dashboards/SKILL.md
@@ -21,9 +21,8 @@ This skill calls SigNoz MCP server tools (`signoz:signoz_get_dashboard`,
 `signoz:signoz_update_dashboard`, `signoz:signoz_list_dashboards`, `signoz:signoz_list_metrics`).
 Before running the workflow, confirm the `signoz:signoz_*` tools are available.
 If they are not, the SigNoz MCP server is not installed or configured —
-stop and direct the user to set it up:
-<https://signoz.io/docs/ai/signoz-mcp-server/>. Do not fall back to raw
-HTTP calls or hand-edit dashboard JSON without the MCP tools.
+run `signoz-mcp-setup` first to initialize or repair the MCP connection. Do not
+fall back to raw HTTP calls or hand-edit dashboard JSON without the MCP tools.
 
 ## When to use
 


### PR DESCRIPTION
## Summary
- add SigNoz MCP registration files for Claude Code, Codex, and Cursor
- add `signoz-mcp-setup` to initialize or repair hosted and self-hosted HTTP MCP endpoints
- expand the setup skill with client-specific recipes for VS Code/GitHub Copilot, Claude Desktop, Gemini CLI, Windsurf, Zed, Antigravity, OpenCode, and generic HTTP clients
- fix Codex and Cursor compatibility by writing concrete URLs to bundled MCP files instead of `${SIGNOZ_MCP_URL:-...}` defaults
- remove the undocumented Cursor plugin `variables` block and route Cursor users through `signoz-mcp-setup`
- clarify README install flows and Codex plugin metadata so users know setup fills bundled MCP placeholders
- document current and future Cloud regions, self-hosted HTTP, stdio/local-binary setup, header-based auth guardrails, and plugin update/reset behavior
- update existing SigNoz skills to route missing MCP tooling through the setup skill

## Validation
- `python3 -m json.tool` on plugin manifests, marketplace files, and MCP configs
- `git diff --check`
- checked `.mcp.json` and `mcp.json` have no `SIGNOZ_MCP_URL` wrapper
- checked Cursor plugin manifest has no undocumented `variables` or redundant `mcpServers` field
- checked `signoz-mcp-setup` description length is under the skill trigger limit