### PR TITLE
feat(cursor): dedicated Cursor MCP config with install-time region dropdown

### DIFF
--- a/plugins/signoz/.cursor-plugin/plugin.json
+++ b/plugins/signoz/.cursor-plugin/plugin.json
@@ -17,5 +17,27 @@
     "tracing",
     "logging"
   ],
-  "skills": "./skills/"
+  "mcpServers": "./.signoz_cursor_mcp.json",
+  "skills": "./skills/",
+  "variables": {
+    "type": "object",
+    "properties": {
+      "SIGNOZ_REGION": {
+        "type": "string",
+        "title": "SigNoz Region",
+        "description": "Select your SigNoz Cloud region. This is the region code shown in **Settings -> Ingestion** (see the [region reference](https://signoz.io/docs/ingestion/signoz-cloud/keys/))",
+        "enum": [
+          "us",
+          "us2",
+          "eu",
+          "eu2",
+          "in",
+          "in2"
+        ]
+      }
+    },
+    "required": [
+      "SIGNOZ_REGION"
+    ]
+  }
 }

--- a/plugins/signoz/.signoz_cursor_mcp.json
+++ b/plugins/signoz/.signoz_cursor_mcp.json
@@ -1,0 +1,7 @@
+{
+  "mcpServers": {
+    "signoz": {
+      "url": "https://mcp.${SIGNOZ_REGION:-not-setup}.signoz.cloud/mcp"
+    }
+  }
+}

--- a/plugins/signoz/skills/signoz-mcp-setup/SKILL.md
+++ b/plugins/signoz/skills/signoz-mcp-setup/SKILL.md
@@ -94,8 +94,8 @@ files using the reference editing rules:
 
 1. In `.mcp.json` for Claude Code and Codex, replace the full `url` value with
    the resolved MCP endpoint.
-2. In `mcp.json` for Cursor, replace the full `url` value with the resolved MCP
-   endpoint.
+2. In `.signoz_cursor_mcp.json` for Cursor, replace the full `url` value with the
+   resolved MCP endpoint.
 3. Preserve unrelated MCP servers and settings.
 
 Claude Code and Codex target shape:

--- a/plugins/signoz/skills/signoz-mcp-setup/references/client-configs.md
+++ b/plugins/signoz/skills/signoz-mcp-setup/references/client-configs.md
@@ -51,9 +51,9 @@ defaults in plugin MCP URLs.
 
 ### Bundled Cursor plugin
 
-Update `mcp.json` in the SigNoz plugin root using the concrete URL rule from
-`mcp-settings.md`. Do not rely on shell-style environment defaults in Cursor
-plugin MCP URLs.
+Update `.signoz_cursor_mcp.json` in the SigNoz plugin root using the concrete URL
+rule from `mcp-settings.md`. Do not rely on shell-style environment defaults in
+Cursor plugin MCP URLs.
 
 ```json
 {

--- a/plugins/signoz/skills/signoz-mcp-setup/references/mcp-settings.md
+++ b/plugins/signoz/skills/signoz-mcp-setup/references/mcp-settings.md
@@ -36,7 +36,7 @@ only the plain outcome: working, not set up, or configured but not connected.
 The SigNoz plugin may ship both bundled registration files in the plugin root:
 
 - `.mcp.json` for Claude Code and Codex
-- `mcp.json` for Cursor
+- `.signoz_cursor_mcp.json` for Cursor
 
 This reference file lives at `skills/signoz-mcp-setup/references/mcp-settings.md`,
 so the plugin root is two directories up from `skills/signoz-mcp-setup/`.
@@ -53,7 +53,7 @@ Use the client-specific shape for the registration file you are editing.
 The URL should use a concrete endpoint in both bundled registration files:
 
 - `.mcp.json` for Claude Code and Codex
-- `mcp.json` for Cursor
+- `.signoz_cursor_mcp.json` for Cursor
 
 ```json
 "url": "https://mcp.us.signoz.cloud/mcp"


### PR DESCRIPTION
## Description

Gives the Cursor plugin its own MCP configuration (decoupled from the shared default) and adds a required, install-time SigNoz Cloud region dropdown, mirroring the Datadog Cursor plugin's install experience.

## What changed

- **Dedicated Cursor config file** — point the Cursor manifest (`.cursor-plugin/plugin.json`) at `plugins/signoz/.signoz_cursor_mcp.json` instead of the shared default, so Cursor's config is independent of the Claude Code / Codex `.mcp.json`.
- **Install-time region dropdown** — add a required `SIGNOZ_REGION` variable to the Cursor manifest with an `enum` of `us`/`us2`/`eu`/`eu2`/`in`/`in2`, rendered as a dropdown the user picks at install time.
- **Templated URL** — ship `.signoz_cursor_mcp.json` with `https://mcp.${SIGNOZ_REGION:-not-setup}.signoz.cloud/mcp`, so Cursor fills the selected region into the endpoint before the server connects.
- **Docs & setup skill** — update the `signoz-mcp-setup` Cursor references (`SKILL.md`, `client-configs.md`, `mcp-settings.md`) to target `.signoz_cursor_mcp.json` (Claude Code / Codex `.mcp.json` paths unchanged).

## Why

The shared default config forced one client's URL constraints on the others. A dedicated Cursor config plus a manifest-level region dropdown lets Cursor users select their region at install time with no manual file edits or `signoz-mcp-setup` run.

Leveraged the Datadog Cursor plugin as the reference for the install-time variable/dropdown pattern: https://github.com/datadog-labs/cursor-plugin/tree/main

## Testing

The region dropdown was confirmed working on a real Cursor install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)