### PR TITLE
docs: use full GitHub URL for Gemini CLI extension install

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ reload Cursor.
 ### Gemini CLI
 
 ```sh
-gemini extensions install SigNoz/agent-skills
+gemini extensions install https://github.com/SigNoz/agent-skills
 ```
 
 When prompted, enter your SigNoz Cloud region (`us`, `us2`, `eu`, `eu2`, `in`, or `in2`).


### PR DESCRIPTION
The `org/repo` shorthand is not accepted by `gemini extensions install` and fails with "Install source not found." Use the full Git URL.