### PR TITLE
feat(skills): counter rate-vs-increase render guidance for low-volume signals

### DIFF
--- a/plugins/signoz/skills/signoz-creating-dashboards/SKILL.md
+++ b/plugins/signoz/skills/signoz-creating-dashboards/SKILL.md
@@ -354,6 +354,7 @@ dry-run uses the exact shape from `queryData`.
 | Section structure (infra/runtime) | Overview / Saturation / Errors / Latency | domain-specific |
 | Headline panels (services) | request rate, error rate, p50/p95/p99 latency, throughput | omit those that don't apply |
 | Headline panels (infra) | resource utilization (CPU, mem), saturation, error/restart counts, throughput | tailor to the technology |
+| Counter render unit (rate vs. count) | per-second rate | per-interval **increase** count over a wider window (24h–7d) for any low-volume / bursty / human-paced counter — requests, **error counts**, restarts, OOM kills — where `/sec` renders as tiny decimals (e.g. `0.03/s`); gauges (CPU/mem/queue depth) are already absolute and unaffected; note `increase` rescales its y-axis with the selected range, so prefer it deliberately, not by reflex |
 | Variables (services) | `service.name`, `deployment.environment` (or `deployment.environment.name` — verify which exists via `signoz:signoz_get_field_keys`) | add `k8s.cluster.name` / `k8s.namespace.name` when k8s-flavored |
 | Variables (k8s/infra) | `k8s.cluster.name`, `k8s.namespace.name` (or `host.name` for hostmetrics) | drop `service.name` — it is rarely populated on infra signals |
 | Layout | 2-column grid (`w: 6`), 12 columns wide | full-width (`w: 12`) for tables and time-series with many series |

--- a/plugins/signoz/skills/signoz-setting-up-observability/SKILL.md
+++ b/plugins/signoz/skills/signoz-setting-up-observability/SKILL.md
@@ -178,6 +178,21 @@ pre-aggregated and cheap, whereas raw trace aggregation over a long alert
 window is expensive and an unstable alert source. (Confirm exact
 metric/label names via discovery — don't hardcode.)
 
+**Render any counter by the volume you just measured, not by reflex.**
+Not throughput-specific — it applies to every counter you'll graph
+(request rate, **error counts**, restarts, OOM kills, evictions), and
+low-volume errors and resource-layer events are the usual victims, not
+just requests. Per-second rate suits steady high-volume signals; where
+Phase 3 shows the count is low, bursty, or human-paced, a `/sec` graph
+renders as unreadable tiny decimals (`0.03/s`). Use the *symptom*, not a
+hard threshold: if per-second shows as fractions, pass that to Phase 6
+as intent — render a per-interval **increase** count over a wider window
+(24h–7d), not a rate. (Gauges — CPU, memory, queue depth — are already
+absolute; this is a counter concern.) It's a deliberate tradeoff
+(`increase` rescales its y-axis with the selected range), so make it a
+conscious call, never a blanket default either way.
+`signoz-creating-dashboards` owns the rate-vs-increase mechanic.
+
 **Verify the infra→service join (the USE half).** Don't assume
 `service.name` is present on host/container/k8s metrics — they often
 carry only `host.name` / `k8s.pod.name` / `k8s.node.name`, and


### PR DESCRIPTION
## What
Adds guidance for choosing how to render **counters** on dashboards — per-second rate vs. per-interval `increase` count — conditioned on the volume the data actually shows.

## Why
A `/sec` rate on a low-volume / bursty / human-paced counter renders as unreadable tiny decimals (e.g. `0.03/s`). The usual victims are **error counts** and resource-layer events (restarts, OOM kills, evictions) — not just request throughput — so the per-second default was silently producing illegible panels for exactly the signals on-call cares about. Surfaced in review after low-volume per-second panels shipped.

## Changes — judgment vs. mechanic split
Kept to the orchestration/sub-skill layering the skills already follow:

- **`signoz-setting-up-observability` (Phase 3)** — the *judgment*: decide the unit from the volume Phase 3 just measured. Symptom test (fractional `/sec`), not a hard QPS threshold; pass *`increase` count + wider window (24h–7d)* to Phase 6 as intent for low-volume counters; keep `/sec` for steady high-volume. Gauges (CPU/mem/queue depth) are exempt — this is a counter concern. The rendering mechanic stays delegated to `signoz-creating-dashboards`.
- **`signoz-creating-dashboards` (Defaults table)** — the *mechanic*: a "Counter render unit (rate vs. count)" row, so the rule also applies on the standalone dashboard path, including the `increase` tradeoff (its y-axis rescales with the selected time range).

## Notes
- Generalized from throughput-only to any counter during review.
- No manual version bump — the CalVer auto-bump workflow handles the `signoz` plugin manifest on merge.