### PR TITLE
feat(claude): dedicated Claude MCP config with install-time region prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,21 @@ See the full setup guide in the [SigNoz MCP Server docs](https://signoz.io/docs/
 /plugin install signoz@signoz-skills
 ```
 
+Set your SigNoz Cloud region with the `SIGNOZ_REGION` environment variable
+before launching Claude Code (optional, defaults to `us`):
+
+```sh
+export SIGNOZ_REGION=eu   # one of: us, us2, eu, eu2, in, in2
+```
+
+The bundled MCP config expands this into the hosted endpoint
+`https://mcp.${SIGNOZ_REGION}.signoz.cloud/mcp`. Find your region under
+**Settings -> Ingestion** in SigNoz, or see the
+[region reference](https://signoz.io/docs/ingestion/signoz-cloud/keys/).
+
 Then run `/mcp`, select the `signoz` server, and complete the authentication flow.
-If the server is not connected yet, ask Claude Code to run `signoz-mcp-setup` first.
+For a self-hosted SigNoz, or to set the endpoint explicitly, ask Claude Code to
+run `signoz-mcp-setup`.
 
 Update:
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,8 @@ npx skills add SigNoz/agent-skills --skill signoz-writing-clickhouse-queries    
 │   ├── .codex-plugin/plugin.json           # Codex plugin manifest
 │   ├── .claude-plugin/plugin.json          # Claude Code plugin manifest
 │   ├── .cursor-plugin/plugin.json          # Cursor plugin manifest
-│   ├── .mcp.json                           # Claude Code and Codex MCP config
+│   ├── .signoz_claude_mcp.json             # Claude Code MCP config
+│   ├── .mcp.json                           # Codex MCP config
 │   ├── mcp.json                            # Cursor MCP config
 │   ├── hooks/                              # Auto-allow hooks
 │   └── skills/

--- a/README.md
+++ b/README.md
@@ -42,17 +42,14 @@ See the full setup guide in the [SigNoz MCP Server docs](https://signoz.io/docs/
 /plugin install signoz@signoz-skills
 ```
 
-Set your SigNoz Cloud region with the `SIGNOZ_REGION` environment variable
-before launching Claude Code (optional, defaults to `us`):
-
-```sh
-export SIGNOZ_REGION=eu   # one of: us, us2, eu, eu2, in, in2
-```
-
-The bundled MCP config expands this into the hosted endpoint
-`https://mcp.${SIGNOZ_REGION}.signoz.cloud/mcp`. Find your region under
-**Settings -> Ingestion** in SigNoz, or see the
+On install, Claude Code prompts for your **SigNoz Cloud Region** (defaults to
+`us`; one of `us`, `us2`, `eu`, `eu2`, `in`, `in2`). The bundled MCP config fills
+this into the hosted endpoint `https://mcp.<region>.signoz.cloud/mcp`. Find your
+region under **Settings -> Ingestion** in SigNoz, or see the
 [region reference](https://signoz.io/docs/ingestion/signoz-cloud/keys/).
+
+To change the region later, reconfigure the plugin's options or run
+`signoz-mcp-setup`.
 
 Then run `/mcp`, select the `signoz` server, and complete the authentication flow.
 For a self-hosted SigNoz, or to set the endpoint explicitly, ask Claude Code to

--- a/plugins/signoz/.claude-plugin/plugin.json
+++ b/plugins/signoz/.claude-plugin/plugin.json
@@ -7,5 +7,14 @@
   },
   "repository": "https://github.com/SigNoz/agent-skills",
   "license": "MIT",
-  "mcpServers": "./.signoz_claude_mcp.json"
+  "mcpServers": "./.signoz_claude_mcp.json",
+  "userConfig": {
+    "SIGNOZ_REGION": {
+      "type": "string",
+      "title": "SigNoz Cloud Region",
+      "description": "Your SigNoz Cloud region code: us, us2, eu, eu2, in, or in2. Find it under Settings -> Ingestion (region reference: https://signoz.io/docs/ingestion/signoz-cloud/keys/).",
+      "default": "us",
+      "required": true
+    }
+  }
 }

--- a/plugins/signoz/.claude-plugin/plugin.json
+++ b/plugins/signoz/.claude-plugin/plugin.json
@@ -7,5 +7,5 @@
   },
   "repository": "https://github.com/SigNoz/agent-skills",
   "license": "MIT",
-  "mcpServers": "./.mcp.json"
+  "mcpServers": "./.signoz_claude_mcp.json"
 }

--- a/plugins/signoz/.mcp.json
+++ b/plugins/signoz/.mcp.json
@@ -1,8 +1,7 @@
 {
   "mcpServers": {
     "signoz": {
-      "type": "http",
-      "url": "https://mcp.${SIGNOZ_REGION:-us}.signoz.cloud/mcp"
+      "url": "https://not-setup/mcp"
     }
   }
 }

--- a/plugins/signoz/.mcp.json
+++ b/plugins/signoz/.mcp.json
@@ -1,7 +1,8 @@
 {
   "mcpServers": {
     "signoz": {
-      "url": "https://not-setup/mcp"
+      "type": "http",
+      "url": "https://mcp.${SIGNOZ_REGION:-us}.signoz.cloud/mcp"
     }
   }
 }

--- a/plugins/signoz/.signoz_claude_mcp.json
+++ b/plugins/signoz/.signoz_claude_mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "signoz": {
+      "type": "http",
+      "url": "https://mcp.${SIGNOZ_REGION:-us}.signoz.cloud/mcp"
+    }
+  }
+}

--- a/plugins/signoz/.signoz_claude_mcp.json
+++ b/plugins/signoz/.signoz_claude_mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "signoz": {
       "type": "http",
-      "url": "https://mcp.${SIGNOZ_REGION:-us}.signoz.cloud/mcp"
+      "url": "https://mcp.${user_config.SIGNOZ_REGION}.signoz.cloud/mcp"
     }
   }
 }

--- a/plugins/signoz/skills/signoz-mcp-setup/SKILL.md
+++ b/plugins/signoz/skills/signoz-mcp-setup/SKILL.md
@@ -92,11 +92,13 @@ cannot complete interactive OAuth, use the header-based fallback in
 For bundled Claude Code, Codex, and Cursor plugin installs, edit the registration
 files using the reference editing rules:
 
-1. In `.signoz_claude_mcp.json` for Claude Code and `.mcp.json` for Codex,
-   replace the full `url` value with the resolved MCP endpoint.
-2. In `mcp.json` for Cursor, replace the full `url` value with the resolved MCP
+1. In `.signoz_claude_mcp.json` for Claude Code, replace the full `url` value
+   with the resolved MCP endpoint.
+2. In `.mcp.json` for Codex, replace the full `url` value with the resolved MCP
    endpoint.
-3. Preserve unrelated MCP servers and settings.
+3. In `mcp.json` for Cursor, replace the full `url` value with the resolved MCP
+   endpoint.
+4. Preserve unrelated MCP servers and settings.
 
 Claude Code and Codex target shape:
 

--- a/plugins/signoz/skills/signoz-mcp-setup/SKILL.md
+++ b/plugins/signoz/skills/signoz-mcp-setup/SKILL.md
@@ -92,8 +92,8 @@ cannot complete interactive OAuth, use the header-based fallback in
 For bundled Claude Code, Codex, and Cursor plugin installs, edit the registration
 files using the reference editing rules:
 
-1. In `.mcp.json` for Claude Code and Codex, replace the full `url` value with
-   the resolved MCP endpoint.
+1. In `.signoz_claude_mcp.json` for Claude Code and `.mcp.json` for Codex,
+   replace the full `url` value with the resolved MCP endpoint.
 2. In `mcp.json` for Cursor, replace the full `url` value with the resolved MCP
    endpoint.
 3. Preserve unrelated MCP servers and settings.

--- a/plugins/signoz/skills/signoz-mcp-setup/references/client-configs.md
+++ b/plugins/signoz/skills/signoz-mcp-setup/references/client-configs.md
@@ -33,11 +33,28 @@ Use these shapes for SigNoz Cloud hosted MCP URLs such as
 `https://mcp.us.signoz.cloud/mcp` and self-hosted HTTP MCP URLs such as
 `http://localhost:8000/mcp`.
 
-### Bundled Claude Code and Codex plugin
+### Bundled Claude Code plugin
 
-Update `.mcp.json` in the SigNoz plugin root using the concrete URL rule from
-`mcp-settings.md`. Codex does not reliably expand shell-style environment
-defaults in plugin MCP URLs.
+In `.signoz_claude_mcp.json` in the SigNoz plugin root, replace only the `url`
+value with the resolved MCP endpoint (concrete URL rule from `mcp-settings.md`).
+Leave the `type` field and other settings unchanged.
+
+```json
+{
+  "mcpServers": {
+    "signoz": {
+      "type": "http",
+      "url": "https://mcp.us.signoz.cloud/mcp"
+    }
+  }
+}
+```
+
+### Bundled Codex plugin
+
+In `.mcp.json` in the SigNoz plugin root, replace only the `url` value with the
+resolved MCP endpoint (concrete URL rule from `mcp-settings.md`). Codex does not
+reliably expand shell-style environment defaults in plugin MCP URLs.
 
 ```json
 {
@@ -51,9 +68,9 @@ defaults in plugin MCP URLs.
 
 ### Bundled Cursor plugin
 
-Update `mcp.json` in the SigNoz plugin root using the concrete URL rule from
-`mcp-settings.md`. Do not rely on shell-style environment defaults in Cursor
-plugin MCP URLs.
+In `mcp.json` in the SigNoz plugin root, replace only the `url` value with the
+resolved MCP endpoint (concrete URL rule from `mcp-settings.md`). Do not rely on
+shell-style environment defaults in Cursor plugin MCP URLs.
 
 ```json
 {

--- a/plugins/signoz/skills/signoz-mcp-setup/references/mcp-settings.md
+++ b/plugins/signoz/skills/signoz-mcp-setup/references/mcp-settings.md
@@ -33,9 +33,10 @@ only the plain outcome: working, not set up, or configured but not connected.
 
 ## Registration Files
 
-The SigNoz plugin may ship both bundled registration files in the plugin root:
+The SigNoz plugin may ship these bundled registration files in the plugin root:
 
-- `.mcp.json` for Claude Code and Codex
+- `.signoz_claude_mcp.json` for Claude Code
+- `.mcp.json` for Codex
 - `mcp.json` for Cursor
 
 This reference file lives at `skills/signoz-mcp-setup/references/mcp-settings.md`,
@@ -50,9 +51,10 @@ Use the client-specific shape for the registration file you are editing.
 
 ### Bundled plugin MCP files
 
-The URL should use a concrete endpoint in both bundled registration files:
+The URL should use a concrete endpoint in all bundled registration files:
 
-- `.mcp.json` for Claude Code and Codex
+- `.signoz_claude_mcp.json` for Claude Code
+- `.mcp.json` for Codex
 - `mcp.json` for Cursor
 
 ```json


### PR DESCRIPTION
## Description

Gives the Claude Code plugin its own MCP configuration (decoupled from Codex) and makes the SigNoz Cloud region a first-class, install-time choice instead of a manual edit or shell env var.

## What changed

- **Dedicated Claude config file** — added `plugins/signoz/.signoz_claude_mcp.json` and pointed the Claude Code plugin manifest at it, so Claude no longer shares `.mcp.json` with Codex. `.mcp.json` stays as the Codex-only config (unchanged placeholder).
- **Install-time region prompt** — the Claude plugin manifest now declares a `userConfig.SIGNOZ_REGION` option (`default: us`, one of `us`/`us2`/`eu`/`eu2`/`in`/`in2`). Claude Code prompts for it on install and substitutes it into the MCP URL via `https://mcp.${user_config.SIGNOZ_REGION}.signoz.cloud/mcp` — resolved before the server connects/authenticates.
- **Docs & setup skill** — updated `signoz-mcp-setup` (`SKILL.md`, `client-configs.md`, `mcp-settings.md`) and the README to document the three separate registration files (Claude → `.signoz_claude_mcp.json`, Codex → `.mcp.json`, Cursor → `mcp.json`) with per-client setup steps, and rewrote the README Claude Code section around the install prompt.

## Why

Claude Code's plugin system supports an install-time config prompt (`userConfig`) with `${user_config.*}` substitution into `mcpServers`, so the region can be picked at install time with a sensible `us` default — no shell env var or `signoz-mcp-setup` run required for the common case. Splitting Claude's config from Codex's avoids forcing one client's URL constraints on the other.

## Testing

Smoke-tested by installing the local plugin in Claude Code: install prompted for the region, `/mcp` showed the `signoz` server resolved to the correct `https://mcp.<region>.signoz.cloud/mcp` URL, and authentication completed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)