### PR TITLE
fix: make root skills/ a real directory so Gemini CLI picks up skills

### DIFF
--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -125,6 +125,14 @@ jobs:
               mv "gemini-extension.json.tmp" "gemini-extension.json"
               echo "Bumped gemini-extension.json -> $NEW (lockstep with signoz)"
             fi
+
+            # The root skills/ directory is a real copy of the signoz plugin
+            # skills (not a symlink — Gemini's extension installer rewrites
+            # symlinks into dangling temp paths). Keep it in lockstep.
+            if [[ "$PLUGIN_NAME" == "signoz" && -d "plugins/signoz/skills" ]]; then
+              rsync -a --delete plugins/signoz/skills/ skills/
+              echo "Synced plugins/signoz/skills -> skills/"
+            fi
           done
 
           if [[ -z "$BUMPED" ]]; then
@@ -143,6 +151,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add plugins/**/.claude-plugin/plugin.json plugins/**/.codex-plugin/plugin.json plugins/**/.cursor-plugin/plugin.json gemini-extension.json
+          git add -A skills
           git commit -m "chore: auto-bump CalVer for ${{ steps.bump.outputs.count }} plugin(s)"
           git pull --rebase origin main || { git rebase --abort 2>/dev/null; echo "ERROR: rebase failed"; exit 1; }
           git push

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,7 @@ npx skills add https://github.com/anthropics/skills --skill skill-creator
 - **Reference files.** Move material >300 lines into `references/`, `scripts/`, or `assets/`. Any reference file longer than 100 lines must start with a `## Contents` table-of-contents.
 - **SKILL.md length.** Keep the body under 500 lines. Use progressive disclosure — link to specific reference files with a clear "read this when X" pointer rather than burying detail inline.
 - **Plugin manifests.** Keep `plugins/signoz/.codex-plugin/plugin.json` and `plugins/signoz/.cursor-plugin/plugin.json` in sync with the Claude manifest when adding or removing skills.
+- **Root `skills/` directory.** The root `skills/` directory is a generated copy of `plugins/signoz/skills/` for the Gemini CLI extension (Gemini's installer cannot follow symlinks). Never edit it directly — edit `plugins/signoz/skills/` and the auto-bump workflow syncs the copy on merge to `main`.
 
 ### Further reading
 

--- a/skills
+++ b/skills
@@ -1,1 +1,0 @@
-plugins/signoz/skills

--- a/skills/signoz-creating-alerts/SKILL.md
+++ b/skills/signoz-creating-alerts/SKILL.md
@@ -1,0 +1,471 @@
+---
+name: signoz-creating-alerts
+description: >
+  Create a new SigNoz alert rule from a natural-language intent — threshold,
+  anomaly, log-volume, error-rate, latency, or absent-data alerts across
+  metrics, logs, traces, and exceptions. Make sure to use this skill whenever
+  the user says "alert me when…", "notify me if…", "set up monitoring for…",
+  "page me on…", "create an alert for…", or asks for a new alert/notification
+  rule, even if they don't say the word "alert" explicitly. Also use it when
+  someone asks to be notified about error rates, latency spikes, log volume,
+  CPU/memory pressure, or anomalous behavior on a service or host.
+argument-hint: <natural-language alert intent>
+---
+
+# Alert Create
+
+Build a SigNoz alert from a user's natural-language intent. The skill targets
+two consumers: an autonomous AI SRE agent that runs without a human in the
+loop, and a human at a Claude Code / Codex / Cursor prompt. Both go through
+the same flow.
+
+## Prerequisites
+
+This skill calls SigNoz MCP server tools (`signoz:signoz_create_alert`,
+`signoz:signoz_list_alert_rules`, `signoz:signoz_get_field_keys`, etc.). Before running the
+workflow, confirm the `signoz:signoz_*` tools are available. If they are not,
+run `signoz-mcp-setup` first to initialize or repair the MCP connection. Do not
+try to fall back to raw HTTP calls or fabricate alert configs without the MCP
+tools.
+
+## When to use
+
+Use this skill when the user wants to:
+- Create, set up, or configure a new alert rule.
+- Get paged or notified when a metric, log volume, latency, or error rate
+  crosses a threshold.
+- Detect anomalous behavior on a service, host, or signal.
+- Catch silent data loss ("alert if data stops arriving from X").
+
+Do NOT use when the user wants to:
+- Understand what an existing alert monitors → `signoz-explaining-alerts`.
+- Diagnose why an existing alert fired → `signoz-investigating-alerts`.
+- Modify thresholds, queries, or routing on an existing alert → call
+  `signoz:signoz_update_alert` directly.
+
+## Required inputs (strict)
+
+Alert creation is a write operation against a shared system. Guessing here
+creates noisy alerts on the wrong service that someone else has to clean up.
+The skill enforces a strict input contract:
+
+| Input | Required | Source if missing |
+|---|---|---|
+| Alert intent (NL goal) | yes | `$ARGUMENTS` or recent user turn |
+| Resource attribute filter (e.g. `service.name`, `k8s.namespace.name`, `host.name`) | yes | discover via `signoz:signoz_get_field_keys` + `signoz:signoz_get_field_values` |
+| Threshold value(s) | inferred from intent | derive a sensible default and surface in the preview |
+| Severity | inferred from intent | default `warning`; promote to `critical` only if user said "page", "wake up", "critical" |
+| Notification channel | yes | `signoz:signoz_list_notification_channels` + offer "create new" |
+
+If a required input is missing and cannot be discovered, **stop before
+calling any write tool** and ask the user. The host application decides
+how the question is surfaced (a structured clarification tool, inline
+`<assistant_question>` tags, an interactive prompt, etc.) — follow the
+host's UI rendering rules.
+
+What to include in the question:
+
+- **What is missing** — name the input concretely (e.g. "which
+  resource-attribute filter to use").
+- **Candidate lists** populated from your discovery calls — concrete
+  values per attribute the user can pick from. Example shape:
+  `service.name` → `frontend`, `checkout`, `payments`;
+  `host.name` → `prod-api-1`, `prod-db-1`.
+- **Allow free-form input** so the user can name a value you didn't
+  surface.
+
+In autonomous mode (no human), escalate to the caller or fill the gap
+from upstream context. Either way, do not proceed to
+`signoz:signoz_create_alert` with a guessed value.
+
+## Workflow
+
+### Step 1: Parse intent and check what's missing
+
+Extract from the user's request:
+1. **What to monitor** — signal type (metrics / logs / traces / exceptions)
+   and the specific condition (CPU, error rate, p99 latency, log count, ...).
+2. **Resource scope** — which service, host, namespace, or environment.
+3. **Threshold** — numeric value and comparison ("above 80%", "below 100/s").
+4. **Severity** — implicit from urgency words ("page" → critical, default
+   warning otherwise).
+5. **Channel** — explicit channel name if the user provided one.
+
+Map signal phrasing to alert type:
+
+| User says | alertType | signal |
+|---|---|---|
+| metric, CPU, memory, latency, request rate | METRIC_BASED_ALERT | metrics |
+| log, error logs, log volume, log pattern | LOGS_BASED_ALERT | logs |
+| trace, span, latency p99, slow requests | TRACES_BASED_ALERT | traces |
+| exception, stack trace, crash | EXCEPTIONS_BASED_ALERT | (clickhouse_sql) |
+
+If resource scope is missing, run discovery (Step 2). If still missing after
+discovery, stop and ask the user (see *Required inputs* above).
+
+### Step 2: Discover resource attributes and metric names
+
+When the user does not name a service / host / namespace, the SigNoz MCP
+guideline applies: **always prefer a resource-attribute filter**. Discover
+candidates instead of guessing:
+
+1. Call `signoz:signoz_get_field_keys` with `fieldContext=resource` to enumerate
+   resource attributes for the chosen signal.
+2. Call `signoz:signoz_get_field_values` for the most likely attribute (typically
+   `service.name`, then `host.name`, then `k8s.namespace.name`) to get
+   concrete values.
+3. If the user mentioned a metric by name, call `signoz:signoz_list_metrics` with a
+   search term to verify the exact OTel metric name. Wrong names create
+   alerts that never fire.
+
+Surface the candidates in your clarification request (see *Required
+inputs* above). Do not pick one.
+
+### Step 3: Check for duplicate alerts
+
+Once the scope is resolved (either provided by the user or discovered in
+Step 2), check for existing alerts before probing data or authoring a
+new config — both are wasted work if the user wants to update an
+existing rule instead.
+
+Call `signoz:signoz_list_alert_rules` and **paginate through every page** —
+`pagination.hasMore` is true until you have walked the full list. This lists
+*configured* alert rules (the durable state); do not use `signoz:signoz_list_alerts`,
+which returns currently triggered/active alert instances and will silently
+miss rules that are configured but not firing right now. Check for existing
+rules that match the user's intent (same signal + same scope + similar
+threshold). If a likely duplicate exists, surface it and ask whether to
+create a new one anyway, modify the existing one (out of scope here — use
+`signoz:signoz_update_alert`), or cancel.
+
+### Step 4: Probe data existence for the chosen filter (fail fast)
+
+Before authoring any alert config, confirm the **specific combination** the
+alert will watch (metric × service × any other filter) actually emits data.
+The most common silent failure is "metric exists in the catalog *and* the
+service exists in the catalog, but the service doesn't emit that metric"
+— each piece checks out in isolation, the alert saves successfully, and it
+silently never fires.
+
+Run a single probe over the last 1 hour using the same filter the alert
+will use, but with the simplest aggregation that confirms data exists:
+
+- **Metrics**: `signoz:signoz_execute_builder_query` with `count()`
+  (or `count_distinct(service.name)` if scope-discovering). Use
+  `signoz:signoz_query_metrics` when you already have a concrete
+  `metricName` — it auto-applies aggregation defaults and accepts
+  `filter`/`groupBy`, but requires a concrete `metricName` (no PromQL,
+  no filter-only probes).
+- **Logs**: `signoz:signoz_aggregate_logs` with `count()` over the filter.
+- **Traces**: `signoz:signoz_aggregate_traces` with `count()` over the filter.
+
+Inspect the result:
+
+- **Probe returns rows** → proceed to Step 5.
+- **Probe returns empty** → STOP. Do not build an alert config the user
+  will then be asked to throw away. Stop and ask the user (see *Required
+  inputs* above), describing what was missing and offering concrete
+  recovery:
+  - Service doesn't emit the metric → call
+    `signoz:signoz_get_field_values signal=metrics name=service.name metricName=<metric>`
+    to list the services that *do* emit it; let the user pick a different
+    service or a different metric.
+  - Wrong attribute name (`service` instead of `service.name`) → suggest
+    the semantic-convention name and re-probe.
+  - Service emits the metric but not in the expected time range → widen
+    the probe window once (e.g. last 24h) before declaring no-data.
+
+**Exception — log-based crash / panic / OOMKilled / FATAL alerts.** These
+intentionally have zero matches in a healthy system. The probe will
+return empty by design. Do not stop; instead, surface the zero-match
+result and ask the user to confirm before save. Treat this exception
+narrowly: it applies to "alert me when bad thing happens" log queries,
+not to alerts that depend on continuous data flow.
+
+This probe is cheap (one query, ~100ms), and catching the no-data case
+early avoids the worst UX failure mode of this skill — the user reading
+through a fully-authored JSON payload and only then learning the alert
+can never fire.
+
+### Step 5: Build the alert config
+
+The MCP server is the source of truth for the alert JSON schema, threshold
+codes, and validation rules. Read the `signoz://alert/instructions` and
+`signoz://alert/examples` MCP resources for the canonical, version-current
+shape.
+
+For most user intents, the config is one of a small number of patterns:
+
+| Pattern | Example intents |
+|---|---|
+| Single-metric threshold | "alert when CPU > 80%", "p99 latency > 2s" |
+| Log volume threshold | "more than N error logs/min" |
+| Trace-based count or p-tile | "p99 span duration > 2s on checkout" |
+| Error-rate formula (A/B*100) — see "Common query shapes" below | "error rate > 5%" |
+| Anomaly detection (Z-score) | "alert me on anomalous traffic" |
+| Absent-data alert | "alert if data stops arriving" |
+| ClickHouse SQL alert — author SQL using the schema in `signoz://alert/examples` | non-trivial joins, custom aggregations the builder cannot express |
+| PromQL alert — delegate to `signoz-generating-queries` for the query, then return here | when user already has PromQL |
+
+**Threshold `op` and `matchType` values.** v2alpha1 accepts the
+human-readable strings (`"above"`, `"on_average"`); the legacy numeric
+codes (`"1"`, `"3"`) are also accepted but harder to read in the UI. Prefer
+the words. **Anomaly rules only support `op: "above"`** — the engine
+already treats z-score breaches as two-sided when the threshold is
+positive, so `"above_or_below"` is rejected and unnecessary.
+
+| Comparison | `op` | Evaluation behavior | `matchType` |
+|---|---|---|---|
+| above / exceeds / > | `"above"` | breach at any point | `"at_least_once"` |
+| below / under / < | `"below"` | breach for entire window | `"all_the_times"` |
+| equal / = | `"equals"` | average breaches | `"on_average"` |
+| not equal / != | `"not_equals"` | sum breaches | `"in_total"` |
+|  |  | last value breaches | `"last"` |
+
+**Defaults the skill applies (and surfaces in the preview):**
+- `evalWindow: 5m0s`, `frequency: 1m0s` — change only if the intent implies
+  a slower or faster cadence.
+- `matchType: "on_average"` for CPU / memory / latency — smooths
+  transient spikes.
+- `matchType: "at_least_once"` for error counts / error rates —
+  catches any breach.
+
+**Severity defaults — derive from the intrinsic urgency of the alert, not
+just the user's words.** The user saying "alert me" doesn't force `warning`
+when the condition itself describes a critical event. Use this table; an
+explicit user cue overrides it ("just FYI" → demote, "page me" / "wake me
+up" → promote).
+
+| Alert intent | Default severity |
+|---|---|
+| Pod crash / OOMKilled / CrashLoopBackOff / panic / FATAL log signals | critical |
+| Service down / no-data on a production service | critical |
+| Error rate above any non-trivial threshold (>1%) | critical |
+| Error logs / exception spikes | warning |
+| Latency degradation (p95/p99 above target) | warning |
+| CPU / memory / disk pressure | warning |
+| Request-rate / traffic anomaly | warning |
+| SLO budget burn (info-level burn rate) | info / warning |
+
+When the user's intent is ambiguous on severity (no urgency cue, no
+clearly-critical condition), default to `warning` and surface the choice
+in the preview so they can adjust.
+
+**OTel attribute names** — always use semantic conventions:
+`service.name`, `host.name`, `k8s.namespace.name`, `deployment.environment` or `deployment.environment.name`. Never `service`, `host`, or `env`.
+
+**Annotation templates** — the on-call engineer sees the notification, not
+the alert config. A notification that says "Pod crash detected" with no
+service name, no count, and no value is nearly useless at 3am. Always
+include the moving values:
+
+- `summary` — single-line headline. Include the resource scope and the
+  numeric value: `"checkoutservice error rate {{$value}}% above 3%"`.
+- `description` — longer message. Include `{{$value}}`, `{{$threshold}}`,
+  the groupBy values (e.g. `{{$labels.service_name}}`), and a sentence on
+  what to do or where to look. For count-based alerts include the count
+  explicitly: `"{{$value}} crash log lines in the last 5 minutes from
+  service {{$labels.service_name}}"`.
+
+Use `{{$value}}` for the breaching value, `{{$threshold}}` for the target,
+and `{{$labels.<key>}}` for groupBy values (note SigNoz substitutes the
+dotted attribute name with underscores: `service.name` → `service_name`).
+
+#### Common query shapes — conventions
+
+Read `signoz://alert/examples` for the authoritative JSON of all
+patterns (error rate, p99 latency, log volume, absent-data, anomaly,
+PromQL, ClickHouse SQL). The conventions that don't live in the
+schema:
+
+- **Error-rate formula:** set `disabled: true` on the component
+  queries A and B so only the formula F1 renders in the alert chart
+  and notification. The raw counts are intermediate, not the alert
+  signal — forgetting this clutters the preview with three series and
+  confuses the on-call engineer reading the notification.
+- **p99 latency:** threshold target is in **nanoseconds** (2s →
+  2000000000), `targetUnit: "ns"`.
+- **Log volume spike:** prefer `groupBy: service.name` over a hard
+  filter when the user said "any service" — groupBy provides the
+  scoping AND keeps the notification useful per-service.
+
+### Step 6: Dry-run the full query and validate the threshold
+
+Step 4 confirmed data flows. Step 6 does two things:
+
+1. **Validate query shape.** Run the full builder spec (with
+   `groupBy`, formulas, disabled component queries, and non-string
+   filters) — Step 4's bare `count()` probe doesn't exercise these.
+   The create-alert schema accepts queries that error at evaluation
+   (numeric `groupBy`, unquoted bool filter, mismatched aggregation).
+   Any HTTP 5xx or "filter type mismatch" = fix the config before
+   proceeding to (2). `disabled: true` on formula component queries
+   (A, B in `A * 100 / B`) is the *recommended* pattern, not a failure
+   — see Step 5.
+2. **Calibrate the threshold.** Given the validated query, would the
+   alert have fired a sensible number of times in the last hour?
+
+Run the full primary query (or formula) over the last hour:
+- `signoz:signoz_execute_builder_query` for **all** builder, formula,
+  and PromQL queries — set `compositeQuery.queries[].type` to
+  `builder_query` / `builder_formula` / `promql` as appropriate. For
+  PromQL put the query string in `spec.query` and read
+  `signoz://promql/instructions` for the UTF-8 quoted-selector form
+  SigNoz requires (`{"metric.name.with.dots"}` — not the underscored
+  or bare-dotted forms).
+- `signoz:signoz_aggregate_logs` / `signoz:signoz_aggregate_traces`
+  when those fit better.
+- `signoz:signoz_query_metrics` when the alert query targets a single
+  known metric by `metricName` — the tool auto-applies aggregation
+  defaults and accepts `filter`, `groupBy`, and `formula` alongside.
+  PromQL is not supported here; use `signoz:signoz_execute_builder_query`
+  for that.
+
+Compute how many evaluation points breached the proposed threshold.
+Surface in the preview as **"would have fired N times in the last 1h"**.
+A 1h window is too short to grade most alerts — only the upper extreme
+is actionable:
+   - **N is large (e.g. > 30)** → likely alert storm. Surface and
+     recommend tightening or adding hysteresis (`recoveryTarget`).
+   - **N = 0** → expected for a healthy system; do not nudge the user
+     to loosen. Only flag if the user said they'd expect the alert
+     firing right now (e.g. during an active incident).
+   - **N is small and non-zero** → report the count; the user decides
+     whether the threshold is right. One hour can't distinguish "tuned
+     well" from "barely caught a transient".
+3. **Exceptions:**
+   - **Anomaly alerts** — skip the breach count entirely (Z-scores aren't
+     directly comparable to raw values). Step 4 already verified the
+     underlying metric × service has data; nothing more to validate here.
+   - **Log-based crash / panic / OOMKilled / FATAL alerts** — these
+     intentionally have zero matches in a healthy system. Step 4 has
+     already surfaced the zero-match result and obtained user confirmation;
+     skip the breach count.
+
+If Step 4 was somehow skipped (e.g. a downstream skill is invoking this
+flow mid-stream), the no-data stop rule applies here too: empty result →
+stop and ask the user (see *Required inputs* above) instead of saving an
+alert that will never fire.
+
+### Step 7: Resolve notification channels
+
+The skill **must** resolve at least one channel before save. An alert with no
+channels saves successfully and silently never notifies anyone — the second
+most common silent failure after bad queries. Channel resolution runs after
+the dry-run so any threshold-driven severity changes (warning → critical)
+are settled before the user is asked to pick routing, and so we never
+create a notification channel inline for an alert that fails validation.
+
+1. Call `signoz:signoz_list_notification_channels` to enumerate existing channels.
+2. If the user named a channel ("send to slack-infra"), use it if it exists;
+   if not, fall through.
+3. Otherwise present the user with two options:
+   - **Pick from existing** — list channels with their type (Slack, PagerDuty,
+     email, webhook) so the user can choose.
+   - **Create new inline** — call `signoz:signoz_create_notification_channel` with
+     channel parameters the user provides (name, type, type-specific config
+     like Slack webhook URL or PagerDuty integration key).
+4. If neither path resolves a channel, stop and ask the user for a
+   notification channel (see *Required inputs* above).
+
+For multi-severity alerts, attach channels per threshold:
+`thresholds.spec[N].channels` is an array — typically warning → Slack only,
+critical → Slack + PagerDuty.
+
+#### Handling secret-bearing channel config
+
+Slack webhook URLs, PagerDuty integration keys, and similar webhook tokens
+are secrets. When the user supplies them inline, treat them as opaque
+inputs and follow these rules:
+
+- **Do not echo the secret back.** Never include the webhook URL,
+  integration key, or any password-like token in chat output, previews,
+  confirmation messages, summaries, or the `<navigation_suggestions>`
+  payload. Refer to the channel by its `name` only ("Slack channel
+  `slack-infra` created") and omit the value entirely.
+- **Do not stash secrets in clarification context.** If you need to ask the
+  user a follow-up question after they pasted a secret, do not include
+  the secret value in the clarification `message`, `discovered_context`,
+  or any other field that the host may persist for resume. Refer to it
+  symbolically (e.g. "the webhook you just provided").
+- **One-pass only.** Pass the secret directly to
+  `signoz:signoz_create_notification_channel` and do not retain it in any
+  intermediate prose. After the create call succeeds, refer to the
+  channel by name; after a failure, ask the user to re-paste rather than
+  echoing what they sent.
+- **If the user instead asks "how do I set up a Slack channel?"** — that
+  is a docs question, not a create-channel request. Answer with the docs
+  flow (the SigNoz UI's Notification Channels page) and do not solicit
+  the secret in chat at all. Prefer the UI path when the user seems
+  uncertain about exposing the token.
+
+### Step 8: Preview the prepared config
+
+Emit a one-paragraph plain-language summary of what will be created —
+no raw JSON dump. The user-facing facts (what fires, on what scope, at
+what threshold, where it routes) are captured by the summary; clicking
+through the JSON does not catch query-shape errors (Step 6's dry-run
+does).
+
+> **Summary**: This alert fires when [condition] for [resource scope],
+> evaluated every [frequency] over the last [window]. Thresholds:
+> warning at X, critical at Y. Notifications go to [channels]. Dry-run on
+> the last hour: would have fired N times.
+
+### Step 9: Save and report
+
+1. Call `signoz:signoz_create_alert` with the config from Step 8.
+2. **Name collision** — if `signoz:signoz_create_alert` returns a duplicate-name
+   error, **do not** suffix-append or call `signoz:signoz_update_alert`. Stop and
+   tell the user the existing alert blocked creation; offer to use a
+   different name or modify the existing alert (which is out of scope for
+   this skill).
+3. On success, report:
+   - The alert ID and name.
+   - What it watches and at what threshold.
+   - Which channels are wired up.
+   - The dry-run summary ("would have fired N times in last 1h").
+
+## Guardrails
+
+- **Strict inputs over guessing** Resource attribute and channel are
+  required. If missing, stop and ask the user (see *Required inputs* above). Creating an alert on
+  a guessed service is harder to undo than asking.
+- **Always paginate `signoz:signoz_list_alert_rules`** Stopping at page 1 misses
+  duplicates and produces noise.
+- **Dry-run is mandatory** Step 4 (data probe) and Step 6 (full
+  query + threshold calibration) are both required before
+  `signoz:signoz_create_alert`. A never-firing alert is *worse* than no
+  alert: it provides a false sense of safety.
+- **Threshold operators use canonical words** Prefer `op: "above"` /
+  `"below"` / `"equals"` / `"not_equals"`. Numeric codes (`"1"`–`"7"`)
+  are accepted but discouraged — same goes for `matchType`
+  (`"on_average"` / `"at_least_once"`, not `"3"` / `"1"`).
+- **Signal must match alertType** `signal: "logs"` requires
+  `LOGS_BASED_ALERT`. Mismatches fail validation.
+- **Anomaly rules are metrics-only** `anomaly_rule` + non-metric alertType
+  is rejected.
+- **Channels must exist.** Use names from `signoz:signoz_list_notification_channels`
+  exactly, or create the channel inline first.
+- **Never echo channel secrets.** Slack webhook URLs, PagerDuty integration
+  keys, and similar webhook tokens are secrets. Pass them to
+  `signoz:signoz_create_notification_channel` once and never repeat the
+  value in chat output, previews, confirmations, summaries, clarification
+  payloads, or navigation suggestions. Refer to the channel by name only
+  after creation; ask the user to re-paste on failure rather than
+  reproducing what they sent.
+
+## Examples
+
+Four canonical alert flows — multi-severity metric threshold,
+error-rate formula, log-volume groupBy, anomaly detection — live in
+[`references/examples.md`](references/examples.md).
+
+## Additional resources
+
+- `signoz://alert/instructions` and `signoz://alert/examples` MCP resources
+  — full alert config JSON schema, threshold codes, filter expression
+  syntax, and version-current pattern examples. Always preferred over any
+  transcribed copy.
+- `signoz-generating-queries` skill — for authoring PromQL or testing queries
+  before wrapping them in an alert.

--- a/skills/signoz-creating-alerts/evals/evals.json
+++ b/skills/signoz-creating-alerts/evals/evals.json
@@ -1,0 +1,40 @@
+{
+  "skill_name": "signoz-creating-alerts",
+  "evals": [
+    {
+      "id": 0,
+      "eval_name": "metric-cpu-multi-severity",
+      "prompt": "set up an alert for cartservice CPU usage. warning at 80%, page on-call at 90%. send warnings to #staging-alerts slack and criticals to 'test pager send resolved' pagerduty.",
+      "expected_output": "Multi-severity METRIC_BASED_ALERT with two thresholds (warning 80, critical 90), per-severity channels (slack on warning, pagerduty on critical), service.name='cartservice' filter on a CPU metric (e.g. system.cpu.utilization or k8s.pod.cpu.utilization), targetUnit percent, op='above', matchType='on_average' (canonical word form preferred over numeric codes). Should run discovery for the right CPU metric and run the mandatory signoz_execute_builder_query dry-run before emitting a plain-language summary and saving.",
+      "files": []
+    },
+    {
+      "id": 1,
+      "eval_name": "traces-error-rate-duplicate-detection",
+      "prompt": "alert me when error rate on checkoutservice goes above 3%. send to #staging-alerts on slack.",
+      "expected_output": "TRACES_BASED_ALERT with formula F1 = A*100/B (A = count of error spans, B = count of all spans) on service.name='checkoutservice', threshold target 3, targetUnit percent. CRITICAL: must paginate signoz_list_alert_rules and detect existing 'checkout-svc Error Rate > 3%' alert, surface it as a duplicate, and ask whether to proceed/modify/cancel rather than silently creating another one.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "eval_name": "logs-pod-crash-keywords",
+      "prompt": "create a log-based alert for pod crashes — fire if we see OOMKilled, CrashLoopBackOff, panic, or FATAL anywhere in log bodies. group by service so I know which one. notify #staging-alerts.",
+      "expected_output": "LOGS_BASED_ALERT, signal=logs, count() aggregation, body filter using LIKE/CONTAINS for the four keywords (OR'd), groupBy service.name with fieldContext=resource and fieldDataType=string. Threshold > 0, matchType='at_least_once' (canonical word form preferred over numeric codes). Runs the mandatory dry-run via signoz_execute_builder_query (with signal=logs in the builder_query.spec). CRITICAL: crash-pattern alerts (OOMKilled / CrashLoopBackOff / panic / FATAL) intentionally have zero matches in a healthy system — agent must surface the zero-match result, ask the user to confirm before saving an alert that returns nothing now, and skip the would-have-fired breach-count computation per the skill's healthy-zero exception. Must NOT treat zero matches as a failure or nudge the user to loosen the filter.",
+      "files": []
+    },
+    {
+      "id": 3,
+      "eval_name": "anomaly-frontend-request-rate",
+      "prompt": "set up anomaly detection for frontend service request rate — alert me if traffic suddenly drops or spikes versus normal patterns. slack #staging-alerts is fine.",
+      "expected_output": "METRIC_BASED_ALERT with anomaly_rule, algorithm=zscore, seasonality=daily or hourly. Uses signoz_calls_total or http.server.request.count metric filtered by service.name='frontend'. Threshold target ~3 (standard deviations), op='above' (anomaly_rule only accepts 'above'; canonical word form preferred over numeric codes). Skips the 'would have fired N times' breach count for anomaly alerts (Z-scores aren't comparable to raw breach counts) but still runs the mandatory signoz_execute_builder_query dry-run to verify the underlying query returns data.",
+      "files": []
+    },
+    {
+      "id": 4,
+      "eval_name": "formula-gated-p99-with-count-guard",
+      "prompt": "alert me when paymentservice p99 latency exceeds 1 second, but ONLY when request count is above 50 per minute — don't want to be paged on low-traffic noise. critical severity, send to both #staging-alerts slack AND 'test pager send resolved' pagerduty.",
+      "expected_output": "TRACES_BASED_ALERT with three queries: A = p99(durationNano) on service.name='paymentservice', B = count() on same filter, F1 = numeric formula that gates p99 by traffic (e.g. F1 = A * (B >= 50) or similar gating expression — exact form depends on alert engine, but skill must explain the gating choice). selectedQueryName='F1'. Threshold target 1000000000 (ns) or appropriate unit, op='above' (canonical word form preferred over numeric codes), critical severity, both channels attached. Runs the mandatory signoz_execute_builder_query dry-run (envelope passes the three queries with names A, B, F1 — name preserved so the formula resolves) before save. Surfaces the gating logic clearly in the plain-language summary.",
+      "files": []
+    }
+  ]
+}

--- a/skills/signoz-creating-alerts/references/examples.md
+++ b/skills/signoz-creating-alerts/references/examples.md
@@ -1,0 +1,86 @@
+# Examples — `signoz-creating-alerts`
+
+Four canonical alert flows: simple metric threshold, error-rate formula,
+log-volume groupBy, and anomaly detection.
+
+## Metric threshold with multi-severity routing
+
+**User:** "Alert me when CPU usage on the checkout service goes above 80%, page me at 90%"
+
+**Agent:**
+1. Intent parsed: metric, CPU, scope `service.name = checkout`,
+   thresholds 80% (warning) / 90% (critical), severity bumped to critical
+   on the higher level because "page me" was used.
+2. `signoz:signoz_list_metrics searchText=cpu` → confirms `system.cpu.utilization`.
+3. `signoz:signoz_list_alert_rules` (paginated) → no existing CPU alert for checkout.
+4. `signoz:signoz_list_notification_channels` → presents existing channels;
+   user picks `slack-infra` for warning and `pagerduty-oncall` for critical.
+5. Builds JSON: `METRIC_BASED_ALERT`, `threshold_rule`,
+   `signal=metrics`, two thresholds (`op="above"`,
+   `matchType="on_average"`, `targetUnit="percent"`), filter
+   `service.name = 'checkout'`.
+6. Dry-run via `signoz:signoz_execute_builder_query` over last 1h: returns data,
+   would have fired 0 times (clean baseline).
+7. Emits a one-paragraph plain-language summary — no JSON dump.
+8. Calls `signoz:signoz_create_alert`. Reports created alert with ID, threshold
+   summary, channel routing, and dry-run result.
+
+## Error-rate formula alert
+
+**User:** "Set up an alert when error rate goes above 5% on payments"
+
+**Agent:**
+1. Intent parsed: traces, error-rate formula, scope
+   `service.name = payments`, threshold 5%, severity default warning.
+2. `signoz:signoz_get_field_keys fieldContext=resource signal=traces` confirms
+   `service.name`. `signoz:signoz_get_field_values` confirms `payments` exists.
+3. No existing payments error-rate alert.
+4. Builds formula alert: query A counts spans with `hasError = true` for
+   `service.name = 'payments'`, query B counts all spans for the same
+   service, formula F1 = `A * 100 / B`, `selectedQueryName: "F1"`,
+   threshold target 5, `targetUnit: "percent"`,
+   `op: "above"`, `matchType: "at_least_once"` (catch any breach).
+5. Channel: user picks `slack-payments`.
+6. Dry-run on last 1h: payments error rate hovered around 0.3%, would have
+   fired 0 times. Clean — not too tight.
+7. Preview, save, report.
+
+## Log-volume threshold with groupBy
+
+**User:** "Notify me if log volume spikes more than 1000 error logs per minute on any service"
+
+**Agent:**
+1. Intent parsed: logs, volume threshold, scope = all services (groupBy
+   `service.name`), threshold 1000/min, severity warning.
+2. `signoz:signoz_get_field_keys signal=logs fieldContext=resource` confirms
+   `service.name` exists; **no service filter required** since the user
+   said "any service" → groupBy provides the scoping.
+3. Builds: `LOGS_BASED_ALERT`, `signal=logs`,
+   `aggregations: [{expression: "count()"}]`,
+   `filter: {expression: "severity_text IN ('ERROR', 'FATAL')"}`,
+   `groupBy: [{name: "service.name", fieldContext: "resource", fieldDataType: "string"}]`,
+   threshold 1000, `targetUnit: ""`, `evalWindow: 1m0s`,
+   `matchType: "at_least_once"` (catch any minute that breaches).
+4. Channels: user picks slack channel.
+5. Dry-run: returned per-service counts, max in last 1h was 87 — would
+   have fired 0 times. Within reasonable headroom.
+6. Preview, save, report.
+
+## Anomaly detection (z-score)
+
+**User:** "Alert me on anomalous request latency for the api gateway"
+
+**Agent:**
+1. Intent parsed: metric, anomaly detection, scope
+   `service.name = api-gateway`. Anomaly detection requires
+   `METRIC_BASED_ALERT` + `anomaly_rule`.
+2. `signoz:signoz_list_metrics searchText=duration` → finds
+   `http.server.request.duration`.
+3. Builds: `anomaly_rule`, `algorithm=zscore`, `seasonality=daily`,
+   threshold target 3 (3 standard deviations), `op: "above"`,
+   `matchType: "at_least_once"`.
+4. Channel: user picks slack-api.
+5. Dry-run validates query returns data. Skip breach-count for
+   anomaly alerts.
+6. Preview emphasizes that the threshold is in standard deviations, not raw
+   latency. Save, report.

--- a/skills/signoz-creating-dashboards/SKILL.md
+++ b/skills/signoz-creating-dashboards/SKILL.md
@@ -1,0 +1,491 @@
+---
+name: signoz-creating-dashboards
+description: >
+  Create a new SigNoz dashboard from a natural-language intent — import a
+  curated template (PostgreSQL, Redis, JVM, k8s, hostmetrics, APM, LLM,
+  etc.) when one fits, or build a custom dashboard from scratch with
+  metric / trace / log panels. Make sure to use this skill whenever the
+  user says "create a dashboard for…", "set up monitoring for…",
+  "build me a dashboard…", "I need observability for…", "import a
+  dashboard template", or asks to track / visualize a service, database,
+  cluster, or AI/LLM platform — even if they don't explicitly say
+  "dashboard". Also use it when someone wants to "monitor", "watch", or
+  "see metrics for" a technology and the natural answer is a dashboard.
+argument-hint: <natural-language dashboard intent>
+---
+
+# Dashboard Create
+
+Build a SigNoz dashboard from a user's natural-language intent. The skill
+targets two consumers: an autonomous AI SRE agent that runs without a
+human in the loop, and a human at a Claude Code / Codex / Cursor prompt.
+Both go through the same flow.
+
+## Prerequisites
+
+This skill calls SigNoz MCP server tools (`signoz:signoz_create_dashboard`,
+`signoz:signoz_list_dashboards`, `signoz:signoz_list_dashboard_templates`,
+`signoz:signoz_import_dashboard`, `signoz:signoz_get_dashboard`,
+`signoz:signoz_update_dashboard`, `signoz:signoz_list_metrics`,
+`signoz:signoz_get_field_keys`, `signoz:signoz_get_field_values`,
+`signoz:signoz_aggregate_logs`, `signoz:signoz_aggregate_traces`, etc.).
+Before running the workflow, confirm the `signoz:signoz_*` tools are
+available. If they are not, the SigNoz MCP server is not installed or
+configured — run `signoz-mcp-setup` first to initialize or repair the MCP
+connection. Do not fall back to raw HTTP calls or fabricate dashboard JSON
+without the MCP tools.
+
+## When to use
+
+Use this skill when the user wants to:
+- Create, set up, or build a new dashboard.
+- "Monitor" or "set up observability" for a service, database,
+  infrastructure component, or AI/LLM platform.
+- Import a curated dashboard template.
+- Visualize a set of metrics / traces / logs together on one screen.
+
+Do NOT use when the user wants to:
+- Modify an existing dashboard → `signoz-modifying-dashboards`.
+- Understand what an existing dashboard shows → `signoz-explaining-dashboards`.
+- Run a one-off query without persisting it → `signoz-generating-queries`.
+
+## Required inputs (strict)
+
+Dashboard creation is a write operation. Guessing here clutters the
+shared workspace with empty or wrongly-scoped dashboards someone else has
+to clean up. The skill enforces a soft input contract — most fields have
+sensible defaults, but a few cannot be guessed:
+
+| Input | Required | Source if missing |
+|---|---|---|
+| Dashboard intent (NL goal) | yes | `$ARGUMENTS` or recent user turn |
+| Technology / domain (e.g. PostgreSQL, Redis, "payment pipeline") | yes | parse from intent; otherwise ask |
+| Modify-or-create choice when duplicates exist | yes | ask the user (Step 2) |
+| Resource scope for custom builds (service / namespace / cluster) | yes for custom builds | discover via `signoz:signoz_get_field_keys` + `signoz:signoz_get_field_values`; fall back to a dashboard variable |
+| Specific metrics / signals for custom builds | inferred | derive from technology + MCP `signoz://dashboard/*` resources; surface in preview |
+| Default time range, refresh, layout | inferred | apply defaults (see "Defaults" below) |
+
+If a required input is missing and cannot be discovered, **stop before
+calling any write tool** and ask the user. The host application decides
+how the question is surfaced (a structured clarification tool, inline
+`<assistant_question>` tags, an interactive prompt, etc.) — follow the
+host's UI rendering rules.
+
+What to include in the question:
+
+- **What is missing** — name the input concretely (e.g. "no service or
+  cluster specified for the custom build").
+- **Candidate lists** populated from your discovery calls — concrete
+  values per attribute the user can pick from. Example shape:
+  `service.name` → `frontend`, `checkout`, `payments`, `inventory`;
+  `k8s.cluster.name` → `prod-us-east-1`, `staging`.
+- **Allow free-form input** so the user can name a value you didn't
+  surface.
+
+In autonomous mode (no human), escalate to the caller or fill the gap
+from upstream context. Either way, do not proceed to
+`signoz:signoz_create_dashboard` / `signoz:signoz_import_dashboard` with
+a guessed value.
+
+## Workflow
+
+The flow runs in order: **duplicate check → user picks modify-or-create
+→ on create, template lookup decides template-import vs custom-build →
+no-data probe → per-panel dry-run → preview → save**. Duplicate check
+comes first so we never silently create a second copy of something that
+already exists. Once the user has chosen to create, the template lookup
+is an internal implementation detail — if a curated template fits we
+use it, otherwise we build from scratch. The per-panel dry-run
+(`signoz:signoz_execute_builder_query` against every query-bearing
+panel) is mandatory before save — a saved empty panel from a typo'd
+attribute or wrong severity filter is the worst failure mode for this
+skill, and dry-run is the only step that catches it. The user is
+offered exactly two upfront choices: modify an existing dashboard, or
+create a new one.
+
+### Step 1: Check for duplicates
+
+Call `signoz:signoz_list_dashboards`. Most installs fit in the default
+page (`limit=50`); only paginate when `pagination.hasMore=true`. Use
+string values for `limit` / `offset` (e.g. `"50"`, `"0"`) — the schema
+expects strings, not integers.
+
+**Match by relevance** Compare each existing
+dashboard's lowercased `name`, `description`, and `tags` against the
+user's technology/domain. Surface only matches a human would recognize
+as the same thing — a "redis" dashboard does not match a "postgresql"
+request just because both have a `database` tag. Collect each match's
+`name`, `uuid`, and `createdAt` for the next step.
+
+### Step 2: Ask the user — modify or create
+
+Present exactly two options (no template-import as a separate top-level
+choice — that's an internal decision in Step 3b):
+
+- **Duplicates found:** "There are already these similar dashboards:
+  [list with name, UUID, created-at]. Want me to (a) modify one of
+  these, (b) create a new dashboard anyway, or (c) stop?"
+- **No duplicates:** "I'll create a new dashboard for this. Proceed?"
+  (No "modify" option when there's nothing to modify.)
+
+Wait for the user's choice. "modify" → Step 3a. "create new" / confirm
+→ Step 3b. "stop" → stop.
+
+### Step 3: Create or modify
+
+#### Step 3a: Modify an existing dashboard
+
+Hand off immediately to `signoz-modifying-dashboards` with the chosen
+dashboard UUID and the user's intent. Do not call
+`signoz:signoz_update_dashboard` from this skill — modification is out
+of scope. (See "Scope boundary" in Guardrails.)
+
+#### Step 3b: Create a new dashboard
+
+Run the template lookup first. The user has already agreed to create
+new — the lookup decides *how* we build it.
+
+Call `signoz:signoz_list_dashboard_templates` once with no arguments.
+The full catalog (~95 entries) returns in a single call — read it
+in-context and pick the best match for the user's intent. When several
+entries plausibly fit, present the top 3–5 and let the user choose.
+
+Branch on the result:
+- **Single clear template match** — proceed to Step 3b-i (template
+  import). Briefly tell the user "I found a pre-built [title] template
+  and will use it" so they know what's being created; do not block on
+  yes/no.
+- **Multiple plausible matches** — present them and ask the user to
+  pick. Once picked, proceed to Step 3b-i.
+- **No template** — proceed to Step 3b-ii (custom build).
+
+#### Step 3b-i: Import the template
+
+> **Tool guardrail** The only template tools are
+> `signoz:signoz_list_dashboard_templates` and
+> `signoz:signoz_import_dashboard`. Do not shell out, fetch raw GitHub
+> URLs, or invent other tool names.
+> `signoz:signoz_import_dashboard` takes the template `path` from the
+> catalog entry and creates the dashboard in one call — you do not need
+> to fetch the JSON yourself or call `signoz:signoz_create_dashboard`
+> afterwards.
+
+##### Step 3b-i.1: Pre-flight no-data probe (fail fast)
+
+Before calling `signoz:signoz_import_dashboard`, confirm the template's
+signals are actually being ingested. The most common silent failure for
+template imports is "the template imports cleanly but every panel reads
+'No data' because the technology isn't being scraped" — the user only
+discovers it after clicking through to a useless dashboard.
+
+Since we don't fetch the template body up front, base the probe on the
+catalog entry's `category`, `title`, and `keywords` plus the user's
+stated technology. Pick up to ~5 representative signals and check them
+— keep the total small:
+
+- **Metric-based templates** (most infra/runtime templates): call
+  `signoz:signoz_list_metrics` with `searchText` set to the technology
+  prefix (e.g. `searchText="postgresql"`). Empty result → metric family
+  is not being ingested. *Early out:* if this returns empty, declare
+  "None present" and skip the rest of the metric probes — they will all
+  return zero. Note: `signoz:signoz_list_metrics` has no `timeRange` parameter;
+  pass `start`/`end` (unix-ms strings) only if you need a window other
+  than the server default.
+- **Trace-based templates** (APM-style): call
+  `signoz:signoz_aggregate_traces` with `aggregation=count`,
+  `timeRange=1h`. No filter is needed for the "is anything flowing"
+  probe — adding `filter="service.name EXISTS"` is fragile and
+  unnecessary. Zero count → no traces flowing.
+- **Log-based templates**: call `signoz:signoz_aggregate_logs` with
+  `aggregation=count`, `timeRange=1h`, no filter. Zero count → no logs.
+- **Variable values** (when the template clearly relies on a resource
+  attribute, e.g. `service.name`, `k8s.cluster.name`): call
+  `signoz:signoz_get_field_values` to confirm there are values to pick
+  from. A dashboard whose top-level dropdown is empty is barely
+  better than one full of empty panels.
+
+Branch on the probe result:
+
+- **All signals present** → proceed silently to Step 3b-i.2.
+- **Some present, some missing** → list which are missing and ask the
+  user to confirm before continuing. Many templates are useful even with
+  partial coverage; let them decide.
+- **None present** → tell the user no data was found for this
+  technology in the probe window, explain the dashboard will show "No
+  data" until ingestion is set up, and offer to create it anyway or
+  stop. Wait for the user's choice.
+
+This probe is cheap (a handful of queries, ~hundreds of ms total), and
+catching the no-data case early avoids the worst UX failure mode of the
+template path.
+
+##### Step 3b-i.2: Preview, import, report
+
+1. **Preview** Tell the user what's about to happen in one short
+   paragraph: which template (`title`, `path`), what category, what the
+   probe found. In autonomous mode the consumer proceeds; in interactive
+   mode the human can intervene.
+2. **Import** Call `signoz:signoz_import_dashboard` with the `path`
+   from the chosen catalog entry (e.g. `postgresql/postgresql.json`).
+   The server fetches the JSON, validates it, and creates the dashboard
+   in one call.
+3. **Report** Read the response and tell the user the dashboard's
+   title, panel count, and section breakdown. Surface the dashboard's
+   variables ("filter by `service.name`", "filter by
+   `k8s.cluster.name`") so the user knows what knobs they have. Offer
+   two follow-ups: "Want me to adjust panels, layout, or variables?"
+   and "Want me to wire alerts for any of these signals?
+   (`signoz-creating-alerts`)".
+4. **Customization handling** If the user asks for any change to the
+   imported dashboard, hand off to `signoz-modifying-dashboards` with
+   the new dashboard's UUID and the requested changes. Do not call
+   `signoz:signoz_update_dashboard` from this skill.
+
+#### Step 3b-ii: Custom build (no template, or import failed)
+
+Run this path when the Step 3b template lookup found no match, the user
+explicitly rejected the suggested template, or
+`signoz:signoz_import_dashboard` failed.
+
+##### Step 3b-ii.1: Gather requirements
+
+Ask the user (skip questions whose answer is already clear from intent):
+
+1. **Signals** — metrics, traces, logs, or a combination.
+2. **Specific signals** — which metrics, which span attributes, which
+   log severities matter most.
+3. **Resource scope** — which service(s), namespace(s), cluster(s), or
+   environment(s).
+4. **Variables** — what should be a dropdown vs. a hard-coded filter
+   (typical: `service.name`, `deployment.environment.name`,
+   `k8s.cluster.name`).
+5. **Sections** — group panels into Overview / Latency / Errors /
+   Saturation, or another structure that fits the domain.
+
+If the user is non-specific ("just make me something useful for X"),
+apply the defaults table below and surface them in the preview.
+
+##### Step 3b-ii.2: Discover names and probe data
+
+The MCP guideline applies: **always prefer resource-attribute filters**.
+Before authoring panels, confirm the names you'll use exist and emit
+data:
+
+1. **Metrics** — call `signoz:signoz_list_metrics` with `searchText`
+   tied to the technology (e.g. `searchText="postgresql"`) to get the
+   *exact* OTel metric names. Catalog presence ≠ data flowing — for
+   any metric you intend to use, follow up with `signoz:signoz_query_metrics`
+   on a representative window to confirm it actually has datapoints.
+2. **Resource attributes** — call `signoz:signoz_get_field_keys` with
+   `fieldContext=resource` for the relevant signal to enumerate
+   available attributes; call `signoz:signoz_get_field_values` on the
+   ones you'll use as variables to confirm concrete values exist. Note
+   that the live data may use older OTel semconv (e.g.
+   `deployment.environment` rather than `deployment.environment.name`)
+   — always trust the discovered key over the one in the defaults
+   table.
+
+Per-panel validation happens later as a hard requirement — see
+Step 3b-ii.6 and the "Mandatory dry-run before save" guardrail.
+
+If **none** of the discovered signals return data, tell the user the
+dashboard's data isn't being ingested yet, explain the panels will
+show "No data" until ingestion is set up, and offer to build anyway
+or stop. Wait for the user's choice before building.
+
+##### Step 3b-ii.3: Read the dashboard MCP resources
+
+These are the source of truth for the JSON schema, panel types, query
+builder shape, and layout rules — do not transcribe schema text into
+this skill, it will rot out of sync with the server. Read the four
+core resources before authoring widget JSON.
+
+> **Fallback when the MCP resource-reader is unavailable** Some MCP
+> client harnesses do not expose a resource-reading tool. If you
+> cannot read `signoz://...` URIs in this session, fall back to
+> `signoz:signoz_list_dashboards` + `signoz:signoz_get_dashboard` on
+> an existing dashboard of the same signal type (metrics / traces /
+> logs) and read its `widgets` array for v5 widget shapes. The
+> mandatory dry-run in Step 3b-ii.6 then backstops any shape errors
+> the fallback misses.
+
+- `signoz://dashboard/instructions` — title, tags, description,
+  variables.
+- `signoz://dashboard/widgets-instructions` — 7 panel types and layout
+  rules.
+- `signoz://dashboard/widgets-examples` — complete widget configs with
+  all required fields (the most important resource — every widget
+  must include `id`, `panelTypes`, `title`, `query`, `selectedLogFields`,
+  `selectedTracesFields`, `thresholds`, `contextLinks`).
+- `signoz://dashboard/query-builder-example` — query builder reference,
+  including operator semantics for `filters.items[].op`.
+
+Add signal-specific resources as needed:
+
+- Metrics (PromQL): `signoz://promql/instructions`.
+- Metrics (ClickHouse): `signoz://dashboard/clickhouse-schema-for-metrics`
+  + `signoz://dashboard/clickhouse-metrics-example`.
+- Metrics (Query Builder aggregation rules):
+  `signoz://metrics-aggregation-guide` — required for picking valid
+  `timeAggregation` / `spaceAggregation` per metric type.
+- Traces (Query Builder): `signoz://traces/query-builder-guide`.
+- Traces (ClickHouse): `signoz://dashboard/clickhouse-schema-for-traces`
+  + `signoz://dashboard/clickhouse-traces-example`.
+- Logs (ClickHouse): `signoz://dashboard/clickhouse-schema-for-logs`
+  + `signoz://dashboard/clickhouse-logs-example`.
+
+##### Step 3b-ii.4: Build the dashboard JSON
+
+Follow the v5 schema as documented in the resources above. Use OTel
+semantic attribute names (not shorthand) in filters, groupBy, and
+variables. Apply the defaults below unless the user specified otherwise.
+
+All panels are validated in Step 3b-ii.6 via the mandatory dry-run
+before save. Author the JSON here as you intend to save it — the
+dry-run uses the exact shape from `queryData`.
+
+**Defaults the skill applies (and surfaces in the preview):**
+
+| Field | Default | When to override |
+|---|---|---|
+| Time range | last 1h | longer for capacity planning, shorter for live debugging |
+| Refresh | manual (no auto-refresh) | set 30s–1m only when the user explicitly wants live updates |
+| Section structure (APM/services) | Overview / Latency / Errors / Throughput | domain-specific (e.g. DB: Overview / Connections / Throughput / Slow Queries) |
+| Section structure (infra/runtime) | Overview / Saturation / Errors / Latency | domain-specific |
+| Headline panels (services) | request rate, error rate, p50/p95/p99 latency, throughput | omit those that don't apply |
+| Headline panels (infra) | resource utilization (CPU, mem), saturation, error/restart counts, throughput | tailor to the technology |
+| Counter render unit (rate vs. count) | per-second rate | per-interval **increase** count over a wider window (24h–7d) for any low-volume / bursty / human-paced counter — requests, **error counts**, restarts, OOM kills — where `/sec` renders as tiny decimals (e.g. `0.03/s`); gauges (CPU/mem/queue depth) are already absolute and unaffected; note `increase` rescales its y-axis with the selected range, so prefer it deliberately, not by reflex |
+| Variables (services) | `service.name`, `deployment.environment` (or `deployment.environment.name` — verify which exists via `signoz:signoz_get_field_keys`) | add `k8s.cluster.name` / `k8s.namespace.name` when k8s-flavored |
+| Variables (k8s/infra) | `k8s.cluster.name`, `k8s.namespace.name` (or `host.name` for hostmetrics) | drop `service.name` — it is rarely populated on infra signals |
+| Layout | 2-column grid (`w: 6`), 12 columns wide | full-width (`w: 12`) for tables and time-series with many series |
+| GroupBy on per-service panels | `service.name` resource attribute | drop when filtering to a single service |
+
+**Title and description** The dashboard title should name the
+technology and the scope clearly: "PostgreSQL — prod-us-east-1", not
+just "PostgreSQL". Description should answer "what is this for" in one
+sentence. Tags: technology + signal types + environment when known.
+
+##### Step 3b-ii.5: Shape check before save
+
+`signoz://dashboard/widgets-examples` is the source of truth for widget
+required fields, panel-type-specific shapes, the canonical
+`filters.items[].key.id` form, operator casing, and common write-shape
+errors. Re-skim it before serialising any custom widget JSON.
+
+One rule `widgets-examples` does not call out, but
+`signoz:signoz_create_dashboard` enforces: **no `JSON.stringify` on
+arrays/objects** `layout`, `widgets`, `tags`, and `variables` are
+native JSON — stringifying them produces errors like
+`cannot unmarshal string into ... layout of type []LayoutItem`.
+
+##### Step 3b-ii.6: Dry-run before save (mandatory)
+
+Call `signoz:signoz_execute_builder_query` per panel. The dry-run
+validates the query is well-formed *and* confirms data flows under
+that filter — the per-panel data probe folds in here.
+
+**Envelope translation** Widget JSON wraps queries in
+`compositeQuery.builder.queryData[]` and `queryFormulas[]`, but
+`signoz:signoz_execute_builder_query` takes
+`compositeQuery.queries[].{type, spec}`. Translate per panel: each
+`queryData[i]` → `{ type: "builder_query", spec: { name, signal,
+filter: {expression}, groupBy, aggregations } }`; each
+`queryFormulas[i]` → `{ type: "builder_formula", spec: { name,
+expression } }`. **Preserve the original `name`** (`A`, `B`, …) on
+every `builder_query.spec` — formula expressions reference inputs
+by that name (e.g., `A * 100 / B`), and dropping it makes the
+dry-run shape diverge from the saved panel so formulas can't
+resolve their inputs. The endpoint cannot consume widget JSON
+directly.
+
+Non-empty response = pass; server error, "filter type mismatch", or
+unexpected zero rows = fail (fix the panel JSON before save).
+
+Coverage: dry-run **every query-bearing panel**, regardless of count
+or shape. Trivial panels fail silently too (wrong severity filter,
+wrong resource scope, attribute name shorthand like `service` instead
+of `service.name`) — the same footguns that bite non-trivial panels.
+Row / header panels (`panelTypes: "row"`) have no query to execute —
+validate their shape against `signoz://dashboard/widgets-examples`
+instead and skip them here.
+
+##### Step 3b-ii.7: Preview, save, report
+
+1. **Preview** Emit a one-paragraph plain-language summary of what
+   will be created — no JSON dump. A 20–30 widget payload is hundreds
+   of lines the user cannot meaningfully review in chat, and the
+   dry-run has already validated every query-bearing panel against
+   live data.
+
+   > **Summary**: This dashboard tracks [signals] for [scope], with
+   > sections [list]. Variables: [list]. Time range default 1h.
+   > Dry-run: all [N] query-bearing panels validated against live
+   > data (any failures have been fixed pre-save).
+
+2. **Save** Call `signoz:signoz_create_dashboard` with the payload.
+
+3. **Report** Tell the user:
+   - The created dashboard's UUID and title.
+   - Panel count and section breakdown.
+   - Which variables are wired.
+   - Two follow-up offers: "Want me to adjust panels, layout, or
+     variables?" and "Want me to wire alerts for any of these signals?
+     (`signoz-creating-alerts`)".
+
+## Guardrails
+
+- **Strict inputs over guessing** Resource scope is required for custom
+  builds. If missing, stop and ask the user (see *Required inputs*
+  above). A guessed scope on a shared dashboard is harder to clean up
+  than asking.
+- **Always paginate `signoz:signoz_list_dashboards`** Stopping at page
+  1 misses duplicates and produces clutter.
+- **Duplicate check first** The user's only two upfront options are
+  "modify an existing one" or "create a new one" — never offer
+  template-import as a separate top-level choice.
+- **Template-first on the create path** Once the user has chosen to
+  create, always run `signoz:signoz_list_dashboard_templates` before any
+  `signoz:signoz_create_dashboard` call. If a matching template exists,
+  import it via `signoz:signoz_import_dashboard` (just inform the user);
+  only build from scratch when no template matches.
+- **No-data probe is mandatory before save** Run the pre-flight probe
+  (Step 3b-i.1 / Step 3b-ii.2) before `signoz:signoz_import_dashboard`
+  / `signoz:signoz_create_dashboard`. A "No data" dashboard is a worse
+  outcome than one extra confirmation prompt. Skip only if the user has
+  explicitly opted out for this request.
+- **Mandatory dry-run before save on custom builds** Before
+  `signoz:signoz_create_dashboard`, run
+  `signoz:signoz_execute_builder_query` per Step 3b-ii.6 — translate
+  each panel's `builder.queryData[]` / `queryFormulas[]` into the
+  endpoint's `queries[].{type, spec}` envelope (mapping in Step
+  3b-ii.6). Skipping is equivalent to skipping the duplicate check.
+  The create-dashboard schema accepts queries that 500 at query time
+  — a `groupBy` on a numeric attribute, an
+  aggregation incompatible with the metric type — and the result
+  ships as a silently empty panel.
+- **Preview before save on custom builds** Emit the plain-language
+  summary before `signoz:signoz_create_dashboard` so the human can
+  intervene on intent.
+- **Prefer OTel attribute names** `service.name` not `service`,
+  `host.name` not `host`. Wrong names produce empty panels. Verify the
+  exact key (`deployment.environment` vs `deployment.environment.name`,
+  for instance) against `signoz:signoz_get_field_keys` rather than guessing —
+  installs running classic OTel semconv emit the no-`.name` form.
+- **No metric guessing** For custom builds, verify metric names with
+  `signoz:signoz_list_metrics` before authoring. Wrong names produce
+  empty panels and the user only finds out later.
+- **Valid JSON shapes only** Follow the v5 schema documented in
+  `signoz://dashboard/*` MCP resources. Required widget and `queryData`
+  fields are listed in `signoz://dashboard/widgets-instructions` and
+  `signoz://dashboard/widgets-examples`. Never wrap arrays/objects in
+  `JSON.stringify`.
+- **Scope boundary** This skill creates dashboards. The moment the
+  user asks to modify, edit, rearrange, or extend an existing dashboard
+  — including immediately after import — hand off to
+  `signoz-modifying-dashboards`. Do not call
+  `signoz:signoz_update_dashboard` from this skill.
+
+## Examples
+
+Four canonical flows — template happy path, template choice, duplicate
+found, custom build — live in [`references/examples.md`](references/examples.md).

--- a/skills/signoz-creating-dashboards/evals/evals.json
+++ b/skills/signoz-creating-dashboards/evals/evals.json
@@ -1,0 +1,254 @@
+{
+  "skill_name": "signoz-creating-dashboards",
+  "evals": [
+    {
+      "id": 0,
+      "eval_name": "template-with-data-jvm",
+      "prompt": "Create a JVM dashboard so I can monitor my Java service.",
+      "expected_output": "Agent paginates signoz_list_dashboards and finds existing JVM dashboards (e.g. 'JVM Performance Metrics', 'JVM Metrics Dashboard'). Surfaces these duplicates with name and UUID and presents the three options: '(a) modify an existing one, (b) create a new one anyway, (c) stop'. When the user picks (b) create new, agent then calls signoz_list_dashboard_templates and picks the JVM catalog entry. Runs the Step 3b-i.1 no-data probe via signoz_list_metrics with searchText='jvm'; finds JVM metrics flowing, proceeds silently to signoz_import_dashboard with the chosen template path. On success, reports the created dashboard's title, panel count, sections, and variables, and offers a customization or alerting follow-up.",
+      "expectations": [
+        "Agent calls signoz_list_dashboards before any write operation and surfaces the existing JVM dashboards as duplicates",
+        "Agent presents modify / create new / stop options to the user before proceeding",
+        "Only after the user picks 'create new', agent calls signoz_list_dashboard_templates to look for a JVM template",
+        "Agent runs a no-data probe (signoz_list_metrics with a jvm-related searchText) before importing",
+        "Agent calls signoz_import_dashboard with the JVM template path",
+        "Agent reports the created dashboard title, panel count, or section breakdown"
+      ],
+      "files": []
+    },
+    {
+      "id": 1,
+      "eval_name": "template-no-data-postgres",
+      "prompt": "Create a dashboard for my PostgreSQL database.",
+      "expected_output": "Agent paginates signoz_list_dashboards and finds existing Postgres dashboards (e.g. 'PostgreSQL', 'Postgres overview'). Surfaces these duplicates and presents '(a) modify, (b) create new, (c) stop'. When the user picks (b) create new, agent calls signoz_list_dashboard_templates and picks the postgresql/postgresql.json catalog entry. Runs the Step 3b-i.1 no-data probe via signoz_list_metrics searchText='postgresql'; the probe returns empty. CRITICAL: agent MUST warn the user that no postgres data was found and offer create-anyway-or-stop, then wait for the user's choice. Must NOT silently call signoz_import_dashboard.",
+      "expectations": [
+        "Agent calls signoz_list_dashboards and surfaces the existing Postgres dashboards as duplicates with modify/create/stop options",
+        "Only after the user picks 'create new', agent calls signoz_list_dashboard_templates and picks the postgresql template",
+        "Agent runs a no-data probe via signoz_list_metrics with a postgresql-related searchText",
+        "Agent emits a warning message noting data is not found before calling signoz_import_dashboard",
+        "Agent waits for user confirmation before calling signoz_import_dashboard (does not import silently)"
+      ],
+      "files": []
+    },
+    {
+      "id": 2,
+      "eval_name": "broad-request-apm-category",
+      "prompt": "I need an APM dashboard - what do you have?",
+      "expected_output": "Agent recognises the request is broad and exploratory. Calls signoz_list_dashboards and may surface existing APM-tagged dashboards (e.g. 'Frontend Service - APM', 'Cart Service - APM') as related context. Calls signoz_list_dashboard_templates (no arguments needed — full catalog returns in one call), reads the catalog in-context, filters to APM entries (apm-metrics, db-calls-monitoring, http-api-monitoring), presents the narrowed list to the user, and asks them to pick before calling signoz_import_dashboard. Must NOT pick a template silently when the request is ambiguous.",
+      "expectations": [
+        "Agent calls signoz_list_dashboard_templates and reads the catalog",
+        "Agent presents multiple APM template options to the user and asks them to choose",
+        "Agent does NOT silently call signoz_import_dashboard without user selection"
+      ],
+      "files": []
+    },
+    {
+      "id": 5,
+      "eval_name": "needs-input-missing-scope-custom-build",
+      "prompt": "Build me a dashboard for some k8s pods.",
+      "expected_output": "Request is too vague (no cluster, namespace, or pod set). Agent must NOT proceed to signoz_create_dashboard with a guessed scope. Either asks the user to clarify scope (using the host's clarification mechanism) with concrete candidates discovered via signoz_get_field_values, or proposes the k8s catalog template and asks the user to confirm scope before importing. Must explicitly ask the user to clarify cluster/namespace before any write tool.",
+      "expectations": [
+        "Agent does NOT call signoz_create_dashboard or signoz_import_dashboard without first clarifying scope with the user",
+        "Agent stops before any write and asks a clarifying question about the cluster or namespace",
+        "Agent calls signoz_get_field_values or signoz_list_dashboard_templates to discover candidates before prompting"
+      ],
+      "files": []
+    },
+    {
+      "id": 6,
+      "eval_name": "custom-build-scylladb-no-near-template-shortcut",
+      "prompt": "I need a dashboard for our ScyllaDB cluster — show me read/write latency, pending compactions, and storage load per node.",
+      "expected_output": "ScyllaDB has NO catalog template (the catalog ships database templates for postgresql, mysql, mongodb, redis, elasticsearch, clickhouse, couchdb, memcached, snowflake, and a JMX/Cassandra template — but no Scylla, which is a distinct product with its own Prometheus exporter and metric names). Agent calls signoz_list_dashboards (no Scylla dashboard). Calls signoz_list_dashboard_templates, reads the catalog in-context, finds no scylla match. CRITICAL: agent must NOT shortcut by importing a near-neighbor template (jmx/cassandra.json, couchdb, mongodb) just because Scylla is Cassandra-compatible — must fall through to custom build. Calls signoz_list_metrics with searchText='scylla' as a no-data probe; if empty (likely on this instance), agent must surface the no-data warning from Step 3b-ii.2 and ask the user whether to proceed before building. If the user says proceed, agent uses signoz_get_field_keys with fieldContext=resource and signoz_get_field_values to surface per-node attributes (host.name, k8s.cluster.name where present). Reads signoz://dashboard/* MCP resources. Builds custom JSON with sections (Overview, Latency, Compaction, Storage), groupBy host.name on per-node panels, OTel attribute names. Emits plain-language summary (no JSON dump) BEFORE signoz_create_dashboard.",
+      "expectations": [
+        "Agent calls signoz_list_dashboard_templates, reads the catalog, and finds no matching scylla template",
+        "Agent does NOT call signoz_import_dashboard with a near-neighbor template (jmx/cassandra, couchdb, mongodb) as a shortcut",
+        "Agent calls signoz_list_metrics with a scylla-related searchText as part of the no-data probe",
+        "When the metric search returns empty, agent surfaces a no-data warning and waits for user confirmation before signoz_create_dashboard",
+        "Agent reads at least one signoz://dashboard/ MCP resource (instructions, widgets-instructions, or widgets-examples) before building JSON",
+        "Agent uses OTel resource attribute names (host.name, not 'host') in filters or groupBy",
+        "Agent emits a plain-language summary (no JSON dump) of the dashboard before calling signoz_create_dashboard",
+        "Agent runs signoz_execute_builder_query as a per-panel dry-run for every authored panel before signoz_create_dashboard"
+      ],
+      "files": []
+    },
+    {
+      "id": 7,
+      "eval_name": "custom-build-kafka-consumer-pressure",
+      "prompt": "Quick — just build me a Kafka consumer-health dashboard with fetch rate and commit latency, grouped by client. Don't ask a bunch of questions, I'm in the middle of an incident.",
+      "expected_output": "Kafka has NO catalog template (rabbitmq exists but is a different broker). The 'incident pressure + don't ask' phrasing tempts the agent to skip discovery and the no-data probe. Agent MUST still: paginate signoz_list_dashboards; call signoz_list_dashboard_templates (no Kafka match); fall through to custom build; call signoz_list_metrics with searchText='kafka' to discover real metric names (kafka.consumer.fetch_rate, kafka.consumer.commit_latency_avg, kafka.consumer.bytes_consumed_rate, etc.) before authoring; call signoz_get_field_keys with metricName scoped to a kafka.consumer metric to discover per-metric attributes (typically client-id and standard resource attrs like service.name, k8s.pod.name); run the mandatory per-panel dry-run via signoz_execute_builder_query (envelope-translated from the widget JSON, with name preserved on each builder_query.spec) so a no-data or malformed panel isn't shipped. The skill's dry-run-before-save guardrail is non-negotiable even under incident pressure. Must emit plain-language summary (no JSON dump) before signoz_create_dashboard. GroupBy uses the actual attribute the metric carries — accept either 'client-id' (kafkametricsreceiver-style) or 'service.name' resource attribute. Reject shorthand keys like 'client' or 'consumer'.",
+      "expectations": [
+        "Agent calls signoz_list_dashboard_templates and finds no matching kafka template before custom build",
+        "Agent does NOT skip metric discovery — calls signoz_list_metrics with a kafka-related searchText before authoring panels",
+        "Agent calls signoz_get_field_keys (with signal=metrics and a kafka metric name) or signoz_get_field_values to discover the actual attribute keys carried by the kafka.consumer.* metrics before grouping",
+        "Agent does NOT skip the per-panel dry-run — calls signoz_execute_builder_query for every authored panel before signoz_create_dashboard",
+        "Agent uses the actual attribute key carried by the metric (e.g. 'client-id') or a real resource attribute (e.g. 'service.name', 'k8s.pod.name') for groupBy — not invented shorthand like 'consumer_group' or 'topic'",
+        "Agent emits a plain-language summary (no JSON dump) before calling signoz_create_dashboard",
+        "Agent either calls signoz_create_dashboard with the custom-built payload or produces a complete, ready-to-send JSON payload that contains the discovered metric names, groupBy attribute, and formula panels (acceptable if harness is in simulation mode)",
+        "Agent does NOT bypass the duplicate check or skip signoz_list_dashboards under the incident-pressure framing"
+      ],
+      "files": []
+    },
+    {
+      "id": 8,
+      "eval_name": "custom-build-checkout-funnel-span-attributes",
+      "prompt": "Create a checkout funnel dashboard for our OpenTelemetry demo store. We instrument the cart, checkout, and payment services with span attributes — I want orders-placed count, total order revenue, and a card-type breakdown for charges. Discover the actual attribute names on the spans rather than guessing.",
+      "expected_output": "Business-KPI dashboard with NO catalog template — must custom build on traces signal, not metrics. Agent paginates signoz_list_dashboards (none). signoz_list_dashboard_templates returns no match. CRITICAL: agent must recognise the signal is TRACES with span-level attributes, not metrics — calls signoz_get_field_keys with signal='traces' to DISCOVER the actual attribute names rather than guessing. On this instance the attributes are app.order.id, app.order.amount, app.order.items.count, app.payment.amount, app.payment.card_type, app.payment.charged. Panel builder_query specs use signal='traces' with aggregation='count' for orders-placed (filtered to spans where app.order.id EXISTS, or operation = 'oteldemo.CheckoutService/PlaceOrder'); aggregation='sum' over app.order.amount for revenue; groupBy app.payment.card_type for the card-type breakdown. Reads signoz://traces/query-builder-guide and signoz://dashboard/* resources. groupBy uses the discovered span-attribute key with the correct attribute type (span attribute / tag, not resource). Emits plain-language summary (no JSON dump) before signoz_create_dashboard.",
+      "expectations": [
+        "Agent calls signoz_list_dashboard_templates and finds no matching template before custom build",
+        "Agent calls signoz_get_field_keys with signal=traces to discover the actual span-attribute names (does not invent attributes like 'order.value' or 'checkout.step' that may not exist on the instance)",
+        "Panel builder_query specs use signal='traces' (not 'metrics') for the headline panels since the data lives on spans",
+        "Agent uses span-attribute keys discovered via field_keys (e.g. app.order.amount, app.payment.card_type) in filters or groupBy with the correct attribute type (tag/attribute, not resource)",
+        "Agent uses a sum aggregation over a numeric order-amount attribute for the revenue panel (not just a count)",
+        "Agent emits a plain-language summary (no JSON dump) before calling signoz_create_dashboard",
+        "Agent runs signoz_execute_builder_query as a per-panel dry-run for every authored panel before signoz_create_dashboard",
+        "Agent calls signoz_create_dashboard with the custom-built payload"
+      ],
+      "files": []
+    },
+    {
+      "id": 9,
+      "eval_name": "custom-build-slo-error-budget-formula",
+      "prompt": "Build me an SLO dashboard for the checkout service — 99.9% availability target, 28-day rolling window, show error-budget burn rate and remaining budget.",
+      "expected_output": "SLO/error-budget dashboard has no catalog template. Agent paginates signoz_list_dashboards (none). signoz_list_dashboard_templates returns no match. Falls through to custom build. Discovers signoz_calls_total / signoz_latency_bucket span metrics via signoz_list_metrics. Calls signoz_get_field_values for service.name to confirm 'checkoutservice' (or whichever exists). Reads signoz://dashboard/* resources. Builds the dashboard in BUILDER MODE ONLY — never PromQL or ClickHouse-SQL. Panels: (a) availability using formula A*100/B or (1-A/B)*100 where A=signoz_calls_total filtered to status_code='STATUS_CODE_ERROR' and B=signoz_calls_total total; (b) error-budget-remaining as (availability - 99.9) / (1 - 0.999) * 100; (c) burn-rate panels with the MWMB pattern (1h and 6h windows; thresholds ≥14.4x / ≥6x). Time range default overridden to 28d (NOT the default 1h) since SLO windows are long. Filter and groupBy use 'service.name' (dotted, type=resource), NOT 'service_name' (underscore — that's PromQL syntax which this skill forbids). Emits plain-language summary (no JSON dump) before signoz_create_dashboard with the explicit time range, SLO target, error budget in minutes, and formula calls in the summary.",
+      "expectations": [
+        "Agent calls signoz_list_dashboard_templates and finds no matching SLO/error-budget template before custom build",
+        "Agent calls signoz_list_metrics to discover signoz_calls_total or signoz_latency_bucket span metrics (or equivalent) before authoring",
+        "Agent uses a formula combining good and total event counts (e.g. A*100/B, (B-A)/B, or a similar ratio) for the availability or error-budget panel",
+        "Agent overrides the default 1h time range to a longer SLO-appropriate window (28d, 30d, or similarly explicit long range) — acceptable either as a dashboard-level timeRange field or as a query-window (e.g. rate[28d]) override with the preview explicitly noting the non-default window",
+        "Agent uses service.name (dotted, OTel resource attribute) in builder-mode filters and variables — not the underscored span-metric label 'service_name' (this skill builds in builder mode only, never PromQL) and not the bare shorthand 'service'",
+        "Agent emits a plain-language summary (no JSON dump) before calling signoz_create_dashboard, surfacing the non-default time range and the formula(s)",
+        "Agent runs signoz_execute_builder_query as a per-panel dry-run for every authored panel before signoz_create_dashboard",
+        "Agent either calls signoz_create_dashboard with the custom-built payload or produces a complete, ready-to-send JSON payload that contains the formula panels, the non-default time range, and the service filter (acceptable if harness is in simulation mode)"
+      ],
+      "files": []
+    },
+    {
+      "id": 11,
+      "eval_name": "duplicate-modify-hands-off",
+      "prompt": "I want to add a slow-query panel to my existing PostgreSQL dashboard.",
+      "expected_output": "Agent calls signoz_list_dashboards, finds the existing PostgreSQL dashboard, and presents the modify/create/stop options. When the user picks (a) modify, agent must hand off to signoz-modifying-dashboards with the dashboard's UUID and the user's intent — must NOT call signoz_get_dashboard or signoz_update_dashboard from this skill. The skill's scope-boundary guardrail forbids inline modification.",
+      "expectations": [
+        "Agent calls signoz_list_dashboards and surfaces the existing PostgreSQL dashboard",
+        "Agent presents modify / create new / stop options to the user",
+        "When the user picks modify, agent hands off to signoz-modifying-dashboards (does NOT call signoz_update_dashboard or signoz_get_dashboard from this skill)"
+      ],
+      "files": []
+    },
+    {
+      "id": 12,
+      "eval_name": "shape-check-no-stringify",
+      "prompt": "Create a dashboard with one timeseries panel showing service request rate for the checkout service. Walk me through the create call.",
+      "expected_output": "Agent walks the standard custom-build path: list_dashboards, list_dashboard_templates (no exact 'request rate one panel' template), discovery via list_metrics + get_field_keys, reads dashboard MCP resources. Builds the JSON, dry-runs the panel via signoz_execute_builder_query, then emits a plain-language summary and calls signoz_create_dashboard. CRITICAL: the payload sent to signoz_create_dashboard must have layout, widgets, and variables as native JSON arrays/objects — NOT as JSON.stringify'd strings. Required top-level fields are title, layout (array of {x,y,w,h,i}), widgets (array). Each widget must include id, panelTypes, title, query (with builder/promql/clickhouse_sql sub-keys), selectedLogFields, selectedTracesFields, thresholds, contextLinks. Agent must NOT wrap any of these in a JSON string.",
+      "expectations": [
+        "Payload sent to signoz_create_dashboard has layout as an array of objects (not a stringified JSON string)",
+        "Payload sent to signoz_create_dashboard has widgets as an array of objects (not a stringified JSON string)",
+        "Each widget in the payload includes id, panelTypes, title, query, selectedLogFields, selectedTracesFields, thresholds, and contextLinks",
+        "The widget's query object includes queryType, builder, promql, and clickhouse_sql sub-keys (with promql and clickhouse_sql passed as empty arrays for builder-mode widgets)",
+        "Agent runs signoz_execute_builder_query as a dry-run for the panel before signoz_create_dashboard"
+      ],
+      "files": []
+    },
+    {
+      "id": 13,
+      "eval_name": "import-failure-falls-back-to-custom",
+      "prompt": "Create a dashboard for our Redis cluster.",
+      "expected_output": "Agent paginates signoz_list_dashboards and finds an existing 'Redis - Overview' dashboard. Surfaces the duplicate and presents '(a) modify, (b) create new, (c) stop'. When the user picks (b) create new, agent calls signoz_list_dashboard_templates and picks the Redis catalog entry, runs the no-data probe. Calls signoz_import_dashboard. Simulated failure: signoz_import_dashboard returns an error (e.g. catalog path not found, server-side validation failure). CRITICAL: agent must NOT silently retry or claim success — must surface the import error to the user and either (a) ask whether to fall through to a custom build using the same template's signals, or (b) stop. Must NOT skip directly to signoz_create_dashboard with a fabricated payload without telling the user the import failed.",
+      "expectations": [
+        "Agent calls signoz_list_dashboards and surfaces the existing Redis dashboard as a duplicate before any import attempt",
+        "Only after the user picks 'create new', agent calls signoz_import_dashboard with the Redis template path",
+        "On import failure, agent surfaces the error to the user and does NOT silently claim success",
+        "Agent either offers a custom-build fallback OR stops — does not silently call signoz_create_dashboard with a guessed payload"
+      ],
+      "files": []
+    },
+    {
+      "id": 10,
+      "eval_name": "custom-build-multi-service-user-journey",
+      "prompt": "Create a user-journey dashboard for our OpenTelemetry demo checkout flow — I want per-hop latency and error rate across frontend, cartservice, checkoutservice, paymentservice, and shippingservice, so I can see where transactions slow down or fail. Discover the exact service names from the instance rather than hard-coding them.",
+      "expected_output": "Multi-service journey dashboard, no catalog template (apm covers single-service). Agent calls signoz_list_dashboards (none). signoz_list_dashboard_templates returns the catalog; agent reads it in-context and finds no user-journey match. Falls through to custom build. Calls signoz_get_field_keys with signal=traces fieldContext=resource to confirm service.name; signoz_get_field_values for service.name (or signoz_list_services) to verify the named services exist on the instance — the actual names are 'frontend', 'cartservice', 'checkoutservice', 'paymentservice', 'shippingservice' (plus others). Reads signoz://traces/query-builder-guide and signoz://dashboard/* resources. Builds JSON with: filter service.name IN (the discovered service names); per-service latency panels (p50/p95/p99) with groupBy=service.name (resource attr); per-service error-rate panels using A*100/B formula (errors / total); a request-rate panel grouped by service.name. Variables include service.name (multi-select pre-populated) and deployment.environment.name. groupBy uses 'service.name' with type='resource', not bare 'service'. Emits plain-language summary (no JSON dump) before signoz_create_dashboard. Performs shape check.",
+      "expectations": [
+        "Agent calls signoz_list_dashboard_templates and finds no matching user-journey template before custom build",
+        "Agent calls signoz_list_services or signoz_get_field_values for service.name (signal=traces) to verify which services actually exist on the instance before authoring",
+        "Agent uses an IN-list filter on service.name with the actual discovered service names (e.g. 'cartservice', 'checkoutservice', 'paymentservice', 'shippingservice') — not invented short names like 'cart' or 'payment'",
+        "Agent uses groupBy on service.name with type=resource (OTel attribute name) on per-hop panels so latency/error breakdown is per service",
+        "Agent includes a formula combining error count and total count (A*100/B or equivalent) for per-service error rate, not a single rate aggregation",
+        "Agent reads at least one signoz://dashboard/ or signoz://traces/ MCP resource before authoring JSON",
+        "Agent emits a plain-language summary (no JSON dump) before calling signoz_create_dashboard",
+        "Agent runs signoz_execute_builder_query as a per-panel dry-run for every authored panel before signoz_create_dashboard",
+        "Agent either calls signoz_create_dashboard with the custom-built payload or produces a complete, ready-to-send JSON payload that includes service.name groupBy, the error-rate formula, and all discovered service names (acceptable if harness is in simulation mode)"
+      ],
+      "files": []
+    },
+    {
+      "id": 14,
+      "eval_name": "custom-build-logs-signal-volume-and-errors",
+      "prompt": "Create a dashboard for our application log analytics — I want a timeseries of log volume per service, a value panel showing total ERROR/WARN count in the last hour, and a table of top 10 services by log volume broken down by severity. Use logs as the data source.",
+      "expected_output": "Logs-signal dashboard with NO catalog template — must custom build on the LOGS signal, not metrics or traces. Agent paginates signoz_list_dashboards (no log-analytics dashboard). signoz_list_dashboard_templates returns no match. Falls through to custom build. CRITICAL: agent must recognise the signal is LOGS (dataSource=logs in queryData), not metrics. Calls signoz_get_field_keys with signal=logs to discover available log attributes (severity_text, service.name as resource attr, body, severity_number). Optionally calls signoz_aggregate_logs at discovery time to gauge log volume. The mandatory per-panel dry-run before save goes through signoz_execute_builder_query (signal=logs in each builder_query.spec), not signoz_aggregate_logs. Reads signoz://dashboard/widgets-instructions, signoz://dashboard/widgets-examples, AND signoz://dashboard/clickhouse-logs-example or query-builder-example for log-specific patterns. Builds three panels: (a) timeseries panel with dataSource=logs, aggregation count(), groupBy service.name, legend {{service.name}}; (b) value panel with dataSource=logs, aggregation count(), filter severity_text IN ('ERROR','WARN','FATAL') — NO groupBy on value panels; (c) table panel with dataSource=logs, aggregation count() as 'Log Count', groupBy service.name AND severity_text (both with isColumn:true on at least one). Each widget includes the required selectedLogFields array (timestamp, body) per the widgets-examples shape. Variables use service.name (DYNAMIC type, source=Logs or 'All telemetry'). Emits plain-language summary (no JSON dump) before signoz_create_dashboard.",
+      "expectations": [
+        "Agent calls signoz_list_dashboard_templates and finds no matching log-analytics template before custom build",
+        "Agent uses dataSource='logs' in queryData (not 'metrics' or 'traces') for the log panels",
+        "Agent calls signoz_get_field_keys with signal=logs to discover log attributes before authoring",
+        "Agent uses severity_text in a filter for the ERROR/WARN value panel (not a guessed key like 'severity' or 'level')",
+        "Value panel does NOT include groupBy (would produce multiple values instead of one)",
+        "Table panel includes groupBy with at least 'service.name' AND 'severity_text' to satisfy the per-service / per-severity breakdown",
+        "Timeseries panel includes legend with {{service.name}} matching the groupBy key",
+        "Each widget includes selectedLogFields array (timestamp, body at minimum) per the widgets-examples shape",
+        "Agent emits a plain-language summary (no JSON dump) before calling signoz_create_dashboard",
+        "Agent runs signoz_execute_builder_query (with signal=logs in each builder_query.spec) as a per-panel dry-run before signoz_create_dashboard"
+      ],
+      "files": []
+    },
+    {
+      "id": 15,
+      "eval_name": "custom-build-list-panel-selectColumns-required",
+      "prompt": "Create a dashboard with one list panel that shows the most recent error traces — I want columns for service.name, span name, duration, http method, and response status code. Sort newest first.",
+      "expected_output": "Single-list-panel dashboard. No catalog template (no curated 'recent error traces list' panel). Agent paginates signoz_list_dashboards (none). signoz_list_dashboard_templates returns no match. Falls through to custom build. CRITICAL: list panels have a known frontend-crash failure mode if selectColumns is missing or malformed (per widgets-examples). Agent MUST: (a) read signoz://dashboard/widgets-examples for the list-panel shape; (b) author the panel with panelTypes='list', dataSource='traces', aggregation count(), filter has_error=true (or status_code='STATUS_CODE_ERROR'), orderBy [{columnName:'timestamp', order:'desc'}], pageSize 10, AND selectColumns array where EACH entry includes name (NOT 'key'), fieldContext (resource for service.name; span for name/duration_nano/http_method/response_status_code), fieldDataType where applicable, and signal='traces'. Reject the deprecated 'key' field in selectColumns — using 'key' instead of 'name' causes frontend crash on dashboard editor. Emits a plain-language summary (no JSON dump) before signoz_create_dashboard, after running a per-panel signoz_execute_builder_query dry-run for every authored panel.",
+      "expectations": [
+        "Agent reads signoz://dashboard/widgets-examples (or widgets-instructions) before authoring the list-panel JSON",
+        "List panel includes panelTypes='list', orderBy on timestamp desc, and pageSize",
+        "selectColumns is present and uses 'name' (not 'key') for each column entry",
+        "Each selectColumns entry includes fieldContext (resource for service.name; span for span-level columns) and signal='traces'",
+        "Filter on the list panel restricts to error spans (e.g. has_error=true, status_code='STATUS_CODE_ERROR', or equivalent)",
+        "Agent does NOT use groupBy on the list panel (lists are unaggregated; groupBy would produce wrong behavior)",
+        "Agent emits a plain-language summary (no JSON dump) before signoz_create_dashboard",
+        "Agent runs signoz_execute_builder_query as a dry-run for the list panel before signoz_create_dashboard"
+      ],
+      "files": []
+    },
+    {
+      "id": 16,
+      "eval_name": "custom-build-multi-panel-types-mixed",
+      "prompt": "Create an APM-style dashboard for the checkoutservice with: (1) a row section called 'Overview', (2) three value panels in a KPI row (total requests, error rate %, p99 latency), (3) a row section called 'Breakdowns', (4) a pie panel showing request distribution by operation, (5) a bar panel showing error count by status code, and (6) a table panel with operation, request count, and avg latency.",
+      "expected_output": "Multi-panel-type dashboard exercises all six non-graph panel types (row, value, pie, bar, table) PLUS the standard graph type if any timeseries is added. No catalog template — custom build on traces signal. Agent paginates signoz_list_dashboards (none — no checkout APM dashboard with this exact layout). signoz_list_dashboard_templates returns the apm category but the user asked for a specific layout, so falls through to custom build. CRITICAL panel-shape rules per widgets-examples: (a) row panels have panelTypes='row' and a title, no query needed; (b) value panels MUST NOT have groupBy (causes multiple values instead of one); (c) pie panels MUST have groupBy AND legend matching the groupBy key; (d) bar panels behave like graph and need groupBy+legend when grouped; (e) table panels need groupBy and SHOULD use 'as' aliases on aggregations (e.g. count() as 'Requests' avg(duration_nano) as 'Latency'); (f) error rate must use A*100/B formula with disabled:true on base queries. Reads signoz://dashboard/widgets-examples for each panel-type shape. Discovers the operation attribute (likely 'name' span column or rpc.method/http.route) via signoz_get_field_keys with signal=traces. Emits a plain-language summary (no JSON dump) before signoz_create_dashboard, after running a per-panel signoz_execute_builder_query dry-run for every authored panel. Layout must place the two row sections at full width (w=12) with appropriate Y progression, and the KPI value panels in a single horizontal row (e.g. three w=4 panels at the same Y).",
+      "expectations": [
+        "Dashboard payload includes at least one row panel (panelTypes='row') for section headers",
+        "Value panels do NOT include groupBy in queryData",
+        "Pie panel includes groupBy AND legend with {{<key>}} matching the groupBy key",
+        "Bar panel uses panelTypes='bar' (not 'graph') and includes groupBy on status_code or equivalent",
+        "Table panel uses groupBy and aggregation expressions include 'as' aliases for column names",
+        "Error-rate value panel uses an A*100/B formula with disabled:true on base queries (per widgets-examples error-rate pattern)",
+        "Agent reads signoz://dashboard/widgets-examples before authoring (panel shapes vary per type)",
+        "Layout places row panels at full width (w=12) and KPI value panels side-by-side at consistent y",
+        "Agent emits a plain-language summary (no JSON dump) before signoz_create_dashboard",
+        "Agent runs signoz_execute_builder_query as a per-panel dry-run for every authored panel (rows excluded — they have no query) before signoz_create_dashboard"
+      ],
+      "files": []
+    },
+    {
+      "id": 17,
+      "eval_name": "custom-build-variable-application-prompt",
+      "prompt": "Create a dashboard for our backend services with three panels: (1) request rate timeseries grouped by service, (2) p99 latency timeseries grouped by service, and (3) a global system health panel showing total error count across all services. I want a service.name dropdown variable to filter the dashboard.",
+      "expected_output": "Custom-build dashboard with a DYNAMIC variable. The user has explicitly asked for a service.name dropdown. Agent's standard custom-build flow applies (duplicate check, list_templates no match, discovery, MCP resource read, build JSON). CRITICAL guardrail per signoz://dashboard/instructions ('Applying Variables to Panels'): before wiring the service.name variable into panel queries, the agent MUST present the panel list (id+title) and ASK the user which panels the variable should apply to — offering (a) all panels, or (b) a subset. The agent must NOT silently inject $service_name into every panel. In this case the third panel is intentionally a 'global' health panel that should NOT carry the service.name filter (over-filtering would hide the global view). The agent should detect this from the user's wording or, at minimum, ask. Variable is DYNAMIC type, DynamicVariablesAttribute='service.name', DynamicVariablesSource='Traces' or 'All telemetry'. Runs per-panel signoz_execute_builder_query dry-runs, then emits a plain-language summary (no JSON dump) before signoz_create_dashboard, calling out which panels the variable applies to.",
+      "expectations": [
+        "Agent creates the variable with type='DYNAMIC' (not CUSTOM/TEXTBOX/QUERY) and DynamicVariablesAttribute='service.name'",
+        "Agent either explicitly asks the user which panels the service.name variable should apply to, OR justifies in the preview which panels it applies to and which it intentionally skips (specifically the 'global system health' panel)",
+        "Variable reference $service_name appears in the filter expression of the per-service request-rate AND latency panels",
+        "Variable reference $service_name does NOT appear in the filter expression of the global error-count panel (over-filtering would defeat the 'across all services' intent)",
+        "Variable references use the $-prefix syntax in filter expressions (e.g. 'service.name in $service_name'), not bare 'service_name'",
+        "Agent emits a plain-language summary (no JSON dump) before signoz_create_dashboard",
+        "Agent runs signoz_execute_builder_query as a per-panel dry-run for every authored panel before signoz_create_dashboard"
+      ],
+      "files": []
+    }
+  ]
+}

--- a/skills/signoz-creating-dashboards/references/examples.md
+++ b/skills/signoz-creating-dashboards/references/examples.md
@@ -1,0 +1,87 @@
+# Examples — `signoz-creating-dashboards`
+
+Walkthroughs of the four canonical flows: template import with data,
+template import without data, duplicate-found choice, and custom build.
+
+## Template import — happy path
+
+**User:** "Create a dashboard for my PostgreSQL database"
+
+**Agent:**
+1. `signoz:signoz_list_dashboards` (paginated) → no PostgreSQL
+   dashboard exists.
+2. Says: "I'll create a new dashboard for PostgreSQL. Proceed?" User
+   confirms.
+3. `signoz:signoz_list_dashboard_templates` → picks
+   `postgresql/postgresql.json`. Tells user: "I found a pre-built
+   PostgreSQL template and will use it."
+4. No-data probe: `signoz:signoz_list_metrics searchText="postgresql"`
+   → returns `postgresql.connections.usage`, `postgresql.commits`, etc.
+   Data flowing.
+5. Calls `signoz:signoz_import_dashboard path=postgresql/postgresql.json`.
+6. Reports: "Created 'PostgreSQL Overview' (UUID `…`) — 24 panels
+   across Overview / Connections / Throughput / Replication. Variables:
+   `postgresql.host.name`. Probe found data for all headline panels.
+   Want me to adjust anything, or wire alerts for slow queries?"
+
+*Variant — no PG data ingested:* the probe in step 4 returns empty;
+agent emits the verbatim no-data warning from Step 3b-i.1 and waits for
+the user to choose between "create anyway" and "stop".
+
+## Template choice when several match
+
+**User:** "I need an APM dashboard — what do you have?"
+
+**Agent:**
+1. `signoz:signoz_list_dashboards` (paginated) → no APM dashboard.
+2. Says: "I'll create a new APM dashboard. Want me to show you what
+   templates we have first?" User: yes.
+3. `signoz:signoz_list_dashboard_templates` → reads the full catalog
+   in-context, filters to APM entries (APM RED, APM Errors, etc.).
+4. Presents the list and asks which to import. User picks "APM RED".
+5. No-data probe: `signoz:signoz_aggregate_traces aggregation=count
+   timeRange=1h` → returns rows. Data flowing.
+6. Imports, reports panels and variables. Offers to wire latency
+   alerts via `signoz-creating-alerts`.
+
+## Duplicate found — modify-or-create
+
+**User:** "Set up monitoring for Redis" (existing "Redis - Overview"
+dashboard found)
+
+**Agent:** surfaces the existing dashboard with UUID and `createdAt`,
+asks the user (a) modify / (b) create new / (c) stop. If user picks
+(b), follows the PostgreSQL flow above against the `redis/redis.json`
+template. If (a), hands off to `signoz-modifying-dashboards` with the
+dashboard's UUID and the user's intent (no `signoz:signoz_get_dashboard` call
+from this skill).
+
+## Custom build — no template match
+
+**User:** "Create a dashboard to track our payment processing pipeline"
+(custom build — no template match)
+
+**Agent:**
+1. Duplicate check (none) and creation confirmation as above.
+2. `signoz:signoz_list_dashboard_templates` → no match in the catalog.
+   Falls through to custom build (Step 3b-ii).
+3. Gathers requirements: signals (traces + metrics), which services
+   are in the pipeline, variables (`service.name` plus the env key
+   that actually exists in the install).
+4. Discovery (parallel): `signoz:signoz_get_field_keys signal=traces
+   fieldContext=resource` → confirms `service.name` and
+   `deployment.environment` (no `.name` suffix in this install);
+   `signoz:signoz_get_field_values name=service.name` → user picks
+   `checkout`, `payments`, `inventory`, `notifications`.
+5. Reads the `signoz://dashboard/*` MCP resources. Builds sections
+   Overview / Latency / Errors / Throughput, with headline panels
+   (request rate, p99 latency, error rate `A*100/B`, throughput) and
+   the two variables.
+6. Per-panel dry-run via `signoz:signoz_execute_builder_query` for
+   **every** panel (envelope translation per Step 3b-ii.6, with
+   `name` preserved on each `builder_query.spec` so formulas
+   resolve). Emits a one-paragraph plain-language summary — no JSON
+   dump — then calls `signoz:signoz_create_dashboard`. Reports UUID,
+   panel count and section breakdown, and which variables are
+   wired. Offers to wire error-rate alerts via
+   `signoz-creating-alerts`.

--- a/skills/signoz-explaining-alerts/SKILL.md
+++ b/skills/signoz-explaining-alerts/SKILL.md
@@ -1,0 +1,378 @@
+---
+name: signoz-explaining-alerts
+description: >
+  Describe what an existing SigNoz alert rule does in plain language —
+  the signal it watches, the threshold and evaluation behavior, the
+  notification routing, and a one-line fire-frequency summary so the user
+  knows whether the alert has been active. Make sure to use this skill
+  whenever the user asks "what does this alert do", "explain alert X",
+  "walk me through this rule", "how does my [Y] alert work", "is this
+  alert configured correctly", or otherwise asks for an interpretation
+  of an existing alert's configuration. Static explanation only — for
+  diagnosing a specific firing incident, use `signoz-investigating-alerts`.
+argument-hint: <alert name or rule id>
+---
+
+# Alert Explain
+
+Decode an existing SigNoz alert's configuration into a plain-language
+explanation. The skill is read-only and stays focused on the rule
+itself: what it watches, when it fires, where it notifies. A single
+line of fire-frequency data is included to ground the explanation, but
+this skill does **not** investigate any specific fire — that is
+`signoz-investigating-alerts`'s job.
+
+## Prerequisites
+
+This skill calls SigNoz MCP server tools (`signoz:signoz_get_alert`,
+`signoz:signoz_list_alert_rules`, `signoz:signoz_get_alert_history`). Before running
+the workflow, confirm the `signoz:signoz_*` tools are available. If they are
+not, run `signoz-mcp-setup` first to initialize or repair the MCP connection.
+Do not guess at alert configuration from the rule name alone.
+
+## When to use
+
+Use this skill when the user wants to:
+- Understand or interpret an existing alert rule.
+- Confirm what signal an alert watches and at what threshold.
+- Audit whether an alert is reasonably configured.
+- Translate raw alert JSON into operational language.
+
+Do NOT use when the user wants to:
+- Create a new alert → `signoz-creating-alerts`.
+- Diagnose why an alert fired or correlate signals around a fire window
+  → `signoz-investigating-alerts`.
+- Modify an existing alert → call `signoz:signoz_update_alert` directly.
+
+## Required inputs
+
+| Input | Required | Source if missing |
+|---|---|---|
+| Alert identifier (rule ID or name) | yes | `$ARGUMENTS`, recent context, or fuzzy match |
+
+If the input is missing or ambiguous, this skill is **best-effort** (not
+strict — read-only operations are cheap to recover from):
+
+1. Call `signoz:signoz_list_alert_rules`, paginate through every page, and find
+   the closest name match.
+2. State the interpretation in the response:
+   "Interpreting your request as alert 'High Error Rate — Checkout' (id 42).
+   If you meant a different one, tell me the name or id."
+3. Proceed with the explanation. The user can correct after.
+
+## Workflow
+
+### Step 1: Resolve the alert
+
+If the user provided a numeric id, skip to Step 2. Otherwise:
+
+1. Call `signoz:signoz_list_alert_rules` and **paginate every page** —
+   `pagination.hasMore` is true until the full list is walked.
+2. Match by name (case-insensitive substring). If multiple match,
+   present the candidates and ask which one (interactive) or pick the
+   closest and flag the assumption (autonomous).
+
+### Step 2: Fetch the full configuration
+
+Call `signoz:signoz_get_alert` with the rule id. This is **mandatory** — the
+list response does not include the full condition / thresholds /
+notification settings, and explanations based on the name alone are
+guesses.
+
+### Step 3: Pull a one-line fire-frequency summary
+
+Call `signoz:signoz_get_alert_history` for the rule with a 7-day lookback. From
+the response, derive a single line:
+
+> Fired N times in the last 7d (last fire: <relative-time>).
+
+If the alert never fired in the window, say so explicitly:
+"Has not fired in the last 7d." If the alert is disabled, mention that
+and skip the history line.
+
+This single line grounds the explanation. Do **not** drill into specific
+fires here — that's `signoz-investigating-alerts`.
+
+### Step 4: Build the explanation
+
+The single most useful thing for the user is a tight summary. Lead
+with a **TL;DR that directly answers the question they asked**, not a
+generic alert summary. The TL;DR is the only thing some users will
+read — burying their answer under a fixed template forces them to
+scroll for what they wanted in the first place.
+
+Match the TL;DR shape to the user's question:
+
+- **"What does this alert do?" / "Explain X"** — describe what fires:
+  > **TL;DR**: Fires when `<condition>` for `<scope>`, notifies
+  > `<channel>`. `<fire-frequency line>`.
+
+- **"Is it configured correctly?" / "Audit this" / "Anything I should
+  change?"** — lead with the **verdict and the top 1–3 changes**, not
+  the description of what fires:
+  > **TL;DR**: Mostly well-configured, but recommend: (1) add
+  > `alertOnAbsent` — currently a crashed service stays silent; (2)
+  > fix annotation template `{{$topic}}` → `{{$labels.topic}}` (won't
+  > interpolate); (3) split critical to PagerDuty (both tiers
+  > currently route to Slack). `<fire-frequency line>`.
+
+- **"How does X work?" / "Explain the count guard"** — answer the
+  mechanism in 1–2 sentences before any framing:
+  > **TL;DR**: The count guard is a `having: count() > 50` clause on
+  > query A — any 1-minute bucket with ≤50 spans is dropped before
+  > evaluation, so low-traffic minutes can't fire the alert.
+
+- **"What's the threshold?" / focused config question** — state the
+  exact thing they asked about:
+  > **TL;DR**: Threshold is **3 standard deviations** (z-score), not
+  > a raw rate value. Daily seasonality means the model compares
+  > each hour against historical norms for that hour.
+
+Always include the fire-frequency line and `disabled` status if
+non-default — those ground every kind of TL;DR. But put the answer to
+the user's specific question first.
+
+After the TL;DR, write the explanation in prose, organized into the
+four sections below. **Skip any section that has nothing meaningful to
+add** — empty severity labels, default notification settings, vanilla
+annotations don't deserve a header. Short and skimmable beats
+perfunctorily complete; the user is not reading a checklist.
+
+**1. What it watches** — one short paragraph. Combine signal type
+(metrics / logs / traces / exceptions), what the query measures, and
+scope. Translate the query to operational language; for formulas, name
+each sub-query (A, B, …) and state what F1 (or whichever
+`selectedQueryName` triggers) computes — e.g. "F1 = A × 100 / B → error
+percentage". Decode filter operators (`=` equals, `!=` not equals,
+`IN` / `NOT IN`, `LIKE` / `ILIKE`, `CONTAINS`, `REGEXP`, `EXISTS` /
+`NOT EXISTS`); enumerate `IN` / `NOT IN` value lists so the user can
+verify them. Name each `groupBy` dimension and its practical effect
+("fires separately per service" for `service.name`).
+
+For **anomaly rules** (`ruleType: anomaly_rule`), explicitly state that
+the threshold is in **standard deviations from the learned pattern, not
+the raw value** — this is the most common point of confusion. Include
+`algorithm` (zscore), `seasonality` (hourly / daily / weekly), and how
+lower/higher targets shift sensitivity (lower → more noise, higher →
+only extreme deviations).
+
+**2. When it fires** — one paragraph covering threshold + timing.
+Decode the threshold spec into plain English using these mappings:
+
+- `op` codes: `1` above, `2` below, `3` equal, `4` not equal.
+- `matchType` codes: `1` at_least_once (any point in window), `2`
+  all_the_times (entire window), `3` on_average (window average), `4`
+  in_total (window sum), `5` last (most recent point).
+
+State each threshold tier's `name`, `target`, `targetUnit`, and
+attached channels. **Always state the threshold in `targetUnit`, not
+the native query unit** (e.g. "fires when p99 exceeds 500 ms", not
+"…exceeds 500 000 000 ns"). Note `recoveryTarget` if set (hysteresis);
+if absent, mention flap risk when the value hovers near the boundary.
+Describe timing as "checks every `<frequency>` over the last
+`<evalWindow>`", and mention that with `at_least_once` a single-point
+breach triggers, while `all_the_times` requires the full window.
+
+**3. Where it notifies** — channels per tier (resolved by name from
+`signoz_list_notification_channels` if needed), `notificationSettings.groupBy`
+(how notifications are bundled), `renotify` (interval + which states),
+`usePolicy` (label-based routing). Skip this section entirely if
+notification settings are vanilla and the user already saw the channel
+in the TL;DR.
+
+**4. Notable concerns** — flag *only* what's non-default and worth the
+user's attention. Don't list every absent field; focus on the
+high-leverage ones:
+
+- **`alertOnAbsent` missing** when the signal is critical: silent data
+  loss (crashed service, broken instrumentation) won't trigger the
+  alert. Always call this out for production-tier rules.
+- **`alertOnAbsent: true` but `nodata` not in `renotify.alertStates`**:
+  the absent-data fire pages once and then goes silent — easy to miss.
+- **Template variable bugs**: `{{$topic}}` won't interpolate; the
+  correct form is `{{$labels.topic}}`. Dots in label keys become
+  underscores (`service.name` → `{{$labels.service_name}}`).
+- **Multiple severity tiers but `labels.severity` missing on the rule**
+  — breaks label-based routing policies. Common gap.
+- **All tiers route to the same channel** — defeats the point of
+  graduated thresholds.
+- **High-cardinality `groupBy`** (e.g. `pod.name` × `partition`) →
+  notification-storm risk during cluster-wide events.
+- **Annotation/description text contradicts `matchType`** (e.g.
+  description says "for over 5 minutes" but `matchType=at_least_once`
+  fires on first breach within the window).
+- **Alert name doesn't match the filter target** (e.g. name says
+  "checkout" but filter targets `payments`) — call this out.
+
+If none of these apply, omit the section. Better silent than padded.
+
+If the user asked only "what does this alert do", stop here. The audit
+(Step 5) is for "is it configured correctly" / "audit this" /
+"anything I should change" requests.
+
+### Step 5: Assess the configuration (only if asked)
+
+The user may ask "is this alert reasonable" alongside the explanation.
+Only assess when asked or when the request implies it (audit, review,
+"is this configured correctly"). Keep assessment grounded in what's
+actually in the config:
+
+- **Threshold calibration** — appropriate for the signal? Consider
+  service criticality and traffic.
+- **matchType fit** — `at_least_once` is sensitive (catches transients);
+  `all_the_times` is conservative; `on_average` smooths noise.
+- **Window vs frequency** — short window + `at_least_once` can be noisy.
+  Long window can delay detection.
+- **Multi-severity** — alerts with both warning and critical thresholds
+  enable graduated response. Single-severity alerts miss this.
+- **Notification routing** — critical → high-urgency channels (PagerDuty);
+  warning → low-urgency (Slack).
+- **Missing runbook / description** — if `annotations` are empty or
+  default, suggest adding context.
+- **Absent-data monitoring** — for critical signals, recommend
+  `alertOnAbsent: true` if it isn't set.
+- **GroupBy cardinality** — high-cardinality groupBy fields can produce
+  many independent alert series; flag potential notification storms.
+- **Filter completeness** — for `IN` / `NOT IN` filters with explicit
+  value lists, flag values that look out of place or missing values
+  that seem expected.
+- **Fire frequency vs threshold** — if Step 3 shows the alert fires
+  many times a day (>10/day in the 7d window), the threshold is likely
+  too tight; if it never fires and the user is asking because they
+  expected it to, the threshold may be too loose or the query may be
+  wrong.
+
+### Step 6: Offer next steps
+
+Surface up to 3 follow-up intents based on what the explanation
+revealed — things like investigating a recent fire, running the
+underlying query to see current values, adjusting a threshold, or
+creating a related alert for a coverage gap. Use your judgment; do
+not pad to 3.
+
+Skip follow-ups entirely when the user is purely inspecting ("what
+does this alert do?") and signals no further intent. No chips beat
+wrong chips.
+
+## Guardrails
+
+- **Fetch before explaining.** Always call `signoz:signoz_get_alert`. Do not
+  base explanations on the rule name or list response alone.
+- **Always pull fire history.** The one-line frequency summary is
+  cheap (one MCP call) and grounds the explanation. Skip it only if
+  the alert is disabled.
+- **Decode, don't dump.** Translate `op`, `matchType`, filter
+  expressions, and query JSON into operational language. Show raw JSON
+  only if the user asks.
+- **Decode every sub-query.** For formula alerts, explain each builder
+  query and the formula. Don't gloss over a formula as "error rate" —
+  show the user what A, B, and F1 each compute.
+- **Anchor to the actual config.** Don't speculate based on the alert
+  name. If the name says "checkout" but the filter targets `payments`,
+  call that out.
+- **No live queries by default.** Do not run the alert's query unless
+  the user asks. Explain is about understanding the rule, not
+  inspecting current data.
+- **Paginate alert listing.** Before concluding an alert does not
+  exist, walk every page of `signoz:signoz_list_alert_rules`.
+- **SigNoz evaluation model.** SigNoz uses `evalWindow` + `frequency`
+  + `matchType`, not Prometheus-style `for` durations. Don't describe
+  the evaluation model in Prometheus terms.
+- **Stay in scope.** Investigation of a specific fire window belongs
+  to `signoz-investigating-alerts`. Modifications belong to
+  `signoz:signoz_update_alert`.
+
+## Examples
+
+**User:** "Explain my checkout error rate alert"
+
+**Agent:**
+1. `signoz:signoz_list_alert_rules` (paginated) → finds "High Error Rate —
+   Checkout" id 42.
+2. `signoz:signoz_get_alert id=42` → traces formula (A errored spans / B
+   total spans × 100), single critical threshold at 5%, `op=1`,
+   `matchType=1`, channel `pagerduty-oncall`.
+3. `signoz:signoz_get_alert_history id=42 lookback=7d` → fired 3 times,
+   last fire 2h ago.
+4. Replies:
+
+   > **TL;DR**: Fires when checkout error rate (errored spans / total
+   > spans) exceeds 5% at any point in the last 5 min, pages
+   > `pagerduty-oncall`. Fired 3 times in the last 7d (last 2h ago).
+   >
+   > **What it watches** — traces from `service.name = 'checkout'`.
+   > Query A counts spans with `hasError = true`, query B counts all
+   > spans, F1 = A × 100 / B is the error percentage; the alert
+   > triggers on F1.
+   >
+   > **When it fires** — `op=above`, `matchType=at_least_once`, target
+   > 5%. Checks every 1 min over the last 5 min — a single elevated
+   > minute fires it.
+   >
+   > **Notable** — no `recoveryTarget` (could flap near 5%); no
+   > `alertOnAbsent` (a checkout outage that drops traffic to zero
+   > won't trigger this rule).
+
+5. Offers: "Want me to investigate the fire from 2h ago?"
+
+---
+
+**User:** "Explain alert rule 17 — is it well configured?"
+
+**Agent:**
+1. `signoz:signoz_get_alert id=17` → metrics, `system.cpu.utilization`,
+   two thresholds (warning 80%, critical 90%), `matchType=3` on_average,
+   filter `deployment.environment.name = 'production'`, groupBy
+   `host.name`.
+2. `signoz:signoz_get_alert_history id=17` → has not fired in last 7d.
+3. The user asked "is it well configured?" — the TL;DR leads with the
+   **verdict**, not a generic description. Then explanation + full
+   audit:
+
+   > **TL;DR**: Mostly well-configured (dual-threshold + `on_average`
+   > is the right call for CPU), but two gaps to fix: (1) no
+   > `alertOnAbsent` — a crashed agent silently stops reporting and
+   > this rule won't catch it; (2) annotations are default — a
+   > runbook URL would help on-call. Has not fired in the last 7d
+   > (could mean production is healthy or thresholds too loose).
+   >
+   > **What it watches** — `system.cpu.utilization` on
+   > `deployment.environment.name = 'production'`, grouped by
+   > `host.name` (fires per host).
+   >
+   > **When it fires** — `op=above`, `matchType=on_average`, two tiers
+   > (warning 80%, critical 90%) over a 5-min window. Short spikes
+   > don't fire — smoothing is correct for CPU.
+   >
+   > **Notable concerns** — same as TL;DR fixes above; nothing else
+   > non-default.
+
+4. Offers next steps.
+
+---
+
+**User:** "Help me understand this anomaly detection alert" (alert id 88)
+
+**Agent:**
+1. `signoz:signoz_get_alert id=88` → `ruleType: anomaly_rule`,
+   `algorithm=zscore`, `seasonality=daily`, target 3, metric
+   `http.server.request.duration`, scope `service.name = 'api-gateway'`.
+2. History: fired 1 time in last 7d.
+3. Replies:
+
+   > **TL;DR**: Fires when api-gateway request latency deviates by more
+   > than **3 standard deviations** (not raw latency, not a fixed value)
+   > from its learned daily pattern. Fired once in the last 7d.
+   >
+   > **What it watches** — `http.server.request.duration` for
+   > `service.name = 'api-gateway'`, evaluated as a Z-score anomaly
+   > with **daily seasonality** — the model learns the typical pattern
+   > for each hour of day, so peak-hour latency won't false-trigger if
+   > it matches the historical norm for that hour.
+   >
+   > **When it fires** — when |Z-score| > 3, i.e. the value is more
+   > than 3 standard deviations away from the expected pattern. Lower
+   > target → more sensitive (more noise); higher → only extreme
+   > deviations. The threshold is **not** in seconds or milliseconds.
+
+4. Offers to investigate the recent fire.

--- a/skills/signoz-explaining-alerts/evals/evals.json
+++ b/skills/signoz-explaining-alerts/evals/evals.json
@@ -1,0 +1,40 @@
+{
+  "skill_name": "signoz-explaining-alerts",
+  "evals": [
+    {
+      "id": 0,
+      "eval_name": "fuzzy-match-audit",
+      "prompt": "Explain my checkout error rate alert. Is it configured correctly?",
+      "expected_output": "Agent paginates signoz_list_alert_rules to find candidates (multiple 'checkout-svc Error Rate > 3%' rules + eval-1 alerts exist on staging). Surfaces ambiguity and either asks user or picks closest with a clear assumption note. Then signoz_get_alert + signoz_get_alert_history (7d), produces structured explanation (Overview, Query breakdown — including the formula A*100/B, Threshold, Evaluation, Notification, Labels), AND performs the audit (Step 5) since user asked 'configured correctly'.",
+      "files": []
+    },
+    {
+      "id": 1,
+      "eval_name": "formula-having-decode",
+      "prompt": "What does alert 019de287-a765-7c80-93e7-f2f0f2f5f927 do? Specifically explain how the count guard works and what conditions trigger a fire.",
+      "expected_output": "Agent calls signoz_get_alert directly with the rule ID. Decodes the 3-query structure: A=p99(duration_nano) WITH having: count()>50, B=count() (disabled), F1=A pass-through. Explains that the having clause is the count guard — it suppresses any 1-minute bucket where span count <= 50, so the threshold evaluator sees no data for those buckets and cannot fire. Translates op=above + matchType=on_average + target=1s into plain language. Pulls fire history.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "eval_name": "anomaly-threshold-explain",
+      "prompt": "Help me understand alert rule 019de287-6752-7629-83e4-375919d56dd8 — I'm confused about how anomaly thresholds work versus regular ones.",
+      "expected_output": "Agent fetches the rule, identifies ruleType=anomaly_rule, and explicitly contrasts anomaly vs threshold semantics: target=3 means 3 standard deviations from the learned baseline, NOT 3 raw req/s. Explains daily seasonality: the baseline adapts to hour-of-day patterns. Mentions z-score algorithm. Notes that lower target = more sensitive (more noise). Pulls fire history. Section order from skill (Anomaly specifics) followed.",
+      "files": []
+    },
+    {
+      "id": 3,
+      "eval_name": "url-parse-panic-logs",
+      "prompt": "What does this alarm fire on? https://us2.staging.signoz.cloud/alerts/edit?ruleId=019dad90-1754-770f-8dae-d28a897167e3",
+      "expected_output": "Agent extracts ruleId from the URL query string, calls signoz_get_alert, identifies as LOGS_BASED_ALERT for 'Payments service panic logs'. Decodes the body filter (panic / fatal / etc keywords), groupBy, threshold target=0/at_least_once (any panic log fires it). Pulls fire history. Explains in plain language without dumping the JSON.",
+      "files": []
+    },
+    {
+      "id": 4,
+      "eval_name": "multi-severity-audit-kafka",
+      "prompt": "Audit alert 019dad90-1c73-715e-b040-79901928deb2 (kafka consumer lag) — anything I should change?",
+      "expected_output": "Agent fetches the rule, decodes the multi-severity threshold spec (warning at lag >= 50, critical at >= 200), explains the tiered routing. Performs Step 5 audit: flags missing labels.severity (rule has no severity label even though thresholds have severity tiers), considers groupBy cardinality, evaluates threshold calibration, suggests adding severity label, runbook annotations, alertOnAbsent if relevant. Pulls fire history.",
+      "files": []
+    }
+  ]
+}

--- a/skills/signoz-explaining-dashboards/SKILL.md
+++ b/skills/signoz-explaining-dashboards/SKILL.md
@@ -1,0 +1,206 @@
+---
+name: signoz-explaining-dashboards
+description: >
+  Explain what an existing SigNoz dashboard shows in plain operational
+  language — the panels, queries, variables, and what to watch for on
+  each. Make sure to use this skill whenever the user asks "explain this
+  dashboard", "what does my [X] dashboard show", "walk me through the
+  panels", "what should I watch for on this dashboard", or "help me
+  understand this dashboard", or otherwise asks for an interpretation of
+  a dashboard's contents — even if they don't say "explain" explicitly.
+  Also use it when someone is onboarding to a service and wants to
+  understand what its existing observability looks like.
+---
+
+# Dashboard Explain
+
+## Prerequisites
+
+This skill calls SigNoz MCP server tools (`signoz:signoz_get_dashboard`,
+`signoz:signoz_list_dashboards`). Before running the workflow, confirm the
+`signoz:signoz_*` tools are available. If they are not, the SigNoz MCP server
+is not installed or configured — run `signoz-mcp-setup` first to initialize or
+repair the MCP connection. Do not guess at a dashboard's contents from its
+title alone.
+
+## When to use
+
+Use this skill when the user asks to:
+- Understand, explain, or interpret an existing dashboard
+- Get a walkthrough of what panels show and why they matter
+- Know what to watch for or what healthy/unhealthy looks like on a dashboard
+- Understand the variables, filters, or queries on a dashboard
+
+Do NOT use when:
+- User wants to modify an existing dashboard → `signoz-modifying-dashboards`
+
+## Instructions
+
+### Step 1: Identify the target dashboard
+
+Determine which dashboard the user wants explained. If the user provides a
+dashboard name, UUID, or it is clear from context (e.g., an @mention or
+auto-context providing a dashboard resource), use that.
+
+If the target dashboard is ambiguous:
+1. Call `signoz:signoz_list_dashboards` to list existing dashboards. **Paginate through
+   all pages** — check `pagination.hasMore` in the response. If `hasMore` is true,
+   call again with `offset` set to `pagination.nextOffset` and repeat until all
+   pages are exhausted. Never stop at the first page.
+2. Present matching candidates to the user and ask which one to explain.
+
+### Step 2: Fetch the full dashboard configuration
+
+Call `signoz:signoz_get_dashboard` with the dashboard UUID. This is **mandatory** — you
+need the complete JSON to explain the dashboard accurately. Never guess based on
+the title alone.
+
+Examine the response to understand:
+- `title`, `description`, `tags` — the dashboard identity and author-provided context
+- `variables` — dashboard-level filters (dropdowns the user can change)
+- `widgets` — the panels, their types, titles, and queries
+- `layout` — how panels are arranged in the 12-column grid
+- `panelMap` — which panels belong to which row sections
+
+### Step 3: Build the explanation
+
+Structure your explanation in this order:
+
+**1. Overview** — One paragraph summarizing the dashboard's purpose, what it
+monitors, and what data sources it draws from (metrics, traces, logs). Mention
+the `tags` if they provide useful context.
+
+**2. Variables and filters** — Explain each variable:
+- Name and what it filters (e.g., "The `service_name` variable filters all panels
+  to a specific service")
+- Type: DYNAMIC (auto-populated from telemetry), QUERY (SQL-driven dropdown), or
+  TEXTBOX (free-form input)
+- Whether it supports multi-select and has "ALL" option
+- Note if any panels do NOT reference a variable in their filters — changing that
+  variable dropdown would not affect those panels, which can be confusing
+
+**3. Panel-by-panel walkthrough** — Group panels by their row sections using the
+`panelMap` structure (row widget titles are the section headers). If the dashboard
+has no rows (empty `panelMap`), walk through panels in layout order (by `y` then
+`x` position) and organize by logical theme. For each panel:
+- **Title** and **panel type** (graph, value, table, bar, pie, histogram, list)
+- **What it shows** — interpret the query in plain language. For builder queries,
+  explain the metric/data source, aggregation, filters, and groupBy. For formulas,
+  explain each sub-query and how the formula combines them. For ClickHouse SQL or
+  PromQL, translate the query intent into plain English.
+- **What to watch for** — describe what healthy looks like and what patterns
+  indicate trouble. Be specific: "sustained usage above 80% means..." not just
+  "watch if it's high". Anchor advice to the actual metric being queried, not
+  generic domain knowledge.
+- **Unit** — mention the y-axis unit so the user knows how to read the values
+
+For panels with complex queries:
+- **Formulas** (queryFormulas): explain each sub-query (A, B, ...) separately,
+  then explain what the formula computes and why
+- **Multiple queries on one panel**: explain each query and how they relate
+- **Functions** (rate, derivative, clampMin/Max, timeShift): explain the transform
+  in plain terms (e.g., "rate converts the raw counter into a per-second value")
+
+**4. Dashboard health observations** — After the walkthrough, note any structural
+issues you spotted:
+- Panels with no queries or empty/disabled queries
+- Variables defined but not referenced in any panel filter
+- Panels missing thresholds where they would be useful (e.g., utilization panels
+  without a saturation warning line)
+- Counters displayed without a rate function (raw counters produce ever-increasing
+  ramps, not operational rates)
+- Very wide step intervals that could hide spikes
+- Panels with high-cardinality groupBy that may produce unreadable charts
+
+**5. Coverage gaps** — Based on what the dashboard actually monitors, note
+significant observability areas that are absent. Only mention gaps that are
+directly related to the technology or domain the dashboard covers — do not
+speculate about unrelated areas. Frame as suggestions: "You may want to consider
+adding panels for X to cover Y."
+
+### Step 4: Offer next steps
+
+Surface up to 3 follow-up intents based on what the explanation
+surfaced — things like running a specific panel's underlying query,
+filling a coverage gap, or wiring an alert for an actionable threshold
+the user has not yet alerted on. Use your judgment; do not pad to 3.
+
+Skip follow-ups when the user was clearly just onboarding to the
+dashboard ("what is this?") and showed no further intent. No chips
+beat wrong chips.
+
+## Guardrails
+
+- **Fetch before explaining**: Always call `signoz:signoz_get_dashboard` to get the full
+  configuration. Never explain based on the dashboard title or listing alone.
+- **Interpret, don't dump**: Translate queries into plain operational language. Never
+  show raw query JSON to the user unless they specifically ask.
+- **Anchor to actual content**: Base "what to watch for" advice on the actual metrics
+  and queries in the dashboard, not on generic domain knowledge unrelated to the
+  panels present.
+- **Group by sections**: Use the `panelMap` row structure to group panels, not layout
+  coordinates. The row titles are the section headers the dashboard author intended.
+- **No data queries by default**: Do not run live queries unless the user asks. The
+  explain skill is about understanding the dashboard structure, not inspecting
+  current data.
+- **Paginate dashboard listing**: When searching for a dashboard by name, always
+  paginate through all pages of `signoz:signoz_list_dashboards` before concluding a
+  dashboard does not exist.
+- **All query types**: Handle builder, ClickHouse SQL, and PromQL queries — each
+  requires a different interpretation approach. For builder queries, read the
+  aggregations, filter expression, and groupBy. For raw SQL/PromQL, parse the
+  query string and explain the intent.
+- **Scope boundary**: This skill explains dashboards. If the user wants to change
+  something after your explanation, redirect to `signoz-modifying-dashboards`.
+
+## Examples
+
+**User:** "Explain my PostgreSQL dashboard"
+
+**Agent:**
+1. Calls `signoz:signoz_list_dashboards` (paginates all pages) — finds "PostgreSQL
+   Overview" dashboard with UUID `abc-123`.
+2. Calls `signoz:signoz_get_dashboard` with UUID `abc-123` — gets full configuration.
+3. Provides structured explanation:
+   - **Overview**: "This dashboard monitors PostgreSQL database health across
+     connections, query performance, buffer cache efficiency, and replication. It
+     uses metrics from the OpenTelemetry PostgreSQL receiver."
+   - **Variables**: "Two variables — `host_name` (DYNAMIC, filters by
+     `host.name`) and `database` (DYNAMIC, filters by `postgresql.database.name`).
+     Both support multi-select."
+   - **Panels by section**: Walks through each row section, explaining every panel's
+     metric, aggregation, and what to watch for.
+   - **Health observations**: "The 'Connection Count' panel has no threshold
+     configured — consider adding a line at 80% of your max_connections."
+   - **Coverage gaps**: "No panels for vacuum/autovacuum health or lock contention.
+     Consider adding these if you manage write-heavy workloads."
+4. Offers: "Want me to run any panel queries to check for data, or add the
+   suggested panels?"
+
+---
+
+**User:** "What does each panel on this dashboard show?" (with dashboard context
+provided via @mention or auto-context)
+
+**Agent:**
+1. Extracts dashboard UUID from the provided context.
+2. Calls `signoz:signoz_get_dashboard` — gets full configuration.
+3. Provides a focused panel-by-panel walkthrough grouped by row sections,
+   explaining what each panel shows and what to watch for.
+4. Skips the health/gaps sections unless something notable stands out, since the
+   user asked specifically about panels.
+
+---
+
+**User:** "Help me understand this LLM monitoring dashboard — I'm new to it"
+
+**Agent:**
+1. Identifies the dashboard, fetches full config.
+2. Provides a beginner-friendly explanation with more context per panel:
+   - Explains what the metrics mean (e.g., "Token usage measures how many
+     tokens your LLM calls consume, which directly impacts cost")
+   - Explains what the variables control and recommends starting with the "ALL"
+     option to see the full picture before filtering
+   - Highlights the most important panels to watch daily vs. those useful only
+     during debugging
+3. Offers to set up alerts on critical panels.

--- a/skills/signoz-explaining-dashboards/evals/evals.json
+++ b/skills/signoz-explaining-dashboards/evals/evals.json
@@ -1,0 +1,55 @@
+{
+  "skill_name": "signoz-explaining-dashboards",
+  "evals": [
+    {
+      "id": 1,
+      "name": "redis-full-explain",
+      "prompt": "Can you walk me through my 'Redis - Overview' dashboard? Want to understand what each panel shows and what to keep an eye on.",
+      "expected_output": "Structured explanation of the Redis dashboard: overview, the host variable, panels grouped by row sections (About Redis, Overview, Performance Metrics, Memory Metrics, Base Activity Metrics, Logs), what to watch for per panel, and any health observations. Should notice that several panels have disabled queries and that some panels reuse the same hit-rate formula.",
+      "files": [],
+      "assertions": [
+        {"id": "a1", "text": "Output includes a high-level overview describing the dashboard's purpose (monitoring Redis)"},
+        {"id": "a2", "text": "Output names the 'host' variable AND identifies it as DYNAMIC"},
+        {"id": "a3", "text": "Output groups panels using the dashboard's row sections (About Redis, Overview, Performance Metrics, Memory Metrics, Base Activity Metrics, Logs)"},
+        {"id": "a4", "text": "Output explains the cache hit-rate formula (A / (A + B)) * 100 in plain language"},
+        {"id": "a5", "text": "Output gives 'what to watch for' guidance specific to Redis (mentions at least one of: evictions, fragmentation ratio, replication lag, blocked clients, slowlog)"},
+        {"id": "a6", "text": "Output flags at least one structural issue: disabled queries on multiple panels, duplicate Cache hit rate panels, or 'Hit rate'/'Cache hit rate' shown as 'value' panel-type instead of graph"},
+        {"id": "a7", "text": "Output does NOT dump raw dashboard JSON or large query objects"},
+        {"id": "a8", "text": "Output ends with concrete next-step offers (e.g., run queries, add panels/thresholds, modify dashboard)"}
+      ]
+    },
+    {
+      "id": 2,
+      "name": "jvm-beginner-walkthrough",
+      "prompt": "I'm new to JVM monitoring — help me understand my 'JVM Metrics Dashboard'. What do these metrics actually mean and which panels matter most for day-to-day vs. debugging?",
+      "expected_output": "Beginner-friendly explanation: explains what JVM heap, GC, threads, and class loading actually mean in plain language, walks through the value panels (heap used, threads, CPU, classes), then the time-series and the memory-pool table, and clearly distinguishes daily-watch panels from debugging-only panels. Should mention the service_name TEXTBOX variable.",
+      "files": [],
+      "assertions": [
+        {"id": "a1", "text": "Output explains in beginner-friendly terms what JVM heap memory means"},
+        {"id": "a2", "text": "Output explains in beginner-friendly terms what garbage collection (GC) means"},
+        {"id": "a3", "text": "Output names the 'service_name' variable AND identifies it as TEXTBOX"},
+        {"id": "a4", "text": "Output explicitly distinguishes which panels matter for daily watch vs debugging-only (the prompt asked for this)"},
+        {"id": "a5", "text": "Output walks through the four value panels (heap used, threads, CPU, classes)"},
+        {"id": "a6", "text": "Output mentions the Memory Pool Details table groups by jvm_memory_type and jvm_memory_pool_name"},
+        {"id": "a7", "text": "Output mentions that GC Duration uses a rate aggregation (not raw counter)"},
+        {"id": "a8", "text": "Output does NOT dump raw dashboard JSON or large query objects"}
+      ]
+    },
+    {
+      "id": 3,
+      "name": "otel-collector-watch-for",
+      "prompt": "explain the OpenTelemetry Collector Metrics Dashboard to me — specifically I want to know what I should be watching for and whether there are any obvious gaps or problems with how it's set up",
+      "expected_output": "Explanation focused on what to watch for and structural observations of the large 65-widget dashboard. Should group panels by the 7 row sections, surface key health indicators (e.g., dropped spans/metrics, queue size, exporter failures), and flag structural issues like counters without rate, missing thresholds, or unused variables.",
+      "files": [],
+      "assertions": [
+        {"id": "a1", "text": "Output groups panels by row sections (the dashboard has 7 rows)"},
+        {"id": "a2", "text": "Output highlights at least 3 critical things to watch (e.g., dropped spans/metrics, queue size, exporter failures, memory limiter, refused items, batch send failures)"},
+        {"id": "a3", "text": "Output surfaces structural observations or gaps (e.g., counters without rate function, missing thresholds, unused variables, very wide step intervals, high-cardinality groupBy, or duplicate panels)"},
+        {"id": "a4", "text": "Output mentions both variables on the dashboard"},
+        {"id": "a5", "text": "Output does NOT dump raw dashboard JSON or large query objects"},
+        {"id": "a6", "text": "Output is well-organized despite the 65 widgets — does not enumerate every panel as a flat list with no grouping"},
+        {"id": "a7", "text": "Output addresses both parts of the prompt: what to watch AND structural problems/gaps"}
+      ]
+    }
+  ]
+}

--- a/skills/signoz-generating-queries/SKILL.md
+++ b/skills/signoz-generating-queries/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: signoz-generating-queries
+description: >
+  Generate, write, or run an ad-hoc query against SigNoz observability
+  data — metrics, logs, traces, or exceptions — without wrapping it in
+  a dashboard panel or alert. Make sure to use this skill whenever the
+  user asks "show me error rates", "query logs for timeout errors",
+  "what's the p99 latency for the cart service", "how many requests hit
+  the payment endpoint", "find slow traces", "errors in the last hour",
+  or otherwise asks an exploratory question that needs live observability
+  data — even if they don't say "query" or "search" explicitly.
+---
+
+# Query Generate
+
+## Prerequisites
+
+This skill calls SigNoz MCP server tools heavily (`signoz:signoz_execute_builder_query`,
+`signoz:signoz_query_metrics`, `signoz:signoz_search_logs`, `signoz:signoz_search_traces`,
+`signoz:signoz_aggregate_logs`, `signoz:signoz_aggregate_traces`, `signoz:signoz_get_field_keys`,
+`signoz:signoz_get_field_values`, `signoz:signoz_list_metrics`, `signoz:signoz_list_services`,
+`signoz:signoz_get_service_top_operations`, `signoz:signoz_get_trace_details`). Before
+running the workflow, confirm the `signoz:signoz_*` tools are available. If they
+are not, run `signoz-mcp-setup` first to initialize or repair the MCP connection.
+Do not fall back to raw HTTP calls or fabricate query results without the MCP
+tools.
+
+## When to use
+
+Use this skill when the user asks to:
+- Query, search, or look up observability data (traces, logs, metrics)
+- Compute aggregations (error rate, p99 latency, request count, throughput)
+- Find specific log entries, traces, or metric values
+- Investigate patterns (spikes, drops, trends over time)
+
+Do NOT use when:
+- User wants raw ClickHouse SQL for a dashboard panel (custom joins, window
+  functions, regex over log bodies) — that's a separate dashboard-panel SQL
+  workflow, not this skill.
+
+## Instructions
+
+### Step 1: Determine the signal type
+
+Map the user's intent to the right signal:
+
+| User intent | Signal | Why |
+|---|---|---|
+| Error rate, latency, throughput, request count | **metrics** (preferred) or **traces** | Metrics are pre-aggregated and fastest. Use traces if the user needs per-request detail or no matching metric exists. |
+| p50/p75/p90/p95/p99 latency | **metrics** (histogram) or **traces** (aggregate on `durationNano`) | Prefer metrics if a histogram metric exists (e.g., `signoz_latency_bucket`). Fall back to trace aggregation. |
+| Find specific log entries, error messages, stack traces | **logs** | Text search, pattern matching, severity filtering. |
+| Find specific traces, slow requests, error spans | **traces** | Per-request detail, span attributes, duration filtering. |
+| Infrastructure metrics (CPU, memory, disk, network) | **metrics** | Always metrics for resource utilization. |
+| "How many X per Y" (count/rate grouped by dimension) | **traces** or **logs** (aggregate) | Use `signoz:signoz_aggregate_traces` or `signoz:signoz_aggregate_logs` for grouped counts. |
+
+If the signal is genuinely ambiguous, ask the user before proceeding. The
+host application decides how the question is surfaced (e.g. a structured
+clarification tool or an inline `<assistant_question>` tag) — follow the
+host's UI rendering rules.
+
+### Step 2: Discover available data
+
+**Always discover before querying.** Use only names returned by tools — never
+guess from training knowledge.
+
+Run discovery calls in parallel where possible:
+
+- **For metrics**: Call `signoz:signoz_list_metrics` with a `searchText` substring
+  matching the user's intent (e.g., `searchText: "http"`, `searchText: "latency"`).
+  The response includes metric type, temporality, and isMonotonic — pass these to
+  `signoz:signoz_query_metrics` to avoid extra lookups.
+- **For traces**: Call `signoz:signoz_list_services` to confirm the service name exists.
+  Optionally call `signoz:signoz_get_service_top_operations` for the service to find
+  operation names. Call `signoz:signoz_get_field_keys(signal: "traces")` if you need
+  to filter on a non-standard attribute.
+- **For logs**: Call `signoz:signoz_get_field_keys(signal: "logs")` if filtering on
+  attributes beyond `body`, `severity_text`, and `service.name`. Call
+  `signoz:signoz_get_field_values` to validate specific filter values.
+
+If the user already provides exact field names, service names, or metric names
+from context (e.g., from a dashboard or @mention), skip redundant discovery.
+
+### Step 3: Choose the right tool
+
+**Use the simplest tool that answers the question:**
+
+| Question type | Tool | When to use |
+|---|---|---|
+| Metric time series or scalar | `signoz:signoz_query_metrics` | Any metrics query. Handles aggregation defaults automatically. Supports formulas via `formula` + `formulaQueries` params. |
+| Log search (find matching entries) | `signoz:signoz_search_logs` | Finding specific log lines. Use `searchText` for body text, `query` for field filters, `severity` for level filtering. |
+| Trace search (find matching spans) | `signoz:signoz_search_traces` | Finding specific traces/spans. Use `service`, `operation`, `error`, `minDuration`/`maxDuration` shortcuts plus `query` for field filters. |
+| Log aggregation (count, avg, percentiles) | `signoz:signoz_aggregate_logs` | "How many errors?", "error count by service", "p99 response time from logs". Set `requestType` to `scalar` for totals or `time_series` for trends. |
+| Trace aggregation (count, avg, percentiles) | `signoz:signoz_aggregate_traces` | "p99 latency for checkout", "error count per operation", "request rate by endpoint". Set `requestType` to `scalar` for totals or `time_series` for trends. |
+| Complex multi-query or formula | `signoz:signoz_execute_builder_query` | Only when the simpler tools above cannot express the query — e.g., joining multiple data sources, complex filter expressions, or queries needing the full Query Builder v5 schema. Read `signoz://traces/query-builder-guide` before using. |
+
+**`requestType` decision for aggregations:**
+- `scalar` (default): "How many?", "What is the p99?", "Which service has the most?"
+- `time_series`: "When did errors spike?", "How did latency change?", "Show trend"
+- If the question has ANY temporal component (spike, trend, change), use `time_series`
+
+### Step 4: Execute the query
+
+- Always include `searchContext` with the user's original question — it improves
+  result relevance.
+- Default time range is last 1 hour. Respect the user's time range if specified.
+  Convert relative times ("last 6 hours", "yesterday") to `timeRange` param format
+  (e.g., `6h`, `24h`) or Unix millisecond `start`/`end`.
+- Use shortcut parameters (`service`, `severity`, `operation`, `error`) when they
+  match the user's filters — they are simpler and less error-prone than building
+  `query` expressions.
+- Combine shortcut params with `query`/`filter` for additional constraints — they
+  are ANDed together.
+- For `signoz:signoz_query_metrics`, pass `metricType`, `temporality`, and `isMonotonic`
+  from the `signoz:signoz_list_metrics` response to avoid an extra auto-fetch round trip.
+
+### Step 5: Handle results
+
+**Data returned:**
+- Present findings as neutral observations with timestamps and values.
+- Include the time range in your response.
+- For aggregations with `groupBy`, highlight the top entries and mention total
+  group count if truncated by `limit`.
+- For search results, summarize patterns rather than listing every entry.
+
+**No data returned — apply three-way distinction:**
+1. **Healthy zero**: The query ran successfully but the count is zero. Say so:
+   "No errors found for checkout-service in the last hour — error count is zero."
+2. **No data in range**: The field/metric exists but no data points fall in the
+   time window. Suggest expanding: "No data in the last hour. Try a wider range?"
+3. **Missing instrumentation**: The metric, field, or service doesn't exist in
+   discovery results. Say what's missing and suggest how to instrument.
+
+**Drill-down:**
+- If an aggregation reveals an interesting pattern (spike, outlier service),
+  offer to drill into individual traces or logs for that scope.
+- If a trace search returns interesting spans, offer to fetch full trace details
+  via `signoz:signoz_get_trace_details`.
+
+## Guardrails
+
+- **Discovery first**: Never guess metric names, field names, or service names.
+  Use discovery tools or context to confirm they exist before querying.
+- **Never claim root cause**: Present data patterns and correlations. Write
+  "Error rate for checkout increased from 0.2% to 4.1% at 14:05" not "The
+  deployment caused the errors."
+- **One focused query per question**: Do not scatter-shot multiple queries when
+  one precise query answers the question. Use parallel discovery calls, but be
+  precise for execution.
+- **Respect MCP server rules**: The MCP server enforces rules about resource
+  attribute filters, filter operators, and redundant queries. Follow them —
+  especially preferring resource attributes in filters for faster queries.
+- **No raw ClickHouse SQL**: Always use the Query Builder tools. Never construct
+  raw SQL.
+- **Scope boundary**: This skill queries data. If the user wants to wrap the
+  query into a recurring alert, redirect to `signoz-creating-alerts`.
+- **Emit `apply_filter` on the final message.** When the user asks you to
+  write, build, generate, or show a query, include an `apply_filter` action
+  on your final assistant message with the resolved `compositeQuery` from
+  the tool result and the appropriate `signal` field (`metrics`, `logs`, or
+  `traces`). This signals to the SigNoz UI that the user wants to apply the
+  query to an explorer page. Only emit `apply_filter` when the user's primary
+  intent is to obtain a runnable query — not when the user is asking a
+  one-shot data question that the analysis text already answers.
+
+## Examples
+
+**User:** "Show me the error rate for the checkout service in the last hour"
+
+**Agent:**
+1. Calls `signoz:signoz_list_metrics(searchText: "error")` — finds
+   `signoz_calls_total` metric.
+2. Calls `signoz:signoz_query_metrics` with `metricName: "signoz_calls_total"`,
+   `filter: "service.name = 'checkout'"`, `formula: "A / B * 100"` where A is
+   error count and B is total count, `timeRange: "1h"`.
+3. Presents: "Error rate for checkout-service: 2.3% over the last hour (14:00–
+   15:00 UTC). 47 errors out of 2,041 total requests."
+4. Offers drill-down: "Want me to check which operations have the highest error
+   rate?"
+
+---
+
+**User:** "Find timeout errors in logs"
+
+**Agent:**
+1. Calls `signoz:signoz_search_logs(searchText: "timeout", severity: "ERROR",
+   timeRange: "1h")`.
+2. Presents: "Found 23 timeout errors in the last hour. Most are from
+   payment-service (18) and gateway (5). Common pattern: 'context deadline
+   exceeded' in gRPC calls to downstream-api."
+3. Offers: "Want me to check traces for these services to see where the
+   timeouts occur?"
+
+---
+
+**User:** "What's the p99 latency for the cart service?"
+
+**Agent:**
+1. Calls `signoz:signoz_aggregate_traces(aggregation: "p99",
+   aggregateOn: "durationNano", service: "cart-service",
+   requestType: "scalar", timeRange: "1h")`.
+2. Presents: "p99 latency for cart-service: 1.2s over the last hour."
+3. Offers: "Want me to break this down by operation or show the trend over time?"
+
+---
+
+**User:** "When did errors spike for the frontend?"
+
+**Agent:**
+1. Calls `signoz:signoz_aggregate_traces(aggregation: "count", error: "true",
+   service: "frontend", requestType: "time_series", timeRange: "6h")`.
+2. Presents: "Error count for frontend over the last 6 hours. Spike at 11:30 UTC
+   — error count jumped from ~5/min to ~45/min, returning to baseline by 12:15."
+3. Offers: "Want me to check what error types appeared during the spike?"

--- a/skills/signoz-generating-queries/evals/evals.json
+++ b/skills/signoz-generating-queries/evals/evals.json
@@ -1,0 +1,40 @@
+{
+  "skill_name": "signoz-generating-queries",
+  "evals": [
+    {
+      "id": 0,
+      "eval_name": "metrics-error-rate-service",
+      "prompt": "Show me the error rate for the checkout-service over the last hour.",
+      "expected_output": "Agent runs metrics discovery (signoz_list_metrics) then queries an error-rate metric (e.g., signoz_calls_total) with service filter and a ratio formula. Reports the rate with the time window, or correctly handles a no-data / missing-instrumentation case.",
+      "files": []
+    },
+    {
+      "id": 1,
+      "eval_name": "logs-text-search-timeouts",
+      "prompt": "Find timeout errors in the payment service logs from the last 6 hours.",
+      "expected_output": "Agent uses signoz_search_logs with searchText for 'timeout', severity=ERROR, service=payment, timeRange=6h. Does NOT use aggregation tools. Summarizes patterns rather than dumping every line.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "eval_name": "traces-p99-latency-by-operation",
+      "prompt": "What's the p99 latency for cart-service broken down by operation in the last 30 minutes?",
+      "expected_output": "Agent uses signoz_aggregate_traces with aggregation=p99, aggregateOn=durationNano, service=cart-service, groupBy includes operation/name, requestType=scalar, timeRange=30m. Reports top operations by p99.",
+      "files": []
+    },
+    {
+      "id": 3,
+      "eval_name": "traces-time-series-error-spike",
+      "prompt": "When did errors spike for the frontend service today?",
+      "expected_output": "Agent uses signoz_aggregate_traces with error=true, service=frontend, requestType=time_series (NOT scalar — temporal question), aggregation=count, time window covers today. Identifies the spike timestamp.",
+      "files": []
+    },
+    {
+      "id": 4,
+      "eval_name": "ambiguous-broad-investigation",
+      "prompt": "My users are reporting the app is slow, can you investigate?",
+      "expected_output": "Agent does NOT scatter-shot many queries. Either asks a clarifying question to scope (which service/endpoint/time) OR starts with one focused overview query (e.g., overall p99 latency or error rate by service) and presents findings before drilling.",
+      "files": []
+    }
+  ]
+}

--- a/skills/signoz-investigating-alerts/SKILL.md
+++ b/skills/signoz-investigating-alerts/SKILL.md
@@ -1,0 +1,478 @@
+---
+name: signoz-investigating-alerts
+description: >
+  Diagnose why a SigNoz alert fired by correlating the alert's own signal
+  with neighbor signals (error rate, latency, throughput, CPU/memory),
+  traces, and logs around the fire window — and rank likely causes.
+  Make sure to use this skill whenever the user asks "why did this alert
+  fire", "what caused alert X", "investigate this alert", "RCA for the
+  alert that paged me", "what's wrong with [service]" in the context of
+  a recent fire, or otherwise asks for a root-cause analysis of a
+  firing or recently-fired alert. Read-only — does not modify any
+  alert or notification.
+argument-hint: <alert name or rule id> [time window]
+---
+
+# Alert Investigate
+
+Diagnose why a SigNoz alert fired. The skill correlates the alert's own
+signal with neighbor signals around the fire window, and surfaces a
+ranked list of likely causes with supporting evidence. It is the
+companion to `signoz-explaining-alerts` — explain decodes the rule
+statically; investigate diagnoses a specific incident.
+
+## Prerequisites
+
+This skill calls SigNoz MCP server tools heavily (`signoz:signoz_get_alert`,
+`signoz:signoz_get_alert_history`, `signoz:signoz_execute_builder_query`,
+`signoz:signoz_query_metrics`, `signoz:signoz_search_traces`, `signoz:signoz_search_logs`,
+`signoz:signoz_get_trace_details`, etc.). Before running the workflow,
+confirm the `signoz:signoz_*` tools are available. If they are not, the
+SigNoz MCP server is not installed or configured — run `signoz-mcp-setup` first
+to initialize or repair the MCP connection. The investigation depends on
+correlating multiple MCP queries; without the server there is no way to ground
+the analysis.
+
+## When to use
+
+Use this skill when the user wants to:
+- Understand why a specific alert fired.
+- Find the root cause of a recent incident triggered by an alert.
+- Correlate the alert's signal with related metrics, traces, and logs.
+- Distinguish "real signal" fires from flapping or threshold-mistuning.
+
+Do NOT use when the user wants to:
+- Understand what an alert is configured to monitor → `signoz-explaining-alerts`.
+- Create a new alert → `signoz-creating-alerts`.
+- Modify an alert (raise threshold, add hysteresis) → call
+  `signoz:signoz_update_alert` directly.
+- Run a free-form ad-hoc investigation without an alert as the anchor →
+  `signoz-generating-queries`.
+
+## Required inputs
+
+| Input | Required | Source if missing |
+|---|---|---|
+| Alert identifier (rule ID or name) | yes | `$ARGUMENTS[0]` or recent context |
+| Time window | no | default to most recent fire from `signoz:signoz_get_alert_history` |
+
+If the alert name is fuzzy, this skill is **best-effort** (read-only):
+1. Call `signoz:signoz_list_alert_rules`, paginate, fuzzy-match the name.
+2. State the interpretation: "Investigating fire of 'High Error Rate —
+   Checkout' (id 42) at 14:32 UTC. If you meant a different alert or
+   fire, tell me."
+3. Proceed.
+
+If the alert has never fired in the lookback window, **stop**: there is
+nothing to investigate. Respond with:
+> "Alert '[name]' has not fired in the last 7d, so there is no fire
+> window to investigate. Use `signoz-explaining-alerts` to walk through
+> the rule, or check whether the alert is enabled."
+
+## Workflow
+
+The investigation runs in three tiers with strict early-stop gates.
+Tier 1 always runs. Tier 2 runs only if tier 1 confirms a real fire.
+Tier 3 runs only if tier 2 surfaces correlated anomalies. Skipping the
+gates produces hundreds of unnecessary trace/log queries on quiet
+alerts.
+
+### Step 1: Resolve alert + fire window (Tier 0)
+
+1. Resolve the alert id via `signoz:signoz_list_alert_rules` (paginated) if
+   not given.
+2. Call `signoz:signoz_get_alert` for the full rule config — needed to know
+   what query, threshold, and resource scope the alert evaluated.
+3. Call `signoz:signoz_get_alert_history` with a 7d lookback. From the
+   response:
+   - **Pick the fire window**. Default to the most recent fire. If the
+     user passed an explicit time window via `$ARGUMENTS[1]`, honor it.
+   - **Note the fire pattern**:
+     - `one-off` → single fire with a long quiet period before/after.
+     - `sustained` → fires that stayed firing for ≥ 1 evaluation cycle.
+     - `flapping` → ≥ 3 fires within a 1h window, alternating fire/resolve.
+     - `recurring` → fires at regular intervals (cron-like, e.g., every hour).
+   - The pattern tells you what to expect from tiers 2/3.
+
+### Step 2: Tier 1 — what fired and how hard
+
+This tier always runs. It establishes the fire is real (vs. transient
+threshold tickle or flap) and quantifies the magnitude.
+
+1. Re-run the alert's primary query over a window centered on the fire
+   start: `[fire_start - 30m, fire_start + 30m]`.
+   - Use `signoz:signoz_execute_builder_query` for builder/formula alerts.
+   - Use `signoz:signoz_query_metrics` for PromQL alerts.
+2. Compute:
+   - **Peak value** during the fire window.
+   - **Threshold breach magnitude**: `(peak - threshold) / threshold *
+     100` for "above" alerts, inverted for "below".
+   - **Fire duration**: how long the breach lasted.
+   - **Pre-fire baseline**: average value in the 30m before fire start.
+3. **Early-stop gate**: if the breach magnitude is < 10% over the
+   threshold AND the fire duration is < 1 evaluation window, classify
+   as "marginal fire" — the alert may be too sensitive. Skip tiers 2
+   and 3 and go to Step 5 with a single hypothesis: "threshold may be
+   too tight, recommend tuning."
+
+### Step 3: Tier 2 — neighbor signals vs baseline
+
+Run only if Tier 1 confirms a real breach. Pull related signals for the
+same resource scope as the alert and compare the fire window to a
+baseline window.
+
+1. **Pick a baseline window**. Use the same hour, previous day
+   (`fire_start - 24h, fire_start - 24h + fire_duration`). If the
+   alert fired during a known-anomalous time (deploy, weekly job),
+   note it in the output but still proceed.
+
+2. **Look up neighbor signals** for the alert's resource type. See
+   `references/neighbor-signals.md` for the lookup table. Common cases:
+   - **Service-level alert** (`service.name = X`): pull error rate,
+     p95/p99 latency, request throughput, dependency error rates if
+     trace data is available.
+   - **Host / VM alert** (`host.name = X`): CPU, memory, disk I/O,
+     network I/O.
+   - **K8s pod / namespace alert**: pod restarts, container CPU/memory
+     limits, node pressure, recent rollouts.
+
+3. For each neighbor signal:
+   - Query both windows (fire + baseline) via
+     `signoz:signoz_execute_builder_query` or `signoz:signoz_query_metrics`.
+   - Compute the delta (% change in fire window vs baseline).
+   - Rank by absolute delta.
+
+4. **Early-stop gate**: if no neighbor signal shows ≥ 25% deviation
+   from baseline, classify as "isolated fire — the alert's own signal
+   moved but nothing else did." This is unusual and worth surfacing.
+   Skip Tier 3 and go to Step 5 with hypotheses focused on the alert's
+   own query (likely causes: data source change, instrumentation
+   change, downstream silent failure that only shows in this metric).
+
+### Step 4: Tier 3 — traces and logs at the fire window
+
+Run only if Tier 2 found correlated neighbor anomalies. Drill into
+specific failing operations.
+
+1. **Traces** (if the alert is service-scoped and traces are
+   available):
+   - Call `signoz:signoz_search_traces` for the fire window with filter:
+     `service.name = <scope>` AND `hasError = true`. Cap at top 20.
+   - Group results by `name` (operation) and `error_message`. Surface
+     the top 3 by frequency with a representative trace ID for each.
+   - Optionally call `signoz:signoz_get_trace_details` on one representative
+     to extract specific span attributes (DB statement, downstream URL,
+     status code).
+
+2. **Logs** for the fire window:
+   - Call `signoz:signoz_search_logs` with filter:
+     `<scope_filter>` AND `severity_text IN ('ERROR', 'FATAL')`. Cap
+     at top 20 most recent.
+   - Group by `body` pattern (or `exception.type` if present). Surface
+     the top 3 distinct messages with counts.
+
+3. Cross-reference: do the traces and logs point at the same
+   downstream service, dependency, or code path? If so, that becomes
+   the leading hypothesis.
+
+See `references/baseline-comparison.md` for query templates that pair
+fire-window and baseline-window calls cleanly.
+
+### Step 5: Build the structured output
+
+Use this exact section order. Lead with a TL;DR — engineers under
+pressure scan the top first and stop reading once they have what
+they need. Compression plus proof: every claim cites the MCP query
+that produced it; no generic "check logs / verify connectivity"
+filler.
+
+**1. TL;DR** — one or two sentences, no more. Leading hypothesis,
+overall confidence, blast radius, and the single most useful next
+action. Example:
+> "checkoutservice error rate hit 12.4% (threshold 5%) for 8m at
+> 14:32 UTC — most likely cause is payments-api timing out
+> (high confidence). Open trace `7af3a09b…` to see the failing call."
+
+If no hypothesis reaches medium confidence, the leading line is
+"No clear root cause found." rather than a low-confidence guess
+dressed up as the answer.
+
+**2. What fired**
+The alert (id, name), the fire window (absolute UTC + relative),
+peak magnitude ("error rate hit 12.4% vs. 5% threshold — 148% over"),
+fire duration, and the fire pattern (`one-off` / `sustained` /
+`flapping` / `recurring` / `marginal`).
+
+**3. Investigation trail**
+A scannable list of what was checked, with ✅ for confirmed signals
+and ❌ for ruled out, each followed by a one-line finding. The point
+is that the reader can see what work the AI did and what it found —
+this is where trust is earned. Example:
+- ✅ Tier 1 — peak error rate 12.4%, fire was real (not marginal).
+- ✅ Tier 2 — payments error rate +8900%, p99 +1180%; downstream
+  cascade.
+- ❌ CPU / memory pressure — flat through the fire window.
+- ✅ Tier 3 — 30 error traces all hit payments-api, same message.
+
+**4. Likely causes** (ranked, max 3)
+Each cause has three parts:
+- **Hypothesis** — one sentence, specific. Bad: "service is unhealthy".
+  Good: "checkout is timing out on calls to payments-api".
+- **Evidence** — the supporting numbers from tiers 1/2/3, with the
+  underlying query inline so the user can re-run it. State the
+  neighbor signal, the delta vs baseline, the trace/log pattern that
+  supports it.
+- **Confidence** — `high` requires ≥2 of: temporal precedence,
+  topology / dependency edge, shared service or entity, correlated
+  metric/log/trace evidence, recent deploy or config change.
+  `medium` is one tier's evidence with at least one of those
+  signals. `low` is a single signal moved with no corroboration —
+  in that case label it a "co-occurring signal," not a cause.
+
+If only Tier 1 ran (marginal fire / no neighbor anomalies), output
+fewer hypotheses with `low` confidence and explicitly call out the
+limitation.
+
+**5. Ruled out**
+Short but explicit. List candidates the evidence eliminated and the
+one-line reason why. Skip the section if there's nothing meaningful
+to rule out — but if you considered something and dropped it, say so
+here so the user doesn't waste time re-checking it.
+
+**6. Suggested next steps**
+Action items the user can take. Be concrete and use SigNoz-native
+handles so the user can act immediately:
+- Specific trace, dashboard, or alert to open
+  (e.g., "open trace `7af3a09b…` in the SigNoz UI").
+- Specific query to run with `signoz-generating-queries` — paste
+  the exact filter and time window.
+- "Tune this alert" if the fire was marginal — name the field
+  (`matchType`, `target`, `recoveryTarget`) and the change to make
+  via `signoz:signoz_update_alert`.
+- "Open an incident" or "page the owning team" if the cause is
+  cross-service.
+
+Do not pad with generic advice ("verify connectivity", "check
+dashboards") — that's noise during an active incident.
+
+**Mirroring as navigation chips.** Mirror up to 3 of these "Suggested
+next steps" as host follow-up intents — the most actionable,
+alert-scoped ones. Keep the rest in the report prose so the user has
+the full picture. The chip surface is capped; the prose is not.
+
+## Out of scope (v1)
+
+- **Deployment / config-change correlation** — SigNoz MCP does not
+  expose a deployments tool; do not fabricate one. If the user
+  mentions a recent deploy, surface it as context but don't claim it
+  caused the fire without the signal evidence.
+- **Cross-service blast-radius walking** — investigating downstream
+  callers of the alert's service. Out of scope to keep context
+  bounded.
+- **Long-horizon historical baselines** — Tier 2 compares to one
+  prior-day window, not to weekly/monthly seasonality. If the user
+  says "is this normal for a Friday afternoon", suggest an anomaly
+  alert (`signoz-creating-alerts` with `anomaly_rule`).
+
+## Guardrails
+
+- **Three-tier early-stop is mandatory.** Skipping the gates pulls
+  hundreds of traces/logs on quiet alerts and explodes context. The
+  gates are not optional optimizations.
+- **Anchor every claim to an MCP query result.** No speculation. If
+  evidence is missing, lower confidence and say so.
+- **Show the supporting query** with each hypothesis so the user can
+  reproduce and dig deeper.
+- **Compression plus proof.** TL;DR is one or two sentences max; the
+  full report is a triage card, not a postmortem. Engineers under
+  pressure should be able to skim the top and act. Every section
+  earns its place by adding evidence the user couldn't already see
+  in the alert payload.
+- **Correlation ≠ causation.** Label something a cause only when at
+  least two of the following converge: temporal precedence (signal
+  moved before symptom), topology / dependency edge, shared service
+  or entity, correlated metric/log/trace evidence, or a recent
+  deploy/config change. A single time-aligned anomaly is a
+  "co-occurring signal," not a cause — say so explicitly.
+- **Don't restate the alert or recommend the obvious.** "Check
+  logs", "verify connectivity", "investigate dashboards" — the
+  reader of this output already knows they need to. Replace generic
+  suggestions with specific queries, traces, or filters they can run
+  immediately.
+- **No fabricated identifiers.** Trace IDs, span names, alert rule
+  IDs, channel names, deploy IDs — every identifier in the output
+  must come from a real MCP response. Don't invent placeholders that
+  look plausible.
+- **Honest uncertainty wins.** If no hypothesis reaches medium
+  confidence, the answer is "No clear root cause found — here's
+  what we checked and what's ruled out." Do not promote a
+  low-confidence guess to the leading hypothesis just to sound
+  useful. False positives waste active incident time more than false
+  negatives.
+- **Prefer resource-attribute filters** in every drill-down query.
+  This is the SigNoz MCP guideline and it directly affects query
+  speed at scale.
+- **Do not modify any alert.** Investigate is read-only. If the user
+  says "and tighten this alert", surface that as a next-step
+  recommendation; do not call `signoz:signoz_update_alert`.
+- **Stay in scope.** Static rule explanation belongs to
+  `signoz-explaining-alerts`. Cause analysis without an alert anchor
+  belongs to `signoz-generating-queries`.
+- **Time zones.** Always state fire windows in UTC alongside relative
+  time ("14:32 UTC, 2h ago") so autonomous and interactive consumers
+  agree on the window.
+
+## Examples
+
+**User:** "Why did the checkout error rate alert fire?"
+
+**Agent:**
+1. Resolves alert: "High Error Rate — Checkout" (id 42).
+2. `signoz:signoz_get_alert_history` → most recent fire 2h ago at 14:32 UTC,
+   sustained for 8m, single fire (not flapping).
+3. **Tier 1**: re-runs error-rate formula over `[14:02, 15:02]`. Peak
+   error rate 12.4% (vs 5% threshold — 148% over). Pre-fire baseline
+   0.3%. Real fire, not marginal.
+4. **Tier 2**: pulls neighbor signals for `service.name = checkout`:
+   - p99 latency: 4.1s vs 320ms baseline (+1180%).
+   - Throughput: -42% (drop).
+   - Downstream `payments` error rate: 18% vs 0.2% baseline (+8900%).
+   - CPU/memory: flat (no resource pressure).
+5. **Tier 3**: traces for `service.name = checkout, hasError = true`
+   in the fire window — top operation `POST /checkout/submit`, top
+   error message "context deadline exceeded calling payments-api".
+   30 traces, all hitting the same downstream URL. Logs show
+   matching "payments client timeout" lines, 142 occurrences.
+6. **Output**:
+
+   > **TL;DR**: checkoutservice error rate hit 12.4% (threshold 5%)
+   > for 8m at 14:32 UTC. Most likely cause: payments-api timing out
+   > (high confidence — converging trace + log + neighbor evidence).
+   > Open trace `7af3a09b…` to see the failing call.
+
+   - **What fired**: alert 42 fired 2h ago at 14:32 UTC, sustained
+     8m. Error rate peaked at 12.4% (148% over threshold).
+   - **Investigation trail**:
+     - ✅ Tier 1 — peak 12.4% vs 5% threshold, pre-fire baseline 0.3%.
+       Real fire.
+     - ✅ Tier 2 — payments error rate +8900%, p99 latency +1180%,
+       throughput −42%.
+     - ❌ CPU / memory pressure on checkout — flat.
+     - ✅ Tier 3 — 30 error traces all hit payments-api with
+       `context deadline exceeded`; 142 matching timeout logs.
+   - **Likely causes** (high confidence): payments service errors
+     cascading into checkout. Evidence converges across topology
+     (checkout → payments edge), temporal precedence (payments
+     errors lead checkout p99), and shared entity (every error
+     trace targets the payments-api URL).
+   - **Ruled out**: checkout-side resource pressure (CPU/memory
+     flat); upstream traffic spike (throughput dropped, didn't
+     spike).
+   - **Next steps**: open trace `7af3a09b…` in the SigNoz UI; if
+     payments has its own alert, run `signoz-explaining-alerts` on
+     it, otherwise `signoz-generating-queries` for payments error
+     rate over the last 4h.
+
+---
+
+**User:** "Investigate the flapping CPU alert on prod-api-3"
+
+**Agent:**
+1. Resolves alert (id 88, host.name = prod-api-3).
+2. History: 7 fires in last 1h, alternating fire/resolve every 8-12
+   minutes — flapping pattern.
+3. **Tier 1**: peak 84% (threshold 80%, only 5% over). Each fire
+   lasted 2-4 minutes. Marginal — the value hovered near threshold.
+   `matchType = at_least_once` made each blip trigger.
+4. Early-stop kicks in. Skip tiers 2/3.
+5. **Output**:
+
+   > **TL;DR**: alert 88 has been flapping on `prod-api-3` — 7 fires
+   > in the last 1h, each 2–4m, all within 5% of the 80% threshold.
+   > No clear root cause; this is threshold tuning, not an incident.
+   > Switch `matchType` to `on_average` or add hysteresis to stop
+   > the noise.
+
+   - **What fired**: alert 88, host `prod-api-3`, fire pattern
+     `flapping`. 7 fires in the last 1h, each 2–4m. Peak 84% (5%
+     over the 80% threshold).
+   - **Investigation trail**:
+     - ✅ Tier 1 — every fire was within 5% of threshold; duration
+       short; baseline already at 70–75%. Marginal fire — early-stop
+       triggered, Tier 2/3 skipped.
+   - **Likely causes** (low / co-occurring signal only): threshold
+     tuned too tight or `matchType` is too sensitive. Evidence:
+     every fire was within 5% of threshold; baseline already runs
+     at 70–75%. Not promoted to a "cause" — single signal, no
+     corroboration.
+   - **Ruled out**: real CPU saturation incident (peaks too small
+     and short-lived; baseline already near threshold).
+   - **Next steps**: change `matchType` to `on_average` (smooths
+     transient spikes) OR raise threshold to 85% with hysteresis
+     (`recoveryTarget: 75`). Use `signoz:signoz_update_alert` to apply.
+
+---
+
+**User:** "RCA for the log volume alert that fired last night"
+
+**Agent:**
+1. Resolves alert: "Error Log Volume Spike" (id 14, no service
+   filter — groupBy `service.name`).
+2. History: fired at 03:12 UTC, sustained 22m, broke down by service
+   in the alert annotations: `service.name = inventory` was the
+   firing series.
+3. **Tier 1**: re-runs log count for inventory in fire window. Peak
+   3,400 errors/min vs 1,000/min threshold (240% over). Pre-fire
+   baseline 12/min. Real, large fire.
+4. **Tier 2**: neighbor signals for `service.name = inventory`:
+   - Request error rate: +600%.
+   - p99 latency: +30% (mild).
+   - CPU: -80% (collapsed). Memory: -60%.
+   - Pod restarts (k8s): 4 in fire window.
+5. **Tier 3**: logs for inventory in fire window. Top message: "OOMKilled
+   restarting" (1,200 occurrences). Top trace error: graceful-shutdown
+   exceptions.
+6. **Output**:
+
+   > **TL;DR**: log volume alert 14 fired at 03:12 UTC for
+   > `service.name = inventory`, sustained 22m at 240% over threshold.
+   > Most likely cause: inventory pods OOM-killed and restarted 4
+   > times (high confidence). Check container memory limits for the
+   > inventory deployment.
+
+   - **What fired**: alert 14 fired at 03:12 UTC for service
+     `inventory`, sustained 22m, 240% over threshold.
+   - **Investigation trail**:
+     - ✅ Tier 1 — peak 3,400 errors/min vs 1,000/min threshold;
+       pre-fire baseline 12/min. Real fire.
+     - ✅ Tier 2 — request error rate +600%; CPU/memory collapsed
+       (−80%/−60%); 4 pod restarts in window.
+     - ❌ p99 latency — only +30%, not a latency-driven incident.
+     - ✅ Tier 3 — top log message "OOMKilled restarting" (1,200
+       occurrences); top trace error: graceful-shutdown exceptions.
+   - **Likely causes** (high confidence): inventory pods OOM-killed
+     and restarted 4 times during the window. Evidence converges
+     across topology (single service), temporal precedence (memory
+     fell to zero before error spike), shared entity (all log lines
+     from `service.name = inventory`), and a single coherent
+     pattern (OOM → restart → graceful-shutdown noise).
+   - **Ruled out**: a true application error-rate change (errors
+     are restart noise, not request-path failures); upstream
+     traffic surge (throughput unchanged).
+   - **Next steps**: check container memory limits for inventory
+     pods; review recent deploys; consider whether the alert should
+     exclude restart-related error patterns or whether the
+     underlying OOM is the real concern.
+
+## Additional resources
+
+- `references/neighbor-signals.md` — lookup table mapping resource type
+  (service / host / k8s) to the neighbor signals to pull in Tier 2.
+- `references/baseline-comparison.md` — query templates that pair
+  fire-window and baseline-window calls cleanly, including how to
+  format `signoz:signoz_execute_builder_query` for both.
+- `signoz-explaining-alerts` skill — to decode the rule before
+  investigating, if the user is unfamiliar with what the alert
+  monitors.
+- `signoz-generating-queries` skill — for ad-hoc follow-up queries on the same
+  resource scope.

--- a/skills/signoz-investigating-alerts/evals/evals.json
+++ b/skills/signoz-investigating-alerts/evals/evals.json
@@ -1,0 +1,40 @@
+{
+  "skill_name": "signoz-investigating-alerts",
+  "evals": [
+    {
+      "id": 0,
+      "eval_name": "full-rca-firing",
+      "prompt": "The 'RED — p99 Latency > 2s by Service' alert (019ddf83-7d04-74c4-97c7-fea13d72c091) is firing. Investigate the most recent fire and tell me the root cause.",
+      "expected_output": "Agent runs full 3-tier flow: signoz_get_alert + signoz_get_alert_history (find recent fire), then Tier-1 re-runs the alert query around the fire window to get peak/baseline/breach magnitude/duration; Tier-2 pulls neighbor signals (error rate, throughput, dependency latency) and compares fire vs baseline window; Tier-3 pulls top error traces + error logs around the fire window. Outputs ranked hypotheses with evidence + supporting query, plus next steps.",
+      "files": []
+    },
+    {
+      "id": 1,
+      "eval_name": "fuzzy-match-rca",
+      "prompt": "I got paged about a checkout error rate alert, can you investigate the most recent fire?",
+      "expected_output": "Agent paginates signoz_list_alert_rules to resolve 'checkout error rate' (multiple candidates exist: 'checkout-svc Error Rate > 3%' METRIC_BASED + TRACES_BASED, plus eval-1 alerts). Picks the one with actual fire history (TRACES_BASED 019dd4cb fired ~7d ago at ~14:32 UTC), states the assumption clearly, then runs full RCA on that fire window. Tier-2 baseline is prior-day same hour; flags if baseline data is sparse since fire is 7d old.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "eval_name": "marginal-flap-detection",
+      "prompt": "Why did the 'test alerts-1' alert fire? Investigate. (rule id 0199e817-3d9f-7a12-99e8-038749ea9562)",
+      "expected_output": "Agent fetches alert + history. If breach magnitude is small (<10% over threshold) AND fire duration short, OR if fires are flapping, classifies as 'marginal fire' per Tier-1 early-stop. Skips Tier-2/3 and outputs a single 'threshold may be too tight, recommend tuning' hypothesis with low-medium confidence rather than fabricating root causes. If fires are flapping, identifies the pattern explicitly.",
+      "files": []
+    },
+    {
+      "id": 3,
+      "eval_name": "never-fired-stop",
+      "prompt": "RCA for the [eval-3-ws-anomaly] frontend service request rate anomaly alert please. Rule ID 019de287-6752-7629-83e4-375919d56dd8.",
+      "expected_output": "Agent fetches alert + history. Detects that the alert is disabled and has never fired (history empty). Stops per skill guardrail with the message 'Alert has not fired in the last 7d, so there is no fire window to investigate.' Suggests using signoz-explaining-alerts to explain the rule, or to enable the alert. Does NOT proceed to Tier-1/2/3 against synthetic data.",
+      "files": []
+    },
+    {
+      "id": 4,
+      "eval_name": "trace-formula-firing",
+      "prompt": "Investigate why alert 019d7041-1937-769f-b0e4-9d4ff846eb43 ('trace formula alert') is firing.",
+      "expected_output": "Agent fetches alert + history. Identifies it as a TRACES_BASED formula alert. Runs Tier-1 to confirm fire is real and quantify magnitude. If real, runs Tier-2 against neighbor signals for the same resource scope (note: the alert may have an empty/missing service filter — agent should handle this gracefully). Surfaces ranked hypotheses with evidence and queries.",
+      "files": []
+    }
+  ]
+}

--- a/skills/signoz-investigating-alerts/references/baseline-comparison.md
+++ b/skills/signoz-investigating-alerts/references/baseline-comparison.md
@@ -1,0 +1,126 @@
+# Baseline Comparison Templates
+
+## Contents
+
+- Window selection
+- Builder query template (`signoz:signoz_execute_builder_query`)
+- Computing the delta
+- Surfacing the comparison
+- When the baseline is invalid
+- Logs / traces drill-down (Tier 3)
+
+Tier 2 of the investigation pairs each neighbor-signal query against a
+fire-window query and a baseline-window query, then computes a delta.
+This file shows how to format those calls cleanly via the SigNoz MCP
+tools.
+
+## Window selection
+
+Given a fire that started at `T_fire_start` and lasted `D` minutes:
+
+- **Fire window**: `[T_fire_start - 5m, T_fire_start + D + 5m]`. The
+  ±5m buffer catches lead-in / cool-down behavior the threshold
+  evaluation may have missed.
+- **Baseline window**: `[T_fire_start - 24h - 5m, T_fire_start - 24h + D + 5m]`.
+  Same hour, previous day, same duration.
+- If the alert has been firing for > 4 hours, expand the baseline to a
+  rolling 7-day median over the same time-of-day to avoid biasing
+  against another fire on the prior day.
+
+State both window timestamps in **UTC absolute** in the output, plus a
+relative description ("24h before fire").
+
+## Builder query template (`signoz:signoz_execute_builder_query`)
+
+For each neighbor signal, run the same builder query twice — once per
+window. The only thing that changes is `start` / `end`.
+
+Pseudo-shape (the actual MCP tool input shape is in the SigNoz MCP
+docs, but the conceptual fields):
+
+```jsonc
+{
+  "compositeQuery": {
+    "queryType": "builder",
+    "panelType": "graph",
+    "queries": [
+      {
+        "type": "builder_query",
+        "spec": {
+          "name": "A",
+          "signal": "<traces|logs|metrics>",
+          "aggregations": [ /* per neighbor-signals.md */ ],
+          "filter": { "expression": "<resource attribute filter from the alert>" },
+          "groupBy": [ /* mirror the alert's groupBy when relevant */ ]
+        }
+      }
+    ]
+  },
+  "start": "<window start, RFC3339 UTC>",
+  "end":   "<window end, RFC3339 UTC>"
+}
+```
+
+## Computing the delta
+
+For each signal, after running both windows:
+
+```text
+delta_pct = (fire_value - baseline_value) / max(baseline_value, epsilon) * 100
+```
+
+- Use the **peak** of the fire window when the alert direction is
+  "above" (op `"1"`), and the **trough** when the direction is "below"
+  (op `"2"`). For the baseline use the **mean** in either case to get
+  a stable reference.
+- Use `epsilon = max(baseline_value * 0.01, signal-specific floor)` to
+  avoid divide-by-zero on metrics that idle at 0 (e.g., error rate).
+- Clamp `delta_pct` for display at ±10000% — beyond that the absolute
+  values matter more than the ratio.
+
+## Surfacing the comparison
+
+In the Tier 2 output for each signal, present:
+
+```
+- p99 latency: 4.1s vs 320ms baseline (+1180%)
+  query: signoz:signoz_execute_builder_query — p99(durationNano) on
+         service.name = checkout, fire window 14:32-14:40 UTC vs
+         baseline 14:32-14:40 UTC (24h prior)
+```
+
+The agent should embed these in the "Likely causes — Evidence"
+sections of the final structured output. The query line lets the user
+re-run the comparison without rebuilding the parameters.
+
+## When the baseline is invalid
+
+Skip baseline comparison and call out the limitation if:
+
+- The baseline window overlaps with another firing of the same alert
+  (`signoz:signoz_get_alert_history` shows a fire in the baseline window).
+  In that case use a 7-day median or the user's confirmed
+  known-healthy window.
+- The service was deployed within 24h before the baseline window —
+  the baseline reflects pre-deploy behavior. Note this and either
+  use a median or explicitly state "no good baseline available".
+- The alert is `anomaly_rule` (Z-score). The rule already encodes a
+  baseline; pulling another comparison usually adds noise. Skip Tier
+  2's per-signal baselines and instead focus Tier 3 on the fire window
+  alone.
+
+## Logs / traces drill-down (Tier 3)
+
+Tier 3 does not require a baseline — the question is "what happened",
+not "what changed". Run a single fire-window query for each:
+
+- `signoz:signoz_search_traces` with the resource filter + `hasError = true`.
+  Cap at 20. Group by `name` (operation) and surface the top 3 by
+  count with one representative `trace_id` each.
+- `signoz:signoz_search_logs` with the resource filter +
+  `severity_text IN ('ERROR', 'FATAL')`. Cap at 20 most recent. Group
+  by message pattern (or `exception.type`) and surface the top 3.
+- For deep drill on one trace, `signoz:signoz_get_trace_details(trace_id)`
+  extracts span-level attributes (DB statement, peer service, status
+  code) — useful when the operation name alone doesn't identify the
+  failing call.

--- a/skills/signoz-investigating-alerts/references/neighbor-signals.md
+++ b/skills/signoz-investigating-alerts/references/neighbor-signals.md
@@ -1,0 +1,78 @@
+# Neighbor Signals Lookup
+
+For each resource type the alert is scoped to, this table lists the
+neighbor signals to pull during Tier 2 (fire-window vs baseline
+comparison). Pull every signal in the row; rank by absolute deviation
+from baseline.
+
+The MCP server's "always prefer resource attributes" guideline applies
+to all of these queries — use the same resource-attribute filter as
+the alert itself.
+
+## Service-level scope (`service.name = X`)
+
+The alert filters or groups by a service. Neighbor signals describe
+the service's health from the perspective of its callers and its
+runtime.
+
+| Signal | Source | Aggregation | Why it matters |
+|---|---|---|---|
+| Error rate (traces) | traces | `count(hasError = true) * 100 / count()` grouped by service | A sympathetic move here usually points at downstream / upstream cascades. |
+| p95 latency | traces | `p95(durationNano)` filtered to entry spans | Latency moving with errors → resource saturation or downstream slowness. Latency without errors → queue/buffer fill. |
+| p99 latency | traces | `p99(durationNano)` | Catches tail-only regressions invisible to p95. |
+| Throughput (RPS) | traces | `rate(count())` | Drops mean upstream stopped sending. Spikes mean retry storms or load shifts. |
+| Dependency error rate | traces | `count(hasError = true)` filtered to outbound spans, grouped by `db.name` / `peer.service` / target host | Surfaces which downstream the service is failing on. |
+| Container CPU (if available) | metrics | `system.cpu.utilization` or `container.cpu.utilization` filtered to the same service | Saturation explains latency/error correlation; flat CPU + errors implies a non-resource cause. |
+| Container memory | metrics | `system.memory.usage` / `container.memory.usage` | OOM context, leak detection. |
+| Pod restarts (if k8s) | metrics | `k8s.pod.phase` transitions or `kube_pod_container_status_restarts_total` rate | Restarts during the fire window strongly bias toward "infrastructure caused this". |
+
+## Host / VM scope (`host.name = X`)
+
+The alert is on a single host or set of hosts. Neighbor signals are
+infrastructure-level.
+
+| Signal | Source | Aggregation | Why it matters |
+|---|---|---|---|
+| CPU utilization | metrics | `system.cpu.utilization` time-avg space-avg | Already may be the alert metric — pull anyway to see how peak relates to threshold. |
+| Memory pressure | metrics | `system.memory.utilization` or free pages | OOM and swap activity. |
+| Disk I/O wait | metrics | `system.disk.io_time` or iowait equivalent | Disk saturation often masquerades as CPU pressure. |
+| Network I/O | metrics | `system.network.io` | Network saturation or NIC errors. |
+| Load average | metrics | `system.cpu.load_average.1m` | Catches contention not visible in raw CPU%. |
+| Service-level signals on this host | traces | filter by `host.name = X` and aggregate by service | Identifies which service workload caused the host pressure. |
+
+## K8s namespace / pod scope
+
+The alert is scoped to a k8s namespace, deployment, or pod set.
+
+| Signal | Source | Aggregation | Why it matters |
+|---|---|---|---|
+| Pod restart count | metrics | restarts in fire window vs baseline | Crash loops dominate every other signal — surface first. |
+| CPU vs requests/limits | metrics | `container.cpu.utilization` divided by limit | Throttling shows up here even when raw CPU% looks healthy. |
+| Memory vs limit | metrics | `container.memory.usage / container.memory.limit` | OOMKilled is the most common k8s failure. |
+| Node pressure | metrics | `kube_node_status_condition` for pressure conditions | Node-level resource exhaustion bleeds into all pods scheduled there. |
+| Recent rollout | metrics | check for `k8s.deployment.replicas_updated` change in window | Rollout overlapping with fire is the strongest single signal of cause. |
+| Service-level signals (errors / latency) | traces | scoped to the k8s workload | The application-layer view of the same problem. |
+
+## Generic (no resource scope identified)
+
+If the alert has no resource filter (e.g., a global error-log alert
+without groupBy), Tier 2 is weaker. Pull:
+
+| Signal | Source | Aggregation |
+|---|---|---|
+| Top services by error rate | traces | `count(hasError = true)` grouped by `service.name`, top 10 |
+| Top services by error log volume | logs | `count()` filtered to `severity_text IN ('ERROR','FATAL')`, grouped by `service.name`, top 10 |
+
+This identifies which service drove the global signal, then re-run
+Tier 2 against that service's row from the table above.
+
+## Selection rules
+
+1. **Pick the row that matches the alert's most specific resource
+   filter.** If the alert filters on both `k8s.namespace.name` and
+   `service.name`, prefer the k8s row plus `service.name` cross-cuts.
+2. **Skip a signal if the data is not available.** Don't fabricate
+   queries against metrics that don't exist — call `signoz:signoz_list_metrics`
+   to verify metric names before querying.
+3. **Cap signal pulls at 6 queries per tier** to keep context bounded.
+   Pick the most informative for the alert's signal type.

--- a/skills/signoz-managing-views/SKILL.md
+++ b/skills/signoz-managing-views/SKILL.md
@@ -1,0 +1,295 @@
+---
+name: signoz-managing-views
+description: >
+  Use when the user wants to create, list, get, update, rename, or delete a
+  SigNoz saved Explorer view. Trigger on phrases like "save this query as a
+  view", "save this filter", "bookmark this search", "list my saved views",
+  "show me views for traces/logs/metrics", "rename the X view", "update my
+  saved view to also filter Y", "delete the X view", or any request to manage
+  Explorer saved views — even if they don't say "view" explicitly. Also use
+  when someone wants to share a recurring Explorer query with their team and
+  asks how to "save" or "bookmark" it.
+argument-hint: <view name, sourcePage (traces/logs/metrics), and filter intent>
+---
+
+# Managing Saved Views
+
+Create, read, update, and delete SigNoz **saved Explorer views** via the
+SigNoz MCP server. A saved view is a reusable snapshot of an Explorer query
+on the Logs, Traces, or Metrics page — name + filters + panel type, scoped
+to one `sourcePage`. They are not dashboards and not alerts.
+
+This skill covers the full CRUD surface in one place because the operations
+share the same schema, the same identity model (UUID per view), and the same
+prerequisite resources. The only operation with real blast radius is delete,
+and update has a sharp edge (full-body replace) — both get explicit guards
+below.
+
+## Prerequisites
+
+This skill calls SigNoz MCP server tools (`signoz:signoz_create_view`,
+`signoz:signoz_list_views`, `signoz:signoz_get_view`,
+`signoz:signoz_update_view`, `signoz:signoz_delete_view`,
+`signoz:signoz_get_field_keys`, `signoz:signoz_get_field_values`). Before
+running the workflow, confirm the `signoz:signoz_*` tools are available. If
+they are not, run `signoz-mcp-setup` first to initialize or repair the MCP
+connection. Do not fall back to raw HTTP calls or fabricate view payloads
+without the MCP tools.
+
+## When to use
+
+Use this skill when the user wants to:
+
+- **Create** a saved view from a current or described Explorer query.
+- **List / find** existing views (by `sourcePage`, name, or category).
+- **Inspect** a single view's filter or panel type.
+- **Update** a view — rename, recategorize, or change its filter,
+  panel type, or aggregations.
+- **Delete** a view that is no longer useful.
+
+Do NOT use when the user wants to:
+
+- Build a dashboard panel → `signoz-creating-dashboards` /
+  `signoz-modifying-dashboards`.
+- Run an ad-hoc Explorer query without saving it → `signoz-generating-queries`.
+- Create or change an alert rule → `signoz-creating-alerts`.
+
+## Schema reference
+
+**Read both resources BEFORE composing any create or update payload.** Do not
+hand-compose a `compositeQuery` from memory — the correct schema is not the
+legacy `builder.queryData` format; it is the v5 spec described in these
+resources. Sending a legacy payload causes a silent HTTP 400.
+
+Read both MCP resources by URI using your client's resource-read mechanism:
+
+- `signoz://view/instructions` — SavedView field reference, `sourcePage`
+  rules, the GET-then-PUT update flow, the minimal create body.
+- `signoz://view/examples` — three round-tripped payloads (traces list, logs
+  list, metrics graph) you can adapt verbatim.
+
+The server returns HTTP 400 on legacy v3/v4 fields (`builder`, `promql`,
+`unit`, top-level `id`, `queryFormulas`, `queryTraceOperator`) — the failure
+mode is silent for the user, so reading the resources first is mandatory, not
+optional.
+
+## Operation flows
+
+### Create a view
+
+1. **Resolve `sourcePage`** — must be exactly one of `traces`, `logs`,
+   `metrics`. If the user's intent is ambiguous ("save this query"), ask
+   which Explorer they mean. It cannot be inferred from filter strings alone.
+2. **Read the schema resources.** Read both `signoz://view/instructions`
+   and `signoz://view/examples` using your client's resource-read mechanism
+   before composing any payload. Do not skip this step even if you think
+   you know the schema — the legacy `builder.queryData` format is rejected
+   with HTTP 400.
+3. **Build the query using `signoz-generating-queries` — mandatory.** Use
+   the `Skill` tool to invoke `signoz-generating-queries`. The sub-skill
+   handles field discovery, type checking, and live-data validation in one
+   pass — adapting an example payload from `signoz://view/examples` or
+   running a bare `signoz:signoz_search_traces` call skips the field-type
+   checks and service-name resolution that catch silent 400s before they
+   become permanent bad views. Skipping it means a malformed filter becomes
+   a saved view that must be deleted and recreated.
+4. **Enforce `signal == sourcePage`** in every `builder_query` spec. A
+   `sourcePage:"traces"` view with `signal:"logs"` is a server-side error.
+5. **Mandatory pre-save sample fetch.** Probe with the **exact** filter
+   from `compositeQuery.queries[0].spec` against the destination
+   signal:
+   - `sourcePage=traces` → `signoz:signoz_search_traces` with `limit=1`
+   - `sourcePage=logs` → `signoz:signoz_search_logs` with `limit=1`
+   - `sourcePage=metrics` → `signoz:signoz_query_metrics` with the
+     `metricName` from `spec.aggregations[0].metricName` plus the same
+     filter, `timeRange=1h`, `requestType=scalar`. Repeat per metric
+     query if the view has multiple. The tool requires `metricName` —
+     a filter-only probe is not supported.
+
+   Required even if Step 3 ran cleanly: the sub-skill validates the
+   query *it* authored, not whatever you persist after edits or lifts.
+   Empty → save anyway / revise / abort. Autonomous mode without
+   authorization to persist empty views: abort and escalate.
+6. **Preview before writing — this step is not optional.** Before calling
+   `signoz:signoz_create_view`, show the user a summary: name, sourcePage,
+   panelType, the full filter expression, and the Step 5 probe result
+   ("sample fetch: N rows in last 1h"). For a human in the loop, wait
+   for confirmation. For an autonomous agent, log the preview and proceed.
+7. Call `signoz:signoz_create_view`. The server populates `id`,
+   `createdAt/By`, `updatedAt/By` — never send those.
+
+### List or find views
+
+`signoz:signoz_list_views` requires a `sourcePage`. If the user did not
+specify one and is searching by name, call it once per signal (traces,
+logs, metrics) and merge — do not guess. Use the `name` and `category`
+parameters for server-side partial-match filtering when the user gives a
+substring; do not fetch everything and grep client-side.
+
+The response paginates. **Always check `pagination.hasMore`** before
+concluding a view does not exist. Default page size is 50; pass `offset =
+pagination.nextOffset` to continue. A view is only confirmed missing for a
+given `sourcePage` once you have walked pages until `hasMore = false`. As
+long as `hasMore = true`, keep paginating — there is no page-count cap.
+
+### Get a single view
+
+Use `signoz:signoz_get_view` with the UUID. The returned `data` object is
+the canonical SavedView shape — it is what you pass back to
+`signoz:signoz_update_view`. Treat that data as the source of truth, not
+whatever the user described from memory.
+
+### Update a view (GET-then-PUT)
+
+`signoz:signoz_update_view` is a **full-body replace** (HTTP PUT
+upstream). Sending a partial body wipes the unspecified fields. The flow:
+
+1. `signoz:signoz_get_view` with the view's `id` → returns
+   `{ "status": "success", "data": { ...SavedView... } }`.
+2. Take the `data` object. Strip server-populated fields (`id`,
+   `createdAt`, `createdBy`, `updatedAt`, `updatedBy`) — the MCP server
+   strips them for you, but omitting them up front makes the diff
+   readable.
+3. **If the update changes `compositeQuery`** (new filter, different panel
+   type, different aggregation), invoke `signoz-generating-queries` to
+   build and validate the new query before proceeding. Do not hand-edit
+   `compositeQuery` from the user's description — the same
+   `signal == sourcePage` rule applies, and `panelType` changes often
+   imply a `stepInterval` change too. For pure metadata tweaks (rename,
+   recategorize), skip this step and do not touch `compositeQuery`.
+4. Modify only the field(s) the user asked to change.
+5. **Mandatory pre-save sample fetch — when `compositeQuery` changed.**
+   Run the 1-row probe from the Create flow's Step 5 against the new
+   filter. Empty → save anyway / revise / abort. Skip only for pure
+   metadata tweaks (rename, recategorize).
+6. **Show a diff-style preview before writing.** One line per changed
+   field: `name: "slow-checkout" → "slow-checkout-p99"`. Explicitly note
+   any fields that are unchanged (e.g. "compositeQuery: unchanged") and
+   include the Step 5 probe result when `compositeQuery` changed. This
+   prevents silent mistakes and gives the user a chance to catch a wrong
+   target view. Wait for confirmation on any change to `compositeQuery`,
+   since that changes what the view actually shows.
+7. Call `signoz:signoz_update_view` with `{ "viewId": "<id>", "view": <modified data> }`.
+
+### Delete a view
+
+Deletion is destructive and immediately removes the view from the shared
+list — any team member who had the view bookmarked will see it disappear.
+Depending on the host application, the user may be offered a one-click
+restore action shortly after the delete (the SigNoz Assistant captures a
+snapshot and exposes a `restore` action), but treat that as a recovery
+affordance, not a substitute for getting the delete right. Treat this like
+dropping a row from a shared table:
+
+1. **List to locate.** Call `signoz:signoz_list_views` to find the view
+   by name. If `sourcePage` is unknown, search all three signals.
+2. **Get to confirm — mandatory.** Call `signoz:signoz_get_view` with the
+   UUID from step 1. Do NOT skip this step even when you got the UUID from
+   a list result that looks correct. List results are paginated and a name
+   match is not a UUID guarantee — `signoz:signoz_get_view` is the confirmation
+   that the UUID maps to the view the user named.
+   Never call `signoz:signoz_delete_view` on a UUID without a prior
+   `signoz:signoz_get_view` confirming the matching name and `sourcePage`.
+3. **Show and ask.** Present the resolved view's name, `sourcePage`, and
+   category, and explicitly ask for confirmation. Do **not** auto-confirm
+   based on the original prompt, even an emphatic one — destructive
+   operations get a fresh confirmation against the resolved target.
+4. Call `signoz:signoz_delete_view`. Report success with the deleted
+   view's name (not just the UUID), so the user can recognize it.
+
+For autonomous agents without a human in the loop: refuse delete unless
+the calling context has been explicitly authorized for destructive
+operations on saved views, and log the resolved view metadata before the
+call.
+
+## Guardrails
+
+- **Mandatory pre-save sample fetch on create and on `compositeQuery`
+  updates.** Step 5 of each flow runs a 1-row probe against the
+  destination signal using the exact filter from the about-to-save
+  payload. Skipping is equivalent to skipping get-before-delete. The
+  Step 3 `signoz-generating-queries` delegation is necessary but not
+  sufficient — it validates the query *it* authored, not the filter
+  you persist after edits.
+
+  *Cross-signal-lift footgun:* field keys are signal-scoped. An
+  attribute observed on **metrics** (e.g. `oauth.error_code` on a
+  counter) may not exist on **traces** or **logs** for the same
+  tenant, even when emitted by the same service. Lifting an attribute
+  from a sibling dashboard panel, alert rule, or view that targets a
+  different signal is the most common source of empty saved views.
+  `signoz:signoz_get_field_keys signal=<sourcePage>` is necessary but
+  not sufficient — sparse emission still produces zero-result views.
+  Only the sample fetch confirms.
+
+  A saved view returning zero rows under its own filter is a
+  permanent artifact in a shared workspace; the human preview can't
+  tell from JSON that the filter won't match, and autonomous mode
+  has no preview, so the sample fetch is the only safety net.
+
+## Quick reference
+
+| Operation | Tools called | Key guard |
+|-----------|-------------|-----------|
+| Create | read `signoz://view/instructions` + `signoz://view/examples` → `signoz-generating-queries` → **sample fetch on exact filter** → preview → `signoz:signoz_create_view` | Mandatory pre-save sample fetch; preview before write; no legacy fields |
+| List | `signoz:signoz_list_views` (× 3 if no sourcePage given) | Check `pagination.hasMore` |
+| Get | `signoz:signoz_get_view(viewId)` | Returns canonical body for update |
+| Update | `signoz:signoz_get_view` → modify → **sample fetch if `compositeQuery` changed** → diff preview → `signoz:signoz_update_view` | Full-body replace; sample fetch when compositeQuery changes; diff preview required |
+| Delete | `signoz:signoz_list_views` → `signoz:signoz_get_view` → confirm → `signoz:signoz_delete_view` | Get-before-delete mandatory; fresh confirmation |
+
+## Common mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Hand-composing `compositeQuery` from examples or memory (even after reading `signoz://view/examples`) | Use the `Skill` tool to invoke `signoz-generating-queries` — reading examples and validating with `signoz:signoz_search_traces` is not a substitute |
+| Lifting an attribute name from a metric, alert rule, or sibling view and using it in a `sourcePage=traces` / `=logs` view filter without re-verifying on the destination signal | Field keys are signal-scoped; an attribute on metrics may not exist on traces or logs. Always re-check via `signoz:signoz_get_field_keys signal=<sourcePage>` **and** run the mandatory pre-save sample fetch — the key check is necessary but not sufficient |
+| Skipping the pre-save sample fetch because `signoz-generating-queries` already validated the query | The sub-skill validates the query *it* authored; the filter you persist may have been edited or lifted since then. The Step 5 sample fetch is mandatory regardless |
+| Skipping `signoz:signoz_get_view` before delete (relying on list UUID alone) | Always call `signoz:signoz_get_view` to confirm name+sourcePage before `signoz:signoz_delete_view` |
+| Sending legacy fields: `builder`, `promql`, `unit`, top-level `id`, `queryFormulas` | Read schema resources; server returns HTTP 400 silently |
+| `signal` ≠ `sourcePage` in builder query | Every `builder_query.signal` must equal the view's `sourcePage` |
+| Partial update body (omitting unchanged fields) | GET full body first → modify only changed fields → PUT entire body |
+| Declaring "no such view" after only page 1 | Check `pagination.hasMore`; continue with `offset = pagination.nextOffset` |
+| Using PromQL or raw ClickHouse in a view | Only `queryType: "builder"` is supported; offer a dashboard panel instead |
+| Setting `category` to an enum value | `category` is free-form string; omit if user doesn't specify |
+
+## Reporting back
+
+After any write (create / update / delete), include in your reply:
+- The view's name and UUID.
+- The `sourcePage`.
+- A direct link **only** if the MCP response or SigNoz frontend provides a
+  canonical URL, or the user explicitly asks for one. Do not fabricate
+  frontend routes — saved-view paths differ per signal and change over
+  time. When in doubt, omit the link and report the UUID + `sourcePage`.
+- For updates, what changed (one-line diff).
+- For deletes, an explicit "deleted" confirmation with the name.
+
+## Follow-up suggestions
+
+After a view operation, you may surface up to 3 follow-up intents that
+match what just happened. The host application renders them — follow
+the host's UI rendering rules for the exact mechanism. Use your
+judgment about what's natural for the user's context; do not pad to 3.
+
+Two anti-rules that override your judgment:
+
+- **Read-only stays read-only at the chip surface.** After list / get /
+  find, do not offer chips that propose a write (e.g. "Update this
+  view", "Delete this view"). That contradicts the read-only stop rule
+  in *Reporting back* below. Chips that re-run the view's underlying
+  query are fine — those stay on the read path. If the user's next
+  message names an update or delete, route from there.
+- **Do not duplicate host-injected actions.** If the host offers a
+  restore action after a delete (the SigNoz Assistant does), do not
+  also surface restore as a follow-up — it would render twice.
+
+When the user is purely exploring ("just listing my views", "what's
+in here?") and signals no further intent, skip follow-ups entirely.
+No chips beat wrong chips.
+
+Describe follow-ups by *user intent*, not by tool or skill name. The
+label the user clicks should read like the user's next prompt.
+
+Read-only operations (list, get) should report concisely — name, id,
+sourcePage, filter expression, panel type — and stop. Don't narrate
+the schema back to the user.

--- a/skills/signoz-managing-views/evals/evals.json
+++ b/skills/signoz-managing-views/evals/evals.json
@@ -1,0 +1,150 @@
+{
+  "skill_name": "signoz-managing-views",
+  "evals": [
+    {
+      "id": 0,
+      "name": "create-trace-view-for-service",
+      "prompt": "Save the current traces query as a view called 'checkout-errors' for the checkout service. I want to see only ERROR spans from service.name = checkout.",
+      "expected_output": "Agent resolves sourcePage=traces, builds a builder_query with filter service.name=checkout and status=error, sets panelType=list, runs the mandatory pre-save sample fetch (signoz:signoz_search_traces with limit=1 using the exact filter from compositeQuery.queries[0].spec), shows a preview with name/sourcePage/filter plus the sample-fetch result, confirms, and calls signoz:signoz_create_view. Reports back the name, UUID, and sourcePage.",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Agent calls signoz:signoz_create_view",
+          "description": "The primary write operation must be called"
+        },
+        {
+          "text": "sourcePage is set to 'traces' (not logs or metrics)",
+          "description": "sourcePage must match the user's intent; wrong value is a 400"
+        },
+        {
+          "text": "Filter includes service.name = checkout and status/error condition",
+          "description": "View must capture the user's stated filter criteria"
+        },
+        {
+          "text": "Agent runs the mandatory pre-save sample fetch via signoz:signoz_search_traces with limit=1 using the exact filter from the about-to-save payload before signoz:signoz_create_view",
+          "description": "Step 5 of the create flow: a saved view returning zero rows is a permanent artifact; the sample fetch is the only confirmation that the filter matches data"
+        },
+        {
+          "text": "Agent shows a preview (name, sourcePage, filter) before calling create",
+          "description": "Skill requires a preview step; without it user cannot catch errors"
+        },
+        {
+          "text": "Final reply includes the UUID returned by the server",
+          "description": "User needs UUID for future get/update/delete operations"
+        }
+      ]
+    },
+    {
+      "id": 1,
+      "name": "list-views-no-sourcepage",
+      "prompt": "Show me all my saved views.",
+      "expected_output": "Agent recognizes no sourcePage was given, calls signoz:signoz_list_views three times (once for each of traces, logs, metrics), merges results, and presents them organized by sourcePage. Checks pagination.hasMore for each signal before concluding.",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Agent calls signoz:signoz_list_views for all three signals: traces, logs, and metrics",
+          "description": "Without a sourcePage the agent must query all three"
+        },
+        {
+          "text": "Agent checks pagination.hasMore before concluding the list is complete",
+          "description": "A single page is not a complete list"
+        },
+        {
+          "text": "Results are organized/labeled by sourcePage in the reply",
+          "description": "Grouping by signal helps user find what they need"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "name": "rename-existing-view",
+      "prompt": "Rename the 'slow-checkout' view to 'slow-checkout-p99'.",
+      "expected_output": "Agent calls signoz:signoz_list_views to find the view by name, then signoz:signoz_get_view to fetch full body, shows diff preview (rename only, compositeQuery untouched), waits for confirmation, then calls signoz:signoz_update_view with the modified name only. Reports UUID, old name, new name.",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Agent calls signoz:signoz_list_views (or signoz:signoz_get_view) to resolve the view before updating",
+          "description": "Blind update without lookup risks wrong UUID"
+        },
+        {
+          "text": "Agent calls signoz:signoz_get_view to fetch the full body before composing update (GET-then-PUT)",
+          "description": "signoz:signoz_update_view is full-body replace; not fetching first risks wiping fields"
+        },
+        {
+          "text": "compositeQuery is not modified for a pure rename",
+          "description": "Touching compositeQuery for metadata-only change risks data loss"
+        },
+        {
+          "text": "Agent shows a diff-style preview before calling update",
+          "description": "Skill requires showing what will change"
+        },
+        {
+          "text": "Agent calls signoz:signoz_update_view with the modified name",
+          "description": "The rename must actually be written back"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "name": "delete-view-by-name",
+      "prompt": "Delete the 'checkout-errors' view.",
+      "expected_output": "Agent calls signoz:signoz_list_views to find the view by name, then calls signoz:signoz_get_view to confirm the UUID maps to a view named 'checkout-errors' with the expected sourcePage. Shows the resolved name, sourcePage, and category to the user and asks for explicit confirmation. Only after confirmation calls signoz:signoz_delete_view. Reports 'deleted' with the view name, not just the UUID.",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Agent calls signoz:signoz_list_views to locate the view by name before acting",
+          "description": "Must resolve name to UUID via listing; do not call delete on a guessed or user-pasted UUID without lookup"
+        },
+        {
+          "text": "Agent calls signoz:signoz_get_view to confirm the resolved UUID before deleting",
+          "description": "Paste errors happen; the get-before-delete guard prevents deleting the wrong view"
+        },
+        {
+          "text": "Agent shows the resolved view's name, sourcePage, and category and asks for explicit confirmation",
+          "description": "Delete is permanent; skill requires fresh confirmation against the resolved target, not just the original prompt"
+        },
+        {
+          "text": "Agent calls signoz:signoz_delete_view only after confirmation",
+          "description": "Must not auto-confirm based on original prompt"
+        },
+        {
+          "text": "Final reply confirms deletion by view name, not just UUID",
+          "description": "User should recognize what was deleted"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "name": "update-view-filter",
+      "prompt": "Update the 'checkout-errors' view to also show WARN spans, not just ERROR.",
+      "expected_output": "Agent calls signoz:signoz_list_views to find the view, then signoz:signoz_get_view to fetch full body. Recognizes this is a compositeQuery change and invokes signoz-generating-queries skill to build a new query with status IN (ERROR, WARN). Runs the mandatory pre-save sample fetch against the new filter (signoz:signoz_search_traces with limit=1 since sourcePage=traces) — required because compositeQuery changed. Shows a diff preview with old vs new filter expression, notes compositeQuery is changing, and includes the sample-fetch result. Waits for confirmation, then calls signoz:signoz_update_view with the validated compositeQuery. Reports back UUID, name, and what changed.",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Agent calls signoz:signoz_get_view to fetch the full body before composing update (GET-then-PUT)",
+          "description": "Full-body replace; not fetching first risks wiping fields"
+        },
+        {
+          "text": "Agent invokes signoz-generating-queries skill to build the new compositeQuery",
+          "description": "Query changes must go through signoz-generating-queries for validation; hand-editing compositeQuery risks malformed payloads"
+        },
+        {
+          "text": "Agent runs the mandatory pre-save sample fetch via signoz:signoz_search_traces with limit=1 using the new filter before signoz:signoz_update_view",
+          "description": "Step 5 of the update flow: compositeQuery changed, so the 1-row probe against the new filter is required (skip only for pure metadata tweaks)"
+        },
+        {
+          "text": "Agent shows a diff-style preview before writing, explicitly calling out the compositeQuery change",
+          "description": "Skill requires confirmation for compositeQuery changes; user must see what is changing"
+        },
+        {
+          "text": "Agent calls signoz:signoz_update_view with the validated compositeQuery",
+          "description": "The filter change must actually be written back"
+        },
+        {
+          "text": "signal in every builder_query matches the view's sourcePage",
+          "description": "signal != sourcePage is a server-side error"
+        }
+      ]
+    }
+  ]
+}

--- a/skills/signoz-mcp-setup/SKILL.md
+++ b/skills/signoz-mcp-setup/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: signoz-mcp-setup
+description: >
+  Initialize or repair SigNoz MCP server configuration for Claude Code, Codex,
+  Cursor, VS Code/GitHub Copilot, Claude Desktop, Gemini CLI, Windsurf, Zed,
+  Antigravity, OpenCode, or another MCP client. Use this skill before any
+  SigNoz docs, query, dashboard, alert, or view workflow when
+  `signoz:signoz_*` tools are unavailable, or when the user says "setup SigNoz
+  MCP", "configure SigNoz plugin", "wrong region", "change SigNoz region",
+  "MCP auth failed", or asks to connect SigNoz Cloud or a self-hosted MCP
+  endpoint, even if they do not mention the plugin.
+argument-hint: <client, SigNoz Cloud region, MCP URL, or self-hosted /mcp URL>
+---
+
+# SigNoz MCP Setup
+
+Initialize or repair the SigNoz MCP server registration shipped with this
+plugin. The target state is one working `signoz` MCP server. Do not create a
+duplicate server unless the user explicitly asks for a separate configuration.
+
+## Shared reference
+
+Read [references/mcp-settings.md](references/mcp-settings.md) before checking
+state, mapping user input, or editing registration files. It contains the
+server-state check, registration file locations, editing rules, and region
+mapping used by this procedure.
+
+Read [references/client-configs.md](references/client-configs.md) when the
+user names a client other than the bundled Claude Code, Codex, or Cursor
+plugin path, when a native client config already exists, or when self-hosted
+stdio/local-binary setup is requested.
+
+## Configuration procedure
+
+### Step 1: Check state
+
+Silently determine the SigNoz MCP server state using the reference flow:
+
+- **working** — continue with the user's original SigNoz request.
+- **not-setup** — run Step 2.
+- **configured-but-not-working** — if the user provided a new region or MCP URL,
+  run Step 2. Otherwise tell them the SigNoz MCP server is configured but not
+  connected, then ask for the SigNoz Cloud region or MCP URL to repair it. If
+  they believe the endpoint is already correct, tell them to complete the
+  client authentication step in Step 5.
+
+Do not fall back to raw HTTP calls for SigNoz data when MCP is unavailable.
+The MCP server is the supported API surface for this plugin's live SigNoz
+workflows.
+
+### Step 2: Identify the client
+
+Use the client named in `$ARGUMENTS` or the user's latest message. If no
+client is named, infer it only when the active environment is obvious:
+
+- Claude Code, Codex, or Cursor plugin install: use the bundled plugin
+  registration files.
+- VS Code / GitHub Copilot, Claude Desktop, Gemini CLI, Windsurf, Zed,
+  Antigravity, or OpenCode: use the matching native client recipe in
+  `client-configs.md`.
+- Unknown or unsupported client: use the generic HTTP MCP recipe and point the
+  user to the SigNoz MCP Server docs for their client's exact config surface.
+
+If you need to edit a native client config and the client is still ambiguous,
+ask which client they want to configure.
+
+### Step 3: Resolve the endpoint
+
+Use `$ARGUMENTS` or the user's latest message if it already contains a region
+or URL. Otherwise ask for one of:
+
+- SigNoz Cloud region: `us`, `us2`, `eu`, `eu2`, `in`, `in2`, or a newer
+  region code
+- SigNoz Cloud MCP URL, such as `https://mcp.us.signoz.cloud/mcp`
+- Self-hosted HTTP MCP URL, such as `http://localhost:8000/mcp`
+
+Map the response using `mcp-settings.md`. If the user gives only a SigNoz
+workspace URL such as `https://your-instance.signoz.cloud`, do not guess the
+region from it. Ask them to check **Settings -> Ingestion** in SigNoz and
+provide the region.
+
+Do not ask for an API key for SigNoz Cloud setup. OAuth asks for the instance
+URL and service account API key after the hosted MCP URL is configured. For
+self-hosted SigNoz, prefer HTTP mode when the user gives an `/mcp` endpoint.
+For stdio/local-binary mode, collect the binary path, SigNoz URL, and API key
+only if the user explicitly asks you to configure that mode. For clients that
+cannot complete interactive OAuth, use the header-based fallback in
+`client-configs.md` only when the user asks for it or the client requires it.
+
+### Step 4: Apply the endpoint
+
+For bundled Claude Code, Codex, and Cursor plugin installs, edit the registration
+files using the reference editing rules:
+
+1. In `.signoz_claude_mcp.json` for Claude Code, replace the full `url` value
+   with the resolved MCP endpoint.
+2. In `.mcp.json` for Codex, replace the full `url` value with the resolved MCP
+   endpoint.
+3. In `.signoz_cursor_mcp.json` for Cursor, replace the full `url` value with the
+   resolved MCP endpoint.
+4. Preserve unrelated MCP servers and settings.
+
+Claude Code and Codex target shape:
+
+```json
+{
+  "mcpServers": {
+    "signoz": {
+      "url": "https://mcp.us.signoz.cloud/mcp"
+    }
+  }
+}
+```
+
+Cursor target shape:
+
+```json
+{
+  "mcpServers": {
+    "signoz": {
+      "url": "https://mcp.us.signoz.cloud/mcp"
+    }
+  }
+}
+```
+
+If either bundled file still uses any `SIGNOZ_MCP_URL` wrapper from an older
+version, replace it with the concrete resolved URL.
+
+Bundled registration files live inside the installed plugin. Plugin updates can
+reset them to the placeholder; if that happens, rerun this setup skill. For a
+more durable native-client setup, use the relevant recipe in `client-configs.md`.
+
+For native client setup, use `client-configs.md`:
+
+- Edit an existing native client config only when the user named that client or
+  the target file is clearly the active config for the task.
+- Create a new native client config only when the user asks for that client to
+  be configured.
+- Never write service account API keys, bearer tokens, or header-based auth
+  values into tracked project files. Prefer client OAuth for SigNoz Cloud,
+  user-level config, environment-variable references, or short commands the
+  user can run locally.
+- Preserve unrelated MCP servers and existing client settings.
+- Keep the server name `signoz`.
+
+### Step 5: Tell the user how to finish
+
+Tell the user that the SigNoz MCP endpoint has been configured, then give the
+client-specific authentication step:
+
+- **Cursor** — reload the window, then authenticate the `signoz` MCP server in
+  Tools & MCP if prompted.
+- **VS Code / GitHub Copilot** — open Copilot Chat in Agent mode, approve the
+  `signoz` server if prompted, then complete the authentication flow.
+- **Codex** — restart Codex if the server does not appear. For SigNoz Cloud,
+  run `codex mcp login signoz` to complete OAuth, then verify with `/mcp`. For a
+  self-hosted HTTP endpoint (no OAuth unless the server runs with
+  `OAUTH_ENABLED=true`), skip the login step and just verify with `/mcp` that the
+  already-authenticated `signoz` server is connected.
+- **Claude Code** — restart Claude Code if the server does not appear, then run
+  `/mcp`, select `signoz`, and complete authentication.
+- **Claude Desktop** — restart Claude Desktop or reconnect the custom
+  connector, then complete authentication when prompted.
+- **Gemini CLI** — restart Gemini CLI if needed, then run `/mcp auth signoz`.
+- **Windsurf** — reload Windsurf and complete authentication when prompted.
+- **Zed** — reload Zed after config changes; self-hosted stdio mode reads the
+  configured environment from the context server entry.
+- **Antigravity** — reload the agent window and complete OAuth when prompted.
+  If authentication is stuck, clear cached dynamic auth providers and retry.
+- **OpenCode** — run `opencode mcp auth signoz` if authentication does not
+  start automatically, then verify with `opencode mcp list`.
+
+Keep the response short. Do not expose registration file paths, placeholder
+values, environment variable names, API keys, tokens, or file contents unless
+the user explicitly asks for implementation details.

--- a/skills/signoz-mcp-setup/references/client-configs.md
+++ b/skills/signoz-mcp-setup/references/client-configs.md
@@ -1,0 +1,406 @@
+# SigNoz MCP Client Config Reference
+
+Use this reference after resolving the SigNoz MCP endpoint in
+[mcp-settings.md](mcp-settings.md). It mirrors the client setup patterns in the
+SigNoz MCP Server docs and adds OpenCode's native config shape.
+
+## Contents
+
+- [Safety Rules](#safety-rules)
+- [Cloud or Self-Hosted HTTP](#cloud-or-self-hosted-http)
+- [Header-Based Auth Fallback](#header-based-auth-fallback)
+- [Self-Hosted Stdio](#self-hosted-stdio)
+- [Authentication Finish Steps](#authentication-finish-steps)
+
+## Safety Rules
+
+- Keep the MCP server name `signoz`.
+- Prefer SigNoz Cloud OAuth over header-based auth whenever the client supports
+  interactive OAuth.
+- Do not write service account API keys, bearer tokens, or header-based auth
+  values into tracked project files.
+- If secrets are needed for self-hosted stdio, prefer user-level config,
+  environment-variable references, or a command the user can run.
+- When editing JSON, TOML, or JSONC, preserve unrelated settings and other MCP
+  servers. Update only the `signoz` server entry.
+- If the client supports both project and user/global config, prefer the scope
+  the user requested. If they did not choose, prefer user/global for secrets
+  and project scope for non-secret hosted MCP URLs.
+
+## Cloud or Self-Hosted HTTP
+
+Use these shapes for SigNoz Cloud hosted MCP URLs such as
+`https://mcp.us.signoz.cloud/mcp` and self-hosted HTTP MCP URLs such as
+`http://localhost:8000/mcp`.
+
+### Bundled Claude Code plugin
+
+In `.signoz_claude_mcp.json` in the SigNoz plugin root, replace only the `url`
+value with the resolved MCP endpoint (concrete URL rule from `mcp-settings.md`).
+Leave the `type` field and other settings unchanged.
+
+```json
+{
+  "mcpServers": {
+    "signoz": {
+      "type": "http",
+      "url": "https://mcp.us.signoz.cloud/mcp"
+    }
+  }
+}
+```
+
+### Bundled Codex plugin
+
+In `.mcp.json` in the SigNoz plugin root, replace only the `url` value with the
+resolved MCP endpoint (concrete URL rule from `mcp-settings.md`). Codex does not
+reliably expand shell-style environment defaults in plugin MCP URLs.
+
+```json
+{
+  "mcpServers": {
+    "signoz": {
+      "url": "https://mcp.us.signoz.cloud/mcp"
+    }
+  }
+}
+```
+
+### Bundled Cursor plugin
+
+Update `.signoz_cursor_mcp.json` in the SigNoz plugin root using the concrete URL
+rule from `mcp-settings.md`. Do not rely on shell-style environment defaults in
+Cursor plugin MCP URLs.
+
+```json
+{
+  "mcpServers": {
+    "signoz": {
+      "url": "https://mcp.us.signoz.cloud/mcp"
+    }
+  }
+}
+```
+
+### Cursor native config
+
+Use `.cursor/mcp.json` in the project root.
+
+```json
+{
+  "mcpServers": {
+    "signoz": {
+      "url": "https://mcp.us.signoz.cloud/mcp"
+    }
+  }
+}
+```
+
+### VS Code / GitHub Copilot
+
+Use `.vscode/mcp.json` in the workspace, or the user-level MCP config opened
+by the `MCP: Open User Configuration` command.
+
+```json
+{
+  "servers": {
+    "signoz": {
+      "type": "http",
+      "url": "https://mcp.us.signoz.cloud/mcp"
+    }
+  }
+}
+```
+
+### Claude Desktop
+
+Claude Desktop can add SigNoz Cloud as a custom connector from Settings. If
+the user asks for raw config, add the `signoz` entry to
+`claude_desktop_config.json`.
+
+```json
+{
+  "mcpServers": {
+    "signoz": {
+      "url": "https://mcp.us.signoz.cloud/mcp"
+    }
+  }
+}
+```
+
+### Claude Code native CLI
+
+For user scope:
+
+```sh
+claude mcp add --scope user --transport http signoz https://mcp.us.signoz.cloud/mcp
+```
+
+For project scope, use `--scope project` instead of `--scope user`.
+
+### Codex native CLI or TOML
+
+CLI:
+
+```sh
+codex mcp add signoz --url https://mcp.us.signoz.cloud/mcp
+```
+
+TOML:
+
+```toml
+[mcp_servers.signoz]
+url = "https://mcp.us.signoz.cloud/mcp"
+```
+
+### Gemini CLI
+
+CLI:
+
+```sh
+gemini mcp add -t http signoz https://mcp.us.signoz.cloud/mcp
+```
+
+Or edit `~/.gemini/settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "signoz": {
+      "httpUrl": "https://mcp.us.signoz.cloud/mcp"
+    }
+  }
+}
+```
+
+### Windsurf
+
+Edit `~/.codeium/windsurf/mcp_config.json`.
+
+```json
+{
+  "mcpServers": {
+    "signoz": {
+      "serverUrl": "https://mcp.us.signoz.cloud/mcp"
+    }
+  }
+}
+```
+
+### Antigravity
+
+Edit `mcp_config.json` from the agent panel's MCP server manager.
+
+```json
+{
+  "mcpServers": {
+    "signoz": {
+      "serverUrl": "https://mcp.us.signoz.cloud/mcp"
+    }
+  }
+}
+```
+
+### OpenCode
+
+Edit `opencode.json` or `opencode.jsonc`.
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "signoz": {
+      "type": "remote",
+      "url": "https://mcp.us.signoz.cloud/mcp",
+      "enabled": true
+    }
+  }
+}
+```
+
+### Generic HTTP MCP client
+
+If the client is not listed, use its native remote or HTTP MCP shape with:
+
+- server name: `signoz`
+- transport/type: HTTP, remote, or streamable HTTP
+- URL: the resolved SigNoz MCP endpoint
+
+## Header-Based Auth Fallback
+
+Use header-based auth only when the MCP client cannot complete interactive
+OAuth, or when the user explicitly asks for a non-OAuth setup. SigNoz Cloud
+needs both headers:
+
+- `SIGNOZ-API-KEY`: service account API key
+- `X-SigNoz-URL`: SigNoz instance URL, such as `https://your-instance.signoz.cloud`
+
+Prefer environment-variable references if the client supports them. Do not
+write real header values into tracked project files.
+
+Generic shape:
+
+```json
+{
+  "mcpServers": {
+    "signoz": {
+      "url": "https://mcp.us.signoz.cloud/mcp",
+      "headers": {
+        "SIGNOZ-API-KEY": "<your-api-key>",
+        "X-SigNoz-URL": "<your-signoz-instance-url>"
+      }
+    }
+  }
+}
+```
+
+## Self-Hosted Stdio
+
+Use stdio/local-binary mode only when the user explicitly requests it or the
+client cannot use HTTP. Collect:
+
+- absolute path to the `signoz-mcp-server` binary
+- SigNoz instance URL
+- service account API key
+
+Prefer placeholders or environment-variable references when writing examples.
+Avoid storing real API keys in tracked project files.
+
+### JSON clients using `mcpServers`
+
+Cursor, Claude Desktop, Windsurf, Gemini CLI, and Antigravity can use this
+basic stdio shape, with client-specific file locations from the HTTP section.
+
+```json
+{
+  "mcpServers": {
+    "signoz": {
+      "command": "<path-to-binary>/signoz-mcp-server",
+      "args": [],
+      "env": {
+        "SIGNOZ_URL": "<your-signoz-url>",
+        "SIGNOZ_API_KEY": "<your-api-key>",
+        "LOG_LEVEL": "info"
+      }
+    }
+  }
+}
+```
+
+### VS Code / GitHub Copilot stdio
+
+```json
+{
+  "servers": {
+    "signoz": {
+      "type": "stdio",
+      "command": "<path-to-binary>/signoz-mcp-server",
+      "args": [],
+      "env": {
+        "SIGNOZ_URL": "<your-signoz-url>",
+        "SIGNOZ_API_KEY": "<your-api-key>",
+        "LOG_LEVEL": "info"
+      }
+    }
+  }
+}
+```
+
+### Claude Code stdio
+
+```sh
+claude mcp add --scope user signoz "<path-to-binary>/signoz-mcp-server" \
+  -e SIGNOZ_URL="<your-signoz-url>" \
+  -e SIGNOZ_API_KEY="<your-api-key>" \
+  -e LOG_LEVEL=info
+```
+
+### Codex stdio
+
+CLI:
+
+```sh
+codex mcp add signoz \
+  --env SIGNOZ_URL="<your-signoz-url>" \
+  --env SIGNOZ_API_KEY="<your-api-key>" \
+  --env LOG_LEVEL=info \
+  -- "<path-to-binary>/signoz-mcp-server"
+```
+
+TOML:
+
+```toml
+[mcp_servers.signoz]
+command = "<path-to-binary>/signoz-mcp-server"
+args = []
+
+[mcp_servers.signoz.env]
+SIGNOZ_URL = "<your-signoz-url>"
+SIGNOZ_API_KEY = "<your-api-key>"
+LOG_LEVEL = "info"
+```
+
+### Zed
+
+Edit Zed settings.
+
+```json
+{
+  "context_servers": {
+    "signoz": {
+      "command": "<path-to-binary>/signoz-mcp-server",
+      "args": [],
+      "env": {
+        "SIGNOZ_URL": "<your-signoz-url>",
+        "SIGNOZ_API_KEY": "<your-api-key>",
+        "LOG_LEVEL": "info"
+      }
+    }
+  }
+}
+```
+
+### OpenCode local
+
+Edit `opencode.json` or `opencode.jsonc`.
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "signoz": {
+      "type": "local",
+      "command": ["<path-to-binary>/signoz-mcp-server"],
+      "environment": {
+        "SIGNOZ_URL": "<your-signoz-url>",
+        "SIGNOZ_API_KEY": "<your-api-key>",
+        "LOG_LEVEL": "info"
+      },
+      "enabled": true
+    }
+  }
+}
+```
+
+## Authentication Finish Steps
+
+- Cursor: reload the window, then authenticate the `signoz` MCP server in
+  Tools & MCP if prompted.
+- VS Code / GitHub Copilot: open Copilot Chat in Agent mode, approve the
+  `signoz` server, and complete authentication.
+- Claude Desktop: restart or reconnect the custom connector, then complete
+  authentication.
+- Claude Code: run `/mcp`, select `signoz`, and complete authentication.
+- Codex (SigNoz Cloud): run `codex mcp login signoz`, then verify with `/mcp`.
+- Codex (self-hosted HTTP): no OAuth step unless the server runs with
+  `OAUTH_ENABLED=true`; skip `codex mcp login` and verify the already-authenticated
+  `signoz` server with `/mcp`.
+- Gemini CLI: run `/mcp auth signoz`.
+- Windsurf: reload and complete authentication when prompted.
+- Zed: reload after stdio config changes.
+- Antigravity: reload the agent window and complete OAuth. If auth is stuck,
+  clear dynamic authentication providers and retry.
+- OpenCode: run `opencode mcp auth signoz` if auth does not start
+  automatically, then verify with `opencode mcp list`.
+- Header-based auth: no OAuth step is expected; verify the `signoz` tools after
+  the client reloads.

--- a/skills/signoz-mcp-setup/references/mcp-settings.md
+++ b/skills/signoz-mcp-setup/references/mcp-settings.md
@@ -1,0 +1,131 @@
+# SigNoz MCP Registration Reference
+
+Use this reference when checking the SigNoz MCP server state, locating plugin
+registration files, editing the endpoint default, or mapping user input to a
+hosted SigNoz Cloud MCP URL.
+
+For native client config shapes such as VS Code, Gemini CLI, Windsurf, Zed,
+Antigravity, or OpenCode, read
+[client-configs.md](client-configs.md) after resolving the endpoint.
+
+## Contents
+
+- [State Check](#state-check)
+- [Registration Files](#registration-files)
+- [Editing Rules](#editing-rules)
+- [Endpoint Mapping](#endpoint-mapping)
+
+## State Check
+
+Silently determine `signoz-server-state`:
+
+1. If `signoz:signoz_*` MCP tools are available, try a lightweight read-only
+   call such as `signoz:signoz_search_docs` for `mcp setup` or
+   `signoz:signoz_list_services` with a small lookback.
+2. If the call returns SigNoz-specific content, state is **working**.
+3. If the call fails, returns no tools, or only generic/empty content, read the
+   plugin registration files below.
+4. If any registration file contains `not-setup`, state is **not-setup**.
+5. Otherwise state is **configured-but-not-working**.
+
+Do not tell the user which checks ran or what file contents were found. Explain
+only the plain outcome: working, not set up, or configured but not connected.
+
+## Registration Files
+
+The SigNoz plugin may ship these bundled registration files in the plugin root:
+
+- `.signoz_claude_mcp.json` for Claude Code
+- `.mcp.json` for Codex
+- `.signoz_cursor_mcp.json` for Cursor
+
+This reference file lives at `skills/signoz-mcp-setup/references/mcp-settings.md`,
+so the plugin root is two directories up from `skills/signoz-mcp-setup/`.
+
+Update every registration file that exists. Do not create duplicate MCP server
+entries, and do not rename the `signoz` server.
+
+## Editing Rules
+
+Use the client-specific shape for the registration file you are editing.
+
+### Bundled plugin MCP files
+
+The URL should use a concrete endpoint in all bundled registration files:
+
+- `.signoz_claude_mcp.json` for Claude Code
+- `.mcp.json` for Codex
+- `.signoz_cursor_mcp.json` for Cursor
+
+```json
+"url": "https://mcp.us.signoz.cloud/mcp"
+```
+
+Replace the entire `url` value with the resolved MCP endpoint. Do not keep
+`${SIGNOZ_MCP_URL:-...}` in bundled plugin MCP files; Codex treats it as a
+literal URL, and Cursor documents interpolation syntax that does not include
+shell-style defaults.
+
+If either bundled file contains any legacy `SIGNOZ_MCP_URL` wrapper, replace
+the full value with the concrete resolved URL.
+
+Examples:
+
+```text
+https://mcp.eu.signoz.cloud/mcp
+http://localhost:8000/mcp
+```
+
+If the user's client has an explicit plugin setting or environment override for
+the endpoint, that value can override this default. If this setup skill updates
+the default but the client still connects to the old endpoint, tell the user to
+clear the explicit plugin setting and reload the client.
+
+### Update behavior
+
+These bundled files live inside the installed plugin. Plugin updates can reset
+them to the placeholder. If the `signoz` server returns to **not-setup** after
+an update, rerun `signoz-mcp-setup`. For durable native client configuration,
+use the client-specific recipes in `client-configs.md`.
+
+## Endpoint Mapping
+
+SigNoz Cloud hosted MCP URLs use the same region code shown in
+**Settings -> Ingestion** and documented in the SigNoz Cloud region reference.
+
+| User input | MCP URL |
+|---|---|
+| `us`, `US`, United States, `ingest.us.signoz.cloud` | `https://mcp.us.signoz.cloud/mcp` |
+| `us2`, `US2`, `ingest.us2.signoz.cloud` | `https://mcp.us2.signoz.cloud/mcp` |
+| `eu`, `EU`, Europe, `ingest.eu.signoz.cloud` | `https://mcp.eu.signoz.cloud/mcp` |
+| `eu2`, `EU2`, `ingest.eu2.signoz.cloud` | `https://mcp.eu2.signoz.cloud/mcp` |
+| `in`, `IN`, India, `ingest.in.signoz.cloud` | `https://mcp.in.signoz.cloud/mcp` |
+| `in2`, `IN2`, `ingest.in2.signoz.cloud` | `https://mcp.in2.signoz.cloud/mcp` |
+
+Mapping rules:
+
+- **Known region code** — map `us`, `us2`, `eu`, `eu2`, `in`, or `in2`
+  case-insensitively.
+- **Hosted MCP URL** — accept `https://mcp.<region>.signoz.cloud/mcp` as-is
+  after normalizing the region to lowercase.
+- **Hosted MCP host only** — add `https://` and `/mcp`.
+- **Ingestion endpoint** — map `ingest.<region>.signoz.cloud` to the matching
+  hosted MCP URL.
+- **Self-hosted HTTP MCP URL** — accept any `http://.../mcp` or
+  `https://.../mcp` URL that is not a SigNoz Cloud workspace URL. This plugin
+  configuration path configures URL-based HTTP MCP. For stdio/local-binary
+  mode, tell the user to register the SigNoz MCP server separately as
+  `signoz`.
+- **SigNoz workspace URL** — do not infer the region from
+  `https://<workspace>.signoz.cloud`. Ask the user for the region from
+  **Settings -> Ingestion**.
+- **Unknown hosted region code** — ask for confirmation before using
+  `https://mcp.<region>.signoz.cloud/mcp`. New SigNoz Cloud regions may exist
+  before this skill is updated.
+
+Do not ask for API keys for SigNoz Cloud endpoint setup. SigNoz Cloud
+authentication happens after endpoint setup through the MCP client's OAuth
+flow. Self-hosted HTTP mode expects the user to run the MCP server with its
+SigNoz URL and API key configured on that server process. For self-hosted
+stdio/local-binary mode, read `client-configs.md` and collect secrets only when
+the user explicitly asks you to configure that mode.

--- a/skills/signoz-modifying-dashboards/SKILL.md
+++ b/skills/signoz-modifying-dashboards/SKILL.md
@@ -1,0 +1,286 @@
+---
+name: signoz-modifying-dashboards
+description: >
+  Modify an existing SigNoz dashboard — add or remove panels, edit a
+  panel's query, threshold, or unit, rename the dashboard, change a
+  panel type (graph ↔ table ↔ value), rearrange the layout, add or edit
+  variables, or update tags. Make sure to use this skill whenever the
+  user says "add a panel to my dashboard", "change the query on this
+  panel", "remove the latency widget", "rename my dashboard", "update
+  the filters", "rearrange the layout", "add a variable", "change panel
+  type from graph to table", or otherwise asks to change something on a
+  dashboard that already exists — even if they don't say "modify" or
+  "edit" explicitly.
+---
+
+# Dashboard Modify
+
+## Prerequisites
+
+This skill calls SigNoz MCP server tools (`signoz:signoz_get_dashboard`,
+`signoz:signoz_update_dashboard`, `signoz:signoz_list_dashboards`, `signoz:signoz_list_metrics`).
+Before running the workflow, confirm the `signoz:signoz_*` tools are available.
+If they are not, the SigNoz MCP server is not installed or configured —
+run `signoz-mcp-setup` first to initialize or repair the MCP connection. Do not
+fall back to raw HTTP calls or hand-edit dashboard JSON without the MCP tools.
+
+## When to use
+
+Use this skill when the user asks to:
+- Add, remove, or edit panels/widgets on an existing dashboard
+- Change a panel's query, title, type, or display settings
+- Add, remove, or edit dashboard variables
+- Rename or re-describe a dashboard
+- Rearrange panel layout or resize panels
+- Change a panel type (e.g., graph to table, value to graph)
+- Add or modify thresholds on a panel
+- Update tags on a dashboard
+
+Do NOT use when:
+- User wants to understand what a dashboard shows → `signoz-explaining-dashboards`
+
+## Instructions
+
+### Step 1: Identify the target dashboard
+
+Determine which dashboard the user wants to modify. If the user provides a
+dashboard name, UUID, or it is clear from context (e.g., an @mention or auto-context
+providing a dashboard resource), use that.
+
+If the target dashboard is ambiguous:
+1. Call `signoz:signoz_list_dashboards` to list existing dashboards. **Paginate through
+   all pages** — check `pagination.hasMore` in the response. If `hasMore` is true,
+   call again with `offset` set to `pagination.nextOffset` and repeat until all
+   pages are exhausted. Never stop at the first page.
+2. Present matching candidates to the user and ask which one to modify.
+
+### Step 2: Fetch the current dashboard state
+
+Call `signoz:signoz_get_dashboard` with the dashboard UUID to retrieve its full
+configuration. This is **mandatory** — `signoz:signoz_update_dashboard` requires the
+complete post-update state, not a partial patch. Never skip this step.
+
+Examine the response to understand:
+- Current widgets and their IDs
+- Current layout positions (x, y, w, h in the 12-column grid)
+- Current variables
+- Current queries on each panel
+- The `panelMap` structure (row-to-child mappings)
+
+### Step 3: Plan the modification
+
+Based on the user's request, plan the changes.
+
+**Confirm with the user before applying if:**
+- The modification is **destructive** — removing panels, deleting variables,
+  replacing an entire query with a different one, changing a panel's `dataSource`
+  (e.g., traces → logs), or fundamentally altering what data is shown (changing
+  aggregation from p99 to avg, removing groupBy dimensions)
+- The request is **ambiguous** — multiple panels could match "the latency panel"
+- The change is **large** — restructuring sections, adding many panels at once
+
+**Destructive means data loss or silent behavior change.** Even if the user says
+"just do it quickly," a brief confirmation ("I'll remove 'Memory Fragmentation'
+permanently — OK?") takes seconds and prevents irreversible mistakes. User urgency
+does not override this guardrail.
+
+**Non-destructive changes proceed directly:** renaming, adding a single panel,
+changing a unit, adding a variable, changing panel type (the query is preserved),
+adjusting layout, adding thresholds.
+
+**Compound modifications:** When a request involves multiple changes (e.g., remove a
+panel + add a panel + rename), plan all changes against the fetched state and apply
+them as a single update. Do not apply and re-fetch between changes.
+
+### Step 4: Apply the modification
+
+Merge the planned changes into the full dashboard JSON from Step 2.
+
+**Modification rules:**
+
+- **Preserve everything you are not changing.** Copy the entire dashboard object
+  and only modify the specific fields the user asked about. Do not drop widgets,
+  variables, layout items, or panelMap entries that are not part of the change.
+
+- **Adding a panel:**
+  1. Create a new widget with a UUID for its `id` (use `crypto.randomUUID()` format).
+  2. Include **all** required widget fields: `id`, `title`, `description`,
+     `panelTypes`, `query`, `opacity` ("1"), `nullZeroValues` ("zero"),
+     `timePreferance` ("GLOBAL_TIME" — note the deliberate misspelling),
+     `stepSize` (60), `yAxisUnit`, `isStacked` (false), `fillSpans` (false),
+     `isLogScale` (false), `mergeAllActiveQueries` (false), `thresholds` ([]),
+     `softMin` (0), `softMax` (0), `legendPosition` ("bottom"), `columnUnits` ({}),
+     `customLegendColors` ({}), `selectedLogFields` ([]), `selectedTracesFields`
+     ([]), `contextLinks` ({"linksData": []}).
+  3. Add a layout entry with `i` matching the widget ID, and appropriate `x`, `y`,
+     `w`, `h` values in the 12-column grid.
+  4. If the dashboard uses rows, add the panel's layout to the appropriate row's
+     `panelMap[rowId].widgets` array. If the dashboard has no rows (empty
+     `panelMap`), skip panelMap — the panel lives at the top level.
+  5. For query construction, read the `signoz://dashboard/query-builder-example`
+     MCP resource for the v5 builder query format. Use the signal-specific
+     resources as needed (`signoz://dashboard/promql-example`,
+     `signoz://dashboard/clickhouse-*`, `signoz://traces/query-builder-guide`).
+  6. All modified panels are validated below as a hard requirement —
+     see the "Dry-run modified panels" step before
+     `signoz:signoz_update_dashboard` and the "Mandatory dry-run
+     before update" guardrail. Author the JSON here as you intend to
+     save it — the dry-run uses the exact shape from `queryData`.
+
+- **Removing a panel:** Remove the widget from `widgets`, its entry from `layout`,
+  and its entry from the parent row's `panelMap.widgets` (if it exists in panelMap).
+  **Do not** try to auto-compact or shift `y` positions of remaining panels — the
+  SigNoz frontend grid engine handles gap-closing automatically. Simply remove the
+  three references (widget, layout, panelMap entry) and leave all other positions
+  unchanged.
+
+- **Editing a panel's query:** Replace the query object on the target widget. Keep
+  all other widget fields intact. If the user is changing *what* the panel
+  measures (not just renaming a label), the new query is validated by the
+  mandatory dry-run step below (and the "Mandatory dry-run before update"
+  guardrail) — replacing a working query with a broken one is a destructive
+  change the user will only notice after the panel goes empty.
+
+- **Changing panel type:** Update `panelTypes` and handle type-specific fields:
+  - `graph` → `table`: add `columnUnits` ({}) and `columnWidths` ({}) if missing.
+    Graph-only fields like `isStacked`, `fillSpans`, `isLogScale` become inert but
+    are harmless to leave.
+  - `graph`/`table` → `histogram`: add `bucketCount` (30) and `bucketWidth` (0).
+  - Any → `list` (logs): add `selectedLogFields` array.
+  - Any → `list` (traces): add `selectedTracesFields` array.
+  - Keep the existing query intact — the data source and query are independent of
+    the visualization type.
+
+- **Adding/editing variables:** Add or update entries in the `variables` map. Use
+  OTel attribute names for the underlying attribute (e.g., `service.name`,
+  `deployment.environment.name`). Use DYNAMIC type when the values come from a
+  standard telemetry attribute. Each variable needs a UUID for `id` and `key`.
+
+- **Rearranging layout / side-by-side placement:**
+  - Dashboard uses a **12-column grid**. `x` ranges 0–11, `w` ranges 1–12.
+  - Two panels side-by-side: each gets `w: 6`, first at `x: 0`, second at `x: 6`,
+    same `y` and `h`.
+  - Three panels in a row: `w: 4` at `x: 0`, `x: 4`, `x: 8`.
+  - When resizing an existing panel to make room, update its `w` and `x`, then
+    place the new panel in the freed space at the same `y`.
+  - Common heights: `h: 6` for graphs/tables, `h: 2`–`h: 3` for value panels,
+    `h: 1` for row headers.
+  - **Keep panelMap in sync**: whenever you change `x`, `y`, `w`, or `h` in the
+    top-level `layout` array, apply the same change to the matching entry in
+    `panelMap[rowId].widgets`. These are duplicated and must stay consistent.
+
+**Dry-run modified panels (mandatory).** Before
+`signoz:signoz_update_dashboard`, call
+`signoz:signoz_execute_builder_query` for each modified panel.
+Translate the widget's `builder.queryData[]` / `queryFormulas[]` into
+the endpoint's `queries[].{type, spec}` envelope: each `queryData[i]`
+→ `{ type: "builder_query", spec: { name, signal, filter:
+{expression}, groupBy, aggregations } }`; each `queryFormulas[i]` →
+`{ type: "builder_formula", spec: { name, expression } }`. **Preserve
+the original `name`** (`A`, `B`, …) on every `builder_query.spec` —
+formula expressions reference inputs by that name (e.g., `A * 100 /
+B`), and dropping it makes the dry-run diverge from the saved panel.
+The endpoint cannot consume widget JSON directly. See the "Mandatory
+dry-run before update" guardrail for the conditions, the bool-filter
+footgun, and why this catches what the JSON diff cannot. Server
+error or unexpected empty result = fix the panel JSON before update.
+
+Call `signoz:signoz_update_dashboard` with the dashboard UUID and the **complete** modified
+dashboard JSON.
+
+### Step 5: Report the result
+
+Briefly tell the user what was changed. Offer further modifications if relevant.
+
+## Guardrails
+
+- **Full state on update**: `signoz:signoz_update_dashboard` requires the complete
+  dashboard JSON (not a partial patch). Always call `signoz:signoz_get_dashboard` first
+  to get the current state, merge your changes into that full object, and pass
+  the result to `signoz:signoz_update_dashboard`. Never construct an update payload from
+  scratch.
+- **Preserve what you don't change**: Never drop or overwrite widgets, variables,
+  layout items, or panelMap entries that are outside the scope of the user's request.
+  Diff-and-merge, do not rebuild.
+- **Confirm destructive changes**: Before removing panels, replacing queries, or
+  deleting variables, confirm with the user — even if they say "just do it" or
+  express urgency. Additions, renames, type changes, and variable additions do not
+  need confirmation.
+- **Mandatory dry-run before update.** For every added or edited
+  query-bearing panel, run `signoz:signoz_execute_builder_query`
+  before `signoz:signoz_update_dashboard` (envelope translation in
+  the Dry-run step above). Row / header panels (`panelTypes:
+  "row"`) have no query — validate their shape against
+  `signoz://dashboard/widgets-examples` instead. Modifications are
+  especially prone to silent regression because the panel worked
+  before the edit — a saved empty panel from a typo'd rename or
+  attribute swap is the worst failure mode for this skill.
+- **Valid JSON only**: Follow the v5 schema documented in the
+  `signoz://dashboard/*` MCP resources (`instructions`, `widgets-instructions`,
+  `widgets-examples`, `query-builder-example`). Include all required widget
+  fields (see "Adding a panel" above). Never generate malformed queries or
+  layouts.
+- **OTel attribute names**: Always use OpenTelemetry semantic conventions for
+  attribute names in filters, groupBy, and variables. Use `service.name` not
+  `service`, `host.name` not `host`, `deployment.environment.name` not `env`.
+- **No metric guessing**: If adding or changing queries and you are not sure what
+  metrics are available, ask the user or call `signoz:signoz_list_metrics` to discover
+  available metrics. Wrong metric names produce empty panels.
+- **Paginate dashboard listing**: When searching for a dashboard by name, always
+  paginate through all pages of `signoz:signoz_list_dashboards` before concluding a
+  dashboard does not exist.
+- **UUIDs for new objects**: Every new widget, layout item, variable, and query
+  needs a unique UUID (`crypto.randomUUID()` format). Never use sequential IDs
+  or short strings.
+- **Scope boundary**: This skill modifies existing dashboards. To create a new
+  dashboard from scratch, point the user at the SigNoz dashboard editor in the
+  UI — there is no creation skill in this plugin yet.
+
+## Examples
+
+**User:** "Add an error rate panel to my Redis dashboard"
+
+**Agent:**
+1. Calls `signoz:signoz_list_dashboards` (paginates all pages) — finds "Redis Overview"
+   dashboard with UUID `abc-123`.
+2. Calls `signoz:signoz_get_dashboard` with UUID `abc-123` — gets full configuration with
+   8 existing panels.
+3. Calls `signoz:signoz_list_metrics` to find available Redis error metrics.
+4. Creates a new graph widget (with UUID, all required fields, and a formula query
+   for error rate), adds a layout entry at the next available `y` position, and
+   adds it to the appropriate row's `panelMap`.
+5. Calls `signoz:signoz_update_dashboard` with the full modified JSON (all 9 panels).
+6. Reports: "Added an 'Error Rate' graph panel to your Redis Overview dashboard
+   under the Overview section. Want me to adjust anything?"
+
+---
+
+**User:** "Change the latency panel from a graph to a table on my API dashboard"
+
+**Agent:**
+1. Identifies "API Monitoring" dashboard from context, calls `signoz:signoz_get_dashboard`.
+2. Finds the panel titled "Request Latency" — if multiple panels could match,
+   confirms with user: "I found 'Request Latency'. Convert that one to a table?"
+3. Changes `panelTypes` from `"graph"` to `"table"`, adds `columnUnits` and
+   `columnWidths` if missing, keeps the query intact.
+4. Calls `signoz:signoz_update_dashboard` with the full modified JSON (all panels
+   preserved).
+5. Reports: "Changed 'Request Latency' from a graph to a table. Want me to adjust
+   column widths or add column units?"
+
+---
+
+**User:** "Remove the CPU panel and rename the dashboard to 'Service Health'"
+
+**Agent:**
+1. Fetches the dashboard via `signoz:signoz_get_dashboard`.
+2. Finds the "CPU Usage" panel. Confirms: "I'll remove the 'CPU Usage' panel and
+   rename the dashboard to 'Service Health'. Proceed?" (Removal is destructive —
+   always confirm.)
+3. User confirms.
+4. Removes the widget from `widgets`, its layout entry, and its panelMap reference.
+   Leaves all other panel positions unchanged (the frontend grid closes gaps
+   automatically). Updates `title` and `name` to "Service Health".
+5. Calls `signoz:signoz_update_dashboard` with the full modified JSON.
+6. Reports: "Removed the 'CPU Usage' panel and renamed the dashboard to 'Service
+   Health'. Anything else to adjust?"

--- a/skills/signoz-modifying-dashboards/evals/evals.json
+++ b/skills/signoz-modifying-dashboards/evals/evals.json
@@ -1,0 +1,98 @@
+{
+  "skill_name": "signoz-modifying-dashboards",
+  "evals": [
+    {
+      "id": 0,
+      "name": "add-panel-to-existing-dashboard",
+      "prompt": "Add a panel showing p99 latency by service to my 'API Monitoring' dashboard. Group by service.name.",
+      "expected_output": "Agent paginates list_dashboards to find 'API Monitoring', fetches it, builds a new graph widget with all required fields and a UUID, places it in the layout (and panelMap if rows exist), preserves all existing panels/variables, and calls update_dashboard with the full state.",
+      "files": [],
+      "assertions": [
+        "Updated dashboard has exactly one more widget than original",
+        "New widget has all required v5 fields",
+        "New widget's id is a valid UUID",
+        "New widget's query uses 'service.name' (OTel naming) in groupBy, not 'service'",
+        "Layout has one new entry whose 'i' matches the new widget's id",
+        "All original widgets and variables remain present and unchanged",
+        "Agent did not call signoz_update_dashboard (read-only eval constraint respected)"
+      ]
+    },
+    {
+      "id": 1,
+      "name": "remove-panel-destructive-confirm",
+      "prompt": "Get rid of the memory fragmentation widget on my Redis dashboard, just do it quickly.",
+      "expected_output": "Despite 'just do it quickly', agent confirms the deletion before applying. On confirmation, removes widget from widgets[], layout entry, and panelMap entry. Leaves other y positions untouched.",
+      "files": [],
+      "assertions": [
+        "Transcript contains an explicit confirmation question before deletion (despite user's 'just do it quickly')",
+        "Updated dashboard has exactly one fewer widget than original",
+        "Removed widget's id is absent from widgets[], layout[], and panelMap[*].widgets",
+        "Remaining widgets' y positions are unchanged from original (no auto-compaction)",
+        "Agent did not call signoz_update_dashboard (read-only eval constraint respected)"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "panel-type-graph-to-table",
+      "prompt": "Change the 'Request Latency' panel on my API dashboard from a graph to a table.",
+      "expected_output": "Non-destructive: proceeds without confirmation. Updates panelTypes from 'graph' to 'table', adds columnUnits ({}) and columnWidths ({}) if missing, keeps the query and other widget fields intact, preserves all other panels.",
+      "files": [],
+      "assertions": [
+        "Target widget's panelTypes is 'table' in updated, was 'graph' in original",
+        "Target widget retains the same query object (deep-equal to original)",
+        "Target widget has both columnUnits and columnWidths keys present",
+        "Widget count is identical between original and updated (no add/remove)",
+        "Transcript shows no confirmation prompt — non-destructive change proceeded directly",
+        "Agent did not call signoz_update_dashboard (read-only eval constraint respected)"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "compound-add-rename-remove",
+      "prompt": "On my 'Service Health' dashboard: rename it to 'Service Health (Production)', remove the CPU Usage panel, and add an Error Rate panel grouped by service.name. Use OTel attribute names.",
+      "expected_output": "Agent fetches the dashboard once, plans all three changes against that single state, confirms the destructive removal, and applies all three as a single update. Uses service.name. Preserves untouched widgets/variables/panelMap entries.",
+      "files": [],
+      "assertions": [
+        "Transcript shows a single confirmation prompt covering the destructive removal of CPU Usage",
+        "Dashboard title (or name) is updated to 'Service Health (Production)'",
+        "CPU Usage widget is absent from widgets[], layout[], and panelMap",
+        "A new Error Rate widget is present with all required v5 fields and groupBy contains 'service.name'",
+        "Net widget count equals original count (one removed, one added)",
+        "Transcript indicates a single planned update_dashboard call (changes batched, not iterative)",
+        "All non-target widgets, variables, and panelMap entries preserved unchanged",
+        "Agent did not call signoz_update_dashboard (read-only eval constraint respected)"
+      ]
+    },
+    {
+      "id": 4,
+      "name": "side-by-side-layout",
+      "prompt": "Put the 'CPU' and 'Memory' panels on my host overview dashboard side by side at the top.",
+      "expected_output": "Agent moves both panels to same y, w:6 each, x:0 and x:6, equal h. Updates panelMap[rowId].widgets entries to match layout. Preserves rest of dashboard.",
+      "files": [],
+      "assertions": [
+        "CPU and Memory widgets in layout[] both have w == 6",
+        "Their x values are {0, 6} (one each, in some order)",
+        "Their y values are equal",
+        "Their h values are equal",
+        "Matching panelMap[rowId].widgets entries for CPU and Memory have the same x, y, w, h as the top-level layout entries (panelMap-sync rule)",
+        "No other panels modified",
+        "Agent did not call signoz_update_dashboard (read-only eval constraint respected)"
+      ]
+    },
+    {
+      "id": 5,
+      "name": "add-environment-variable",
+      "prompt": "Add a deployment environment dropdown variable to my Kafka dashboard so I can filter by env.",
+      "expected_output": "Agent adds a DYNAMIC variable for deployment.environment.name with UUID id and key, valid v5 structure, preserves existing variables, panels, and layout.",
+      "files": [],
+      "assertions": [
+        "variables map in updated has exactly one more entry than original",
+        "New variable's type is 'DYNAMIC'",
+        "New variable's underlying attribute is 'deployment.environment.name' (not 'env', 'environment', or 'deployment.environment')",
+        "New variable has UUID-shaped id and key",
+        "Existing variables, widgets, and layout are untouched",
+        "Agent did not call signoz_update_dashboard (read-only eval constraint respected)"
+      ]
+    }
+  ]
+}

--- a/skills/signoz-searching-docs/README.md
+++ b/skills/signoz-searching-docs/README.md
@@ -1,0 +1,36 @@
+# signoz-searching-docs
+
+Agent skill for answering SigNoz questions with official documentation from [signoz.io/docs](https://signoz.io/docs).
+
+This skill ships inside the official `signoz` Claude plugin and the shared `skills.sh` package.
+
+## How it works
+
+1. **Docs fetch** — Prefers the SigNoz MCP server tools (`signoz:signoz_search_docs`, `signoz:signoz_fetch_doc`) when available, and falls back to direct HTTP fetch with `Accept: text/markdown` (which SigNoz docs support natively) so the agent gets clean markdown instead of scraping HTML.
+2. **Domain heuristics** — Decision trees route the user to the right guide before fetching docs, which avoids jumping to a random page without understanding the setup.
+
+## Structure
+
+```
+plugins/signoz/skills/signoz-searching-docs/
+├── SKILL.md              # Entry point — goal, docs-fetch method, workflow, heuristic routing table
+├── README.md
+└── heuristics/
+    └── sending-logs.md   # Log collection method decision tree
+```
+
+## Adding a heuristic
+
+1. Create a new file in `heuristics/` (e.g., `sending-traces.md`)
+2. Follow the pattern: questions → decision table → gotchas → reference link
+3. Add a row to the routing table in `SKILL.md`:
+
+```markdown
+| Sending Traces | traces, instrumentation, APM, distributed tracing | [sending-traces.md](./heuristics/sending-traces.md) |
+```
+
+## Planned heuristics
+
+- **Sending Traces** — language selection, auto vs manual instrumentation
+- **Sending Metrics** — application metrics vs infrastructure vs Prometheus
+- **Troubleshooting** — data not showing up, collector issues, common errors

--- a/skills/signoz-searching-docs/SKILL.md
+++ b/skills/signoz-searching-docs/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: signoz-searching-docs
+description: >
+  Look up information in SigNoz documentation. Make sure to use this skill
+  whenever the user asks "how do I", "where in the docs", "what does the
+  docs say about", "find docs for", or otherwise needs reference material
+  on SigNoz instrumentation, OpenTelemetry setup, self-hosted deployment,
+  API endpoints, auth headers, or troubleshooting steps — even if they
+  don't say the word "docs" explicitly. Docs lookup only — for actions
+  inside SigNoz, the agent will pick the matching `signoz-*` action skill.
+---
+
+# SigNoz Docs
+
+Use official `signoz.io` documentation and API references only. Ground every answer in fetched docs content and cite the canonical docs URL.
+
+## Access Docs
+
+Prefer the SigNoz MCP server tools when available; fall back to direct HTTP fetch.
+
+### Preferred: MCP tools
+
+- `signoz:signoz_search_docs` — BM25 search over the indexed docs corpus. Pass the user's natural-language query as `query`. Narrow with `section_slug` when the question maps cleanly to a single docs section (the tool's own schema lists valid slugs — defer to it rather than memorizing). Trust the ranking — the index handles relevance.
+- `signoz:signoz_fetch_doc` — full markdown for one indexed page. Pass the canonical URL or `/docs/...` path; optionally narrow to a section with `heading`.
+
+### Fallback: direct HTTP fetch
+
+If the MCP tools are unavailable, SigNoz docs support `Accept: text/markdown` natively.
+
+Discover via the sitemap:
+
+```
+GET https://signoz.io/docs/sitemap.md
+```
+
+Fetch a specific page:
+
+```
+GET https://signoz.io/docs/<path>/
+Accept: text/markdown
+```
+
+## Workflow
+
+1. **Identify the domain** from the user's question: instrumentation, OpenTelemetry setup, querying, dashboards, alerts, troubleshooting, deployment, or API docs.
+2. **Check the heuristics table below**. If a heuristic matches, read it before answering — heuristics encode product decisions (which path/method fits the user's environment), useful in both paths.
+3. **Search and fetch** — pick the path based on tool availability:
+   - **With MCP tools**: call `signoz:signoz_search_docs` with the user's query; pass `section_slug` if the domain maps cleanly to one. Read the top 1-3 results and call `signoz:signoz_fetch_doc` on the chosen URL (use `heading` to narrow if the page is large and the question is sub-section-specific).
+   - **Without MCP tools**: grep `sitemap.md` for candidate pages, rank the best 2-5 by how directly they answer the task, and `GET` the top page(s) with `Accept: text/markdown`. Heuristic coverage is sparse — for topics without a heuristic row, skim the sitemap by section path and prefer setup/troubleshooting/API-reference pages over overviews.
+   - Fetch **one page** for narrow questions; fetch **multiple pages** when the task spans setup + troubleshooting, or method-selection + language guide. Keep the set small.
+4. **Answer from the fetched docs** and cite canonical `https://signoz.io/docs/...` URLs.
+5. **Handle ambiguity deliberately**: if multiple pages are plausible, prefer the one that completes the task most directly; mention alternates only when they materially change the answer.
+
+## Message Actions
+
+On the terminal answer, emit FE-handoff actions per the SigNoz Skills & MCP spec:
+
+- **`open_docs`** — include with the canonical URL of the primary cited page. Docs lookups are precisely the case where deep-linking to the source page helps the user read in context and verify the answer.
+- **`follow_up`** — 1-2 next-step prompts that build on a docs answer. After a setup guide: *"walk me through the first command"* or *"what's a common gotcha here?"*. After a concept page: *"show me a worked example."*
+- **Do NOT emit `apply_filter`.** Docs answers do not produce a query for an explorer page; emitting `apply_filter` would overwrite the user's working query.
+
+Verbatim guardrail: *When answering a SigNoz docs question, include an `open_docs` action on the final message with the canonical URL of the primary cited page.*
+
+## Domain Heuristics
+
+Read the matching heuristic file **before** fetching docs. Each file contains decision logic to route the user to the right guide.
+
+| Topic | Trigger keywords | Heuristic file |
+|---|---|---|
+| Sending Logs | logs, log collection, logging, send logs | [sending-logs.md](./heuristics/sending-logs.md) |

--- a/skills/signoz-searching-docs/evals/evals.json
+++ b/skills/signoz-searching-docs/evals/evals.json
@@ -1,0 +1,95 @@
+{
+  "skill_name": "signoz-searching-docs",
+  "evals": [
+    {
+      "id": 0,
+      "eval_name": "mcp-path-narrow-language",
+      "prompt": "How do I configure the OTLP exporter for a Python application sending traces to SigNoz Cloud?",
+      "expected_output": "Agent calls signoz:signoz_search_docs with the user's natural-language query and section_slug='apm-distributed-tracing' (or similar). Trusts BM25 ranking — does not invent its own keyword scoring. Picks the Python-specific instrumentation guide from top results, calls signoz:signoz_fetch_doc on the canonical URL, and answers with the OTLP endpoint, headers (signoz-ingestion-key), protocol, and a Python code snippet. Cites the canonical https://signoz.io/docs/... URL. Does not fetch unrelated language guides.",
+      "files": [],
+      "assertions": [
+        {"id": "uses_mcp_search", "text": "Agent calls signoz_search_docs (MCP tool) rather than only HTTP fetching."},
+        {"id": "narrows_section", "text": "Agent passes a section_slug for tracing/APM (e.g. apm-distributed-tracing) to narrow the BM25 search."},
+        {"id": "fetches_python_page", "text": "Agent fetches a Python-specific instrumentation guide via signoz_fetch_doc, not a generic overview."},
+        {"id": "cites_canonical_url", "text": "Answer cites at least one canonical https://signoz.io/docs/... URL."},
+        {"id": "answer_includes_key_setup", "text": "Answer includes OTLP endpoint, signoz-ingestion-key header, and a Python code snippet or env var setup."},
+        {"id": "no_unrelated_languages", "text": "Agent does not fetch unrelated language guides (Java/Go/Node) just because they share keywords."}
+      ]
+    },
+    {
+      "id": 1,
+      "eval_name": "heuristic-gated-k8s-logs",
+      "prompt": "How do I send logs from my Kubernetes pods to SigNoz?",
+      "expected_output": "Agent recognizes 'logs' + 'Kubernetes' as triggers for the Sending Logs heuristic. Reads heuristics/sending-logs.md BEFORE fetching docs. Applies the decision tree: identifies infrastructure logs in K8s, recommends k8s-infra agent (which collects pod logs automatically) or File + OTel Collector path. Mentions the duplicate-logs gotcha if SDK OTLP is also in use. Then fetches the k8s-infra or pod-logs docs page via MCP (or HTTP fallback) and cites canonical URLs. Does not jump straight to a random language guide.",
+      "files": [],
+      "assertions": [
+        {"id": "reads_heuristic_first", "text": "Agent reads heuristics/sending-logs.md BEFORE fetching any docs page."},
+        {"id": "applies_decision_tree", "text": "Agent applies the heuristic decision tree: identifies K8s + infrastructure logs and routes to k8s-infra agent or File + OTel Collector."},
+        {"id": "mentions_k8s_infra", "text": "Answer mentions the k8s-infra agent (Helm chart) which collects pod logs automatically."},
+        {"id": "mentions_duplicate_gotcha", "text": "Answer surfaces the duplicate-logs gotcha if SDK OTLP and k8s-infra are both used."},
+        {"id": "fetches_relevant_docs", "text": "Agent fetches the k8s pod logs collection guide or k8s-infra configuration page."},
+        {"id": "cites_canonical_url", "text": "Answer cites at least one canonical https://signoz.io/docs/... URL."}
+      ]
+    },
+    {
+      "id": 2,
+      "eval_name": "multi-page-alerts-config-and-troubleshoot",
+      "prompt": "How do I configure alert rules in SigNoz, and how do I troubleshoot when they fire unexpectedly?",
+      "expected_output": "Agent recognizes the task spans two needs: alert setup AND troubleshooting. Calls signoz:signoz_search_docs with section_slug='alerts' and fetches TWO pages — one on alert configuration, one on alert troubleshooting/debugging. Synthesizes both into a single answer: setup steps first, then debugging guidance. Cites both canonical URLs. Does not pad with loosely-related pages just because they share keywords.",
+      "files": [],
+      "assertions": [
+        {"id": "fetches_multiple_pages", "text": "Agent fetches at least 2 distinct docs pages — one on alert configuration, one on troubleshooting."},
+        {"id": "uses_alerts_section_slug", "text": "Agent passes section_slug='alerts' to signoz_search_docs."},
+        {"id": "synthesizes_both_topics", "text": "Answer covers BOTH alert configuration AND troubleshooting unexpected fires."},
+        {"id": "cites_both_urls", "text": "Answer cites at least 2 canonical https://signoz.io/docs/... URLs."},
+        {"id": "no_padding", "text": "Agent does not fetch loosely-related pages (dashboards, metrics overview) just because they share keywords."}
+      ]
+    },
+    {
+      "id": 3,
+      "eval_name": "sub-section-heading-narrow",
+      "prompt": "Which authentication header does the SigNoz Cloud ingestion endpoint require, and where do I get its value?",
+      "expected_output": "Agent calls signoz:signoz_search_docs with section_slug='setup' or 'signoz-apis' to find the SigNoz Cloud ingestion / auth page. Calls signoz:signoz_fetch_doc with a heading anchor scoped to the auth/ingestion-key sub-section rather than fetching the whole page. Answers with the canonical header name (signoz-ingestion-key) and where users obtain the value (SigNoz Cloud settings UI). Cites the canonical URL with the section anchor. Does not invent a header name from training memory without grounding in fetched docs.",
+      "files": [],
+      "assertions": [
+        {"id": "uses_mcp_search", "text": "Agent calls signoz_search_docs (MCP tool)."},
+        {"id": "uses_relevant_section", "text": "Agent passes section_slug for setup, signoz-apis, or similar relevant section."},
+        {"id": "uses_heading_anchor", "text": "Agent calls signoz_fetch_doc with a heading parameter to narrow to the auth sub-section."},
+        {"id": "answer_names_canonical_header", "text": "Answer names the canonical header signoz-ingestion-key."},
+        {"id": "answer_explains_value_source", "text": "Answer explains where to obtain the value (SigNoz Cloud settings UI / ingestion settings)."},
+        {"id": "grounded_in_docs", "text": "Answer is grounded in fetched docs (cites a canonical URL); does not invent header from training memory."}
+      ]
+    },
+    {
+      "id": 4,
+      "eval_name": "no-heuristic-topic-dashboards",
+      "prompt": "How do I create a dashboard panel that shows p99 latency for my metrics?",
+      "expected_output": "Agent recognizes there is no heuristic row for dashboards. Goes directly to signoz:signoz_search_docs with the user's query and section_slug='dashboards'. Does NOT invent a heuristic claim or pretend to follow one. Picks the dashboard panel / metrics query guide from top BM25 results, fetches it, and answers with the panel-builder steps. Cites canonical URL.",
+      "files": [],
+      "assertions": [
+        {"id": "no_false_heuristic", "text": "Agent does NOT claim to follow a heuristic for dashboards (none exists)."},
+        {"id": "uses_mcp_search", "text": "Agent calls signoz_search_docs (MCP tool) directly."},
+        {"id": "uses_dashboards_section", "text": "Agent passes section_slug='dashboards' to narrow the search."},
+        {"id": "fetches_dashboard_guide", "text": "Agent fetches a dashboard panel / metrics-query guide page."},
+        {"id": "answer_explains_panel_steps", "text": "Answer explains concrete dashboard panel construction steps (panel type, query, p99 aggregation, group/legend)."},
+        {"id": "cites_canonical_url", "text": "Answer cites at least one canonical https://signoz.io/docs/... URL."}
+      ]
+    },
+    {
+      "id": 5,
+      "eval_name": "query-builder-howto",
+      "prompt": "How do I use the SigNoz query builder to compute p95 latency grouped by service.name?",
+      "expected_output": "Agent calls signoz:signoz_search_docs with section_slug='querying' (no heuristic exists for querying — agent must not invent one). Picks the query builder docs page from BM25 results and fetches it. Answers with the concrete UI steps: choose traces signal, select duration metric, set aggregation to p95, set group-by to service.name. Grounds the answer in fetched docs content. Cites the canonical URL. Does NOT delegate to signoz-generating-queries — this is a docs lookup ('how do I use the query builder'), not query generation.",
+      "files": [],
+      "assertions": [
+        {"id": "no_false_heuristic", "text": "Agent does NOT claim to follow a heuristic for querying (none exists)."},
+        {"id": "uses_mcp_search", "text": "Agent calls signoz_search_docs (MCP tool)."},
+        {"id": "uses_querying_section", "text": "Agent passes section_slug='querying' to narrow the search."},
+        {"id": "fetches_query_builder_doc", "text": "Agent fetches a query-builder docs page (not a generic traces overview)."},
+        {"id": "answer_explains_qb_steps", "text": "Answer explains query-builder UI steps for p95 by service.name."},
+        {"id": "no_action_skill_handoff", "text": "Agent does NOT delegate to signoz-generating-queries; treats this as a docs lookup."},
+        {"id": "cites_canonical_url", "text": "Answer cites at least one canonical https://signoz.io/docs/... URL."}
+      ]
+    }
+  ]
+}

--- a/skills/signoz-searching-docs/heuristics/sending-logs.md
+++ b/skills/signoz-searching-docs/heuristics/sending-logs.md
@@ -1,0 +1,54 @@
+# Sending Logs to SigNoz
+
+When a user asks about sending/collecting/forwarding logs to SigNoz, **do not jump to a specific guide**. First determine the right collection method by working through these questions.
+
+## 1. What kind of logs?
+
+- **Application logs** (from code you control) → compare SDK OTLP, HTTP API, or File + Collector based on needs below
+- **Infrastructure logs** (K8s pods, Docker, syslogs) → usually File + OTel Collector
+- **Cloud service logs** (CloudWatch, Azure, GCP) → OTel Collector Receivers or cloud-specific guides
+- **Existing log pipeline** (FluentBit, Fluentd, Logstash, Vector) → Log Processors path
+
+## 2. Is trace-log correlation needed?
+
+- **Yes** → SDK OTLP export (Path 1) — the only path with automatic `trace_id`/`span_id` injection
+- **No** → choose based on simplicity, reliability, and where logs already live
+
+## 3. Is reliability or external collection more important than in-app export?
+
+- **Yes** → File + OTel Collector (Path 3) is usually the right default
+- **No** → SDK OTLP or HTTP API may be simpler for application logs
+
+## 4. What's the deployment environment?
+
+- **Kubernetes** → check if k8s-infra agent is already installed; it collects pod logs automatically
+- **Docker** → filelog receiver via OTel Collector
+- **AWS** (ECS, Lambda, EC2) → cloud-specific guides; SigNoz Cloud users should check [One-Click AWS Integrations](https://signoz.io/docs/integrations/aws/one-click-aws-integrations/)
+- **Azure / GCP** → platform-specific monitoring guides
+- **PaaS** (Heroku, Vercel, Cloudflare) → platform-specific log forwarding
+
+## Decision Table
+
+| Scenario | Recommended Path | Docs |
+|---|---|---|
+| App logs + need trace correlation | SDK OTLP Export | [Path 1](https://signoz.io/docs/logs-management/send-logs/collection-methods/#path-1-sdk-otlp-export) |
+| App logs + simple custom integration | HTTP API | [HTTP Logs API](https://signoz.io/docs/userguide/send-logs-http/) |
+| App logs + need reliability, preprocessing, or external collection | File + OTel Collector | [Path 3](https://signoz.io/docs/logs-management/send-logs/collection-methods/#path-3-write-to-file--otel-collector) |
+| K8s pod/container logs | k8s-infra agent or File + OTel Collector | [K8s Pod Logs](https://signoz.io/docs/userguide/collect_kubernetes_pod_logs/) |
+| Docker or VM file/stdout logs | File + OTel Collector | [Path 3](https://signoz.io/docs/logs-management/send-logs/collection-methods/#path-3-write-to-file--otel-collector) |
+| CloudWatch / syslog / journald | OTel Collector Receivers | [Path 4](https://signoz.io/docs/logs-management/send-logs/collection-methods/#path-4-otel-collector-receivers) |
+| Already using FluentBit/Fluentd/Logstash/Vector | Log Processors | [Path 5](https://signoz.io/docs/logs-management/send-logs/collection-methods/#path-5-log-processors) |
+
+## After Selecting a Path
+
+If more than one path fits, recommend the simplest default for the user's environment and briefly explain the tradeoff.
+
+Fetch the specific language or platform guide for detailed setup steps.
+
+## Gotchas
+
+- **Kubernetes duplicate logs**: If using both SDK OTLP (for app logs) and k8s-infra (for pod logs), [disable automatic log collection](https://signoz.io/docs/opentelemetry-collection-agents/k8s/k8s-infra/configure-k8s-infra/#disable-logs-collection) for SDK-instrumented pods to avoid duplicates.
+
+## Reference
+
+[Choosing a Collection Method](https://signoz.io/docs/logs-management/send-logs/collection-methods/)

--- a/skills/signoz-setting-up-observability/SKILL.md
+++ b/skills/signoz-setting-up-observability/SKILL.md
@@ -1,0 +1,450 @@
+---
+name: signoz-setting-up-observability
+description: >
+  Run the full end-to-end observability setup for a service after its
+  telemetry is already flowing into SigNoz — sequence SLI/SLO capture,
+  data exploration (RED/USE), focused dashboards, saved Explorer views,
+  burn-rate and absent-data alerts, and a tuning loop into one
+  opinionated, SLO-aware workflow. Make sure to use this skill whenever the user says "set up
+  observability after ingestion", "now that data is flowing, give me
+  dashboards and alerts", "onboard this service to SigNoz end-to-end",
+  "I want the full monitoring setup for X", or asks to go from raw
+  telemetry to a complete dashboard + alerts + views package — even if
+  they don't say "observability" explicitly. This is the orchestration
+  layer: for a single artifact (just a dashboard, just one alert, just a
+  saved view, or one static threshold alert, or a one-off query) use
+  signoz-creating-dashboards, signoz-creating-alerts,
+  signoz-managing-views, or signoz-generating-queries directly.
+argument-hint: <service name + what to set up (dashboard / alerts / views)>
+---
+
+# Setting Up Observability After Ingestion
+
+Take a service from "telemetry is flowing into SigNoz" to "I have a
+dashboard, alerts, saved views, and a tuning loop." This skill is an
+**orchestration layer, not a standalone reference** — the mechanical
+work lives in the sibling SigNoz skills and the MCP tools/resources hold
+the current payload schemas. This skill sequences them and supplies the
+judgment calls (scope, SLOs, thresholds, what to skip) that no single
+skill owns; it deliberately does not restate payload schemas or field
+rules, so read the relevant `signoz://…` resource before composing any
+payload.
+
+Use this when traces, logs, or metrics are **already landing** in
+SigNoz and you want an opinionated, SLO-aware setup — not when you're
+still wiring up the SDK. Audience: two consumers — an autonomous AI SRE
+agent that runs without a human in the loop (e.g. an in-product SigNoz
+assistant), and an engineer at a Claude Code / Codex / Cursor prompt.
+Both follow the same flow; where a step needs a human decision (Phase 1
+triage, Phase 5 sign-off), the host decides how to surface it, and an
+autonomous host fills the gap from upstream context instead of blocking.
+
+## Prerequisites
+
+This skill calls SigNoz MCP server tools (`signoz:signoz_list_services`,
+`signoz:signoz_list_dashboards`, `signoz:signoz_get_field_keys`,
+`signoz:signoz_execute_builder_query`, `signoz:signoz_create_dashboard`,
+`signoz:signoz_create_alert`, `signoz:signoz_create_view`, etc.) and
+delegates to sibling skills. Before running the workflow, confirm the
+`signoz:signoz_*` tools are available. If they are not, the SigNoz MCP
+server is not installed or configured — run `signoz-mcp-setup` first. Do
+not fall back to raw HTTP calls or fabricate payloads.
+
+## When to use
+
+Use this skill when the user wants the **whole post-ingestion setup**:
+SLI/SLO → exploration → dashboard → views → alerts → tuning, in any
+combination of those deliverables, sequenced as one workflow.
+
+Do NOT use this skill when the user wants a single artifact — hand off
+directly:
+- Just a dashboard → `signoz-creating-dashboards`.
+- Just one static / threshold alert or notification rule →
+  `signoz-creating-alerts`. (But SLO / burn-rate / error-budget
+  alerting — even with no dashboard — stays *here*: it needs the SLI/SLO
+  capture and burn-rate judgment in the phases below.)
+- Just a saved Explorer view → `signoz-managing-views`.
+- A one-off exploratory query → `signoz-generating-queries`.
+- A concept/doc lookup (SRE methods, OTel conventions, burn-rate math)
+  → `signoz-searching-docs` / `signoz:signoz_search_docs`.
+
+Each phase below points to the skill that does the mechanical work; this
+skill owns the order and the decisions.
+
+## Phase 1 — Triage scope (don't skip)
+
+Before touching any tools, get these answers. Each unblocks a downstream
+phase.
+
+1. **What does this service do, and does it call external services?**
+   One or two sentences. This shapes the SLI (what "working" means) and
+   flags downstream dependencies worth monitoring — if it calls a DB,
+   cache, queue, or third-party API, plan to watch the client-span
+   latency and error rate to each dependency, since a healthy service
+   fronting a sick dependency still fails users.
+2. **What deliverables?** dashboard / alerts / saved views — any
+   combination.
+3. **Infra monitoring too? (optional — ask)** If the service runs on
+   infra you own (k8s pods, VMs, containers) shipping telemetry under
+   the same resource attributes, you can add USE/infra panels (CPU,
+   memory, restarts, network) with no extra instrumentation — see Phase
+   3. Skip if a platform team already owns the host/cluster dashboard.
+4. **Which signals are emitted?** traces / logs / metrics. Drives which
+   `signoz:signoz_get_field_keys` calls you make.
+5. **What's the canonical resource filter?** Usually `service.name`.
+   Confirm the exact value before querying — don't guess.
+6. **What does success look like for users of this service?** (Sets up
+   Phase 2.) Even a one-line answer ("requests under 1s with no 5xx") is
+   enough — it becomes the SLI.
+7. **Who owns it, and is there a runbook?** Owning team, service tier,
+   and the prod/staging scope — these become alert labels and
+   annotations in Phase 8. Capture a real runbook URL if one exists;
+   never invent one.
+
+Offer "explore data first" as an explicit option.
+
+## Phase 1.5 — Inventory what already exists
+
+Each create sub-skill runs its own rigorous duplicate-check when invoked
+(`signoz-creating-dashboards` lists dashboards; `signoz-creating-alerts`
+paginates alert rules) — don't re-implement that here. The orchestration
+value is a single up-front sweep so you *sequence around* what exists
+instead of hitting collisions mid-build:
+
+- **Is the service reporting, and under what exact name?**
+  (`signoz:signoz_list_services`.) This name is the resource filter every
+  later phase reuses — pin it before anything else.
+- **Does a dashboard / alert / saved view already exist for it?** If so,
+  plan to **extend** it — route to `signoz-modifying-dashboards`,
+  `signoz-managing-views`, or `signoz:signoz_update_alert` — rather than
+  standing up a parallel one. `signoz-explaining-dashboards` /
+  `signoz-explaining-alerts` summarize anything you're inheriting.
+- **Is there a notification channel to reuse?** (Carried into Phase 5.)
+
+Learn just enough to decide extend-vs-create per artifact; leave the
+exhaustive listing to the sub-skills.
+
+## Phase 2 — Capture the SLI/SLO before designing anything
+
+This is the gating artifact. Without it, alerts become "the metric
+crossed a line" instead of "the user-visible error budget is being burnt
+fast enough to matter."
+
+Collect:
+- **SLI formula** — `good events / valid events`. E.g. *successful
+  checkout requests / total checkout requests* (excluding health checks,
+  synthetic probes, scanner traffic, and non-user long-poll endpoints).
+- **SLO target** — e.g. 99.5% over a 30-day rolling window.
+- **Exclusions** — what doesn't count as a valid event (synthetic
+  probes, scanner traffic, streaming endpoints).
+- **Error budget remaining** — derived from target. Drives burn-rate
+  alert math.
+
+Carry these forward — they feed Phase 8 directly. (SLO/burn-rate
+background: `signoz-searching-docs`.)
+
+## Phase 3 — Explore what's actually there (RED + USE coverage)
+
+`signoz-generating-queries` owns the exploration itself — the
+discover-before-querying rule, every discovery call
+(`signoz:signoz_list_metrics`, `signoz:signoz_get_field_keys`,
+`signoz:signoz_get_field_values`,
+`signoz:signoz_get_service_top_operations`), tool choice, and the
+no-data distinction. Drive it to inventory the data; don't restate its
+query mechanics here. (`signoz-searching-docs` covers the RED/USE methods
+and SigNoz field semantics if you need a refresher.)
+
+The orchestration job is to map what it finds onto **RED** (Request
+rate, Errors, Duration) and **USE** (Utilization, Saturation, Errors),
+spot the gaps, and make the judgment calls generating-queries doesn't:
+
+**Coverage checklist** (RED for services, USE for infra/resources):
+
+- [ ] **R**ate — request/call rate per operation
+- [ ] **E**rrors — error count or rate per operation
+- [ ] **D**uration — p50/p95/p99 latency from spans or histograms
+- [ ] **U**tilization — CPU, memory, disk, queue depth, pool occupancy (only if you own the infra)
+- [ ] **S**aturation — request queue, GC pause, connection pool wait
+- [ ] **E**rrors at the resource layer — disk failures, evictions, OOM kills
+
+A missing signal (e.g. no error count) is an **instrumentation gap** —
+flag it before building around what's there.
+
+**Span metrics back alerts, not just panels.** When generating-queries
+surfaces SigNoz's trace→metrics output (`signoz_calls_total`,
+`signoz_latency_*`, DB/external-call span metrics), prefer it as the RED
+source for *both* the dashboard and the burn-rate alerts: it's
+pre-aggregated and cheap, whereas raw trace aggregation over a long alert
+window is expensive and an unstable alert source. (Confirm exact
+metric/label names via discovery — don't hardcode.)
+
+**Render any counter by the volume you just measured, not by reflex.**
+Not throughput-specific — it applies to every counter you'll graph
+(request rate, **error counts**, restarts, OOM kills, evictions), and
+low-volume errors and resource-layer events are the usual victims, not
+just requests. Per-second rate suits steady high-volume signals; where
+Phase 3 shows the count is low, bursty, or human-paced, a `/sec` graph
+renders as unreadable tiny decimals (`0.03/s`). Use the *symptom*, not a
+hard threshold: if per-second shows as fractions, pass that to Phase 6
+as intent — render a per-interval **increase** count over a wider window
+(24h–7d), not a rate. (Gauges — CPU, memory, queue depth — are already
+absolute; this is a counter concern.) It's a deliberate tradeoff
+(`increase` rescales its y-axis with the selected range), so make it a
+conscious call, never a blanket default either way.
+`signoz-creating-dashboards` owns the rate-vs-increase mechanic.
+
+**Verify the infra→service join (the USE half).** Don't assume
+`service.name` is present on host/container/k8s metrics — they often
+carry only `host.name` / `k8s.pod.name` / `k8s.node.name`, and
+`k8s.deployment.name` may differ from `service.name`. Have
+generating-queries confirm which identity attribute actually joins the
+infra metric to this workload, then scope USE panels by that *confirmed*
+attribute. If nothing joins, ask the user for the workload selector
+rather than guessing.
+
+**Discover downstream topology from traces, not the human's memory**
+(Phase 1 Q1). The gotcha worth carrying: client spans are
+`kind_string = 'Client'` in the SigNoz v5 schema — *not* `kind`, *not*
+`SPAN_KIND_CLIENT` — so verify the field/value, then group by the
+populated dependency attribute (`external_http_url` / `http_host` for
+HTTP, `db_name` / `db_operation` for databases) to surface every
+downstream the service actually calls, including ones the human forgot.
+
+**Multi-tenant note** — if the service serves multiple tenants/regions,
+look for a stable non-PII tenant/region attribute (e.g. `tenant.id`,
+`region`, `deployment.environment`) — avoid raw URLs or user
+identifiers. Per-tenant breakdowns belong on the dashboard;
+aggregate-only views hide single-tenant outages.
+
+**SLI hygiene** — confirm the events your SLI counts carry the right
+labels. For a broad denominator ("all requests to the service"), scanner
+traffic on `/.env*`, `/.git*` is real but should be **excluded** — it's
+not user traffic. The exclusion predicate should *only subtract scanners*
+and stay neutral otherwise, so use the **bare** negation —
+`<url_or_route_field> NOT REGEXP '/\\.(env|git|aws|ssh|well-known)'` —
+**not** `EXISTS AND …`. SigNoz negative operators also match rows where
+the field is *absent*, so fieldless valid events (non-HTTP spans,
+internal ops) stay counted; let the SLI's own scope filter
+(`service.name`, `http.route`) define the event universe, not the
+scanner predicate. (Pair `EXISTS` with a negation only for the *opposite*
+intent — excluding a specific value among rows that have the field, e.g.
+`service.name EXISTS AND service.name != 'redis'`.) A well-scoped SLI
+already excludes scanner paths, so this mainly bites service-wide ratios.
+Keep a separate security view if you care about scanners.
+
+## Phase 4 — Classify labels by cardinality and cost
+
+Before wiring labels into queries, classify each. Wrong classification
+is the #1 source of metric-bill explosions and dashboard unreadability.
+
+| Class | Cardinality | Where it goes |
+|---|---|---|
+| Routing | <20 | Alert label, inhibition rule, notification policy (e.g. `severity`, `team`) |
+| Variable | <100, human-readable | Dashboard variable (e.g. `environment`, `tenant`) |
+| Breakdown | <500 typically | groupBy on graphs / tables (e.g. `gen_ai.tool.name`) |
+| Trace/log-only | Unbounded | Only on traces or logs — never on metric series |
+
+Never let raw URLs, query strings, user IDs, session IDs, or request IDs
+end up as metric labels — they explode cardinality and the bill. Those
+belong on traces/logs.
+
+Cardinality matters more for *cost* than for *display performance* —
+SigNoz/ClickHouse handles 100s of variable values fine; the limit is
+human readability of the dropdown.
+
+## Phase 5 — Confirm channels, burn-rate windows, recovery thresholds
+
+Lock in before creating alerts:
+
+1. **Notification routing.** Decide *which* channel each severity tier
+   routes to (e.g. critical → PagerDuty, warning → Slack). Reuse an
+   existing channel from `signoz:signoz_list_notification_channels` where
+   one fits; never invent a name. The actual channel resolution/creation
+   and secret handling are owned by `signoz-creating-alerts` (Phase 8) —
+   here you only lock the tier→channel mapping.
+2. **Burn-rate windows.** Common starting points for a 99.9% SLO over a
+   30-day budget:
+
+   | Severity | Burn rate | Long window | Short window | Routing |
+   |---|---|---|---|---|
+   | Page-now critical | 14.4× | 1h | 5m | PagerDuty |
+   | Slow burn warning | 6× | 6h | 30m | Slack |
+   | Ticket-level low | 1× | 3d | 6h | Ticket queue |
+
+   The burn-rate multipliers are SLO-independent — for a different
+   target, compute each absolute threshold inline as
+   `error-rate = burn rate × (1 − SLO)` (e.g. 14.4× → 1.44% at 99.9%).
+   `signoz-searching-docs` explains the burn-rate *method*; it can't
+   compute your numbers.
+
+   Both windows must trip simultaneously for the alert to fire: the long
+   window suppresses brief spikes; the short window gives fast recovery
+   so a resolved incident stops paging quickly. (The 6× row is a page in
+   the canonical SRE table — routing it to Slack here is a deliberate
+   severity downgrade; adjust to your on-call norms.)
+3. **Recovery thresholds** (hysteresis). Decide that every numeric alert
+   recovers *below* its firing target (e.g. fire at 80%, recover at 70%)
+   to prevent boundary flapping — `signoz-creating-alerts` carries this
+   into the `recoveryTarget` field.
+
+Surface these as a clarification with concrete proposed values, using
+the host application's question/UI mechanism (a structured clarification
+tool, inline tags, an interactive prompt — follow the host's rules).
+Never ask open-ended "what threshold do you want?" — propose, let the
+user adjust.
+Get explicit sign-off on scope and thresholds before building. Flag
+baselines that affect thresholds ("current error rate is 5.1%, so a
+static 5% alert will be noisy — proposing a burn-rate alert instead").
+
+## Phase 6 — Build the dashboard(s)
+
+Hand off to `signoz-creating-dashboards` — it owns templates, the
+layout/variable/OTel-naming defaults, the v5 schema and its gotchas, the
+no-data probe, and the mandatory per-panel dry-run (`signoz-modifying-dashboards`
+for later edits). Do **not** restate panel JSON or grid mechanics here;
+pass intent and let that skill build.
+
+**Prefer several focused dashboards over one large one.** Since
+`signoz-creating-dashboards` builds one dashboard per call — and its
+template catalog is already organized per technology — the orchestration
+decision is *which set of boards to compose*. Default to splitting by
+category/audience and invoking the sub-skill once per board:
+
+- **Service / RED (APM):** KPI tiles + request rate, errors,
+  p50/p95/p99. The primary on-call board.
+- **Infra / USE:** CPU, memory, restarts, network — only if infra
+  monitoring was opted into (Phase 1 Q3), scoped by the attribute
+  *confirmed* in Phase 3. Usually a stock template (`hostmetrics`,
+  `k8s`) imported as its own board.
+- **Downstream dependencies:** client-span p99 + error rate per
+  dependency — only if the service has external deps (Phase 1 Q1),
+  grouped by the attribute found in Phase 3 (`external_http_url` /
+  `db_name`).
+- **Business / SLO:** the SLI ratio and error budget, with a per-tenant
+  breakdown if multi-tenant (Phase 3) — aggregate-only panels hide
+  single-tenant outages.
+
+Splitting keeps each board fast, single-purpose, and ownable by the
+right audience (SRE vs app dev vs platform). **Collapse into one board
+only when the split would otherwise yield several near-empty ones** — a
+small service's handful of panels reads better as rows on one board than
+as four 2-panel dashboards. Each board still passes the Phase 1.5
+extend-vs-create check, so you reuse an existing board rather than adding
+a parallel one.
+
+**Quality bar (every board you create):** production config for a 3am
+responder — each panel earns a "what to watch for" description and a
+drill-down, and each dashboard earns a top-of-page "start here". Pass
+this as intent so `signoz-creating-dashboards` applies it.
+
+## Phase 7 — Saved Explorer views
+
+Hand off to `signoz-managing-views` for the create mechanics (it owns
+the view payload and the `extraData`/`selectColumns` shape). The
+orchestration value is *which* views to stand up — cheaper than panels
+and high-leverage mid-incident:
+
+- ERROR/FATAL logs for the service.
+- API request list — the Traces *list* view over server spans
+  (`kind_string = 'Server'`, verify per Phase 3): a per-request table
+  surfacing service / operation (or `http.route`) /
+  `http.response.status_code` / duration / `trace_id`. The fastest "what
+  are my endpoints doing right now" surface — sortable by latency or
+  status, one click to the full trace, and the broad view that the
+  failing/slow-span views below are just filtered subsets of.
+- Failing spans for the canonical operation (`has_error = true`).
+- Slow spans (`duration_nano > <threshold>`).
+- Failed sub-flows (e.g. OAuth requests with errors).
+- Correlation drill-downs — error logs carrying `trace_id` (a log spike
+  jumps straight to the trace) and slow/error traces that link back to
+  their logs.
+
+Two cross-phase constraints to pass along: every view carries the same
+environment/tenant filter as the dashboard (so `prod` and `staging` rows
+never mix), and the selected columns pass the same PII / no-identifiers
+gate as Phase 4.
+
+## Phase 8 — Alerts
+
+`signoz-creating-alerts` owns every per-alert mechanic — channel
+resolution (create-first with a test message, name-not-UUID, secret
+handling), severity defaults, `op`/`matchType`, units, annotations,
+`evalWindow`/`recoveryTarget`, anomaly-rule shape, and the mandatory
+dry-run. Drive it once per alert and don't restate any of that here.
+(`signoz-explaining-alerts` reads a rule back; `signoz-investigating-alerts`
+does RCA once one fires.)
+
+What this orchestration layer adds on top of that skill:
+
+- **SLI-bound alerts are burn-rate pairs, not static thresholds.** A
+  static threshold on a ratio flaps; the burn-rate pair is the default
+  for anything tied to the Phase 2 SLO.
+- **The burn-rate recipe** (the one thing `signoz-creating-alerts`
+  can't derive without the SLO). Hand it the *inputs*, not a rule shape:
+  the bad/total event definition (prefer the Phase-3 `signoz_calls_total`
+  error/total split over raw trace aggregation), the long+short window
+  lengths from Phase 5, and the firing target `burnRate × (1 − SLO)`.
+  Two judgment calls travel with those inputs — the long and short
+  windows must be evaluated as **one rule that ANDs both** (two
+  independent rules page on every short spike; if the SigNoz version
+  can't express the short-window confirmation in a single rule, ship the
+  long window alone and *say so*), and if no clean bad/total split
+  exists in the ingested data, burn-rate isn't buildable yet — fall back
+  to a baseline-tuned threshold rather than emit a broken rule. Let
+  `signoz-creating-alerts` + `signoz://alert/*` pick the
+  version-correct rule shape. Note that creating-alerts' "would have
+  fired N times in the last 1h" calibration can't grade a 6h/3d
+  burn-rate window — don't read a "fired 0 times" there as tuned; the
+  Phase 9 re-tune-after-a-week loop is the real calibration.
+- **Burn-rate only covers ratio SLIs — schedule the non-ratio failure
+  modes too.** A service that stops emitting, or whose traffic
+  collapses, never burns error budget (the SLI ratio is undefined at
+  zero volume), so the burn-rate pair pages no one. A complete setup
+  adds a telemetry-presence / absent-data alert on the primary signal,
+  and treats traffic/throughput as its own signal. Hand these intents
+  to `signoz-creating-alerts` — it owns the rule shape (absent-data,
+  anomaly, threshold) and the healthy-zero handling; the orchestration
+  decision is only that they belong in the package.
+- **Batch + sequence.** Resolve/confirm the channel (Phase 5 mapping)
+  before any rule references it, then create the alerts as a batch
+  grouped by routing tier — not one rule per metric.
+- **Manual-TODO boundary.** Inhibition rules, org-level notification
+  policies (`usePolicy: true` only *opts into* one), and maintenance
+  windows are configured in the SigNoz UI / Terraform — these tools
+  don't create them. Flag as TODO; never report them done.
+
+## Phase 9 — Hand off
+
+Hand back to the human:
+- Dashboard ID(s), view IDs, alert IDs. Don't synthesize frontend URLs —
+  return IDs and let the UI resolve them.
+- Open questions you couldn't resolve — hand them over as explicit
+  TODOs.
+- Baselines that may need tuning (e.g. "tool error rate is 5.1% today;
+  burn-rate alert tuned for 99% SLO will fire occasionally — re-tune
+  after a week of data").
+
+## What to avoid
+
+- **Inventing channel names or webhook URLs.** Ask.
+- **Static thresholds for SLI-bound alerts.** Burn-rate pairs are the
+  modern default; static thresholds for ratios produce flap.
+- **Wrong-sizing dashboards.** Don't cram 18 panels where 12 will do,
+  and don't scatter four 2-panel boards where one would read better —
+  split by category, then right-size each. Sprawl cuts both ways.
+- **Skipping dry-runs to save time.** A 500 at create time is harder to
+  debug than at dry-run time.
+- **One alert per metric.** Group by routing tier, not per-metric.
+- **High-cardinality labels on metric series.** They detonate the bill.
+  Move to traces/logs.
+- **Synthesizing frontend URLs.** Tools return IDs. Return IDs.
+- **Including scanner traffic in SLI denominators.** Real but
+  irrelevant. Exclude.
+- **Treating exploration findings as throwaway.** Baselines,
+  cardinalities, and error counts set your thresholds and tuning
+  baseline — don't drop them. Persist them where they survive *any*
+  host: bake the numbers into the artifacts (panel/dashboard
+  descriptions, alert annotations) and the Phase 9 hand-off, all of
+  which live in SigNoz. Don't rely on a local notes file.
+- **Letting AI-written instrumentation ship unaudited.** Spot-check what
+  is actually emitted before designing dashboards around it.

--- a/skills/signoz-setting-up-observability/evals/evals.json
+++ b/skills/signoz-setting-up-observability/evals/evals.json
@@ -1,0 +1,40 @@
+{
+  "skill_name": "signoz-setting-up-observability",
+  "evals": [
+    {
+      "id": 0,
+      "eval_name": "full-end-to-end-traces-service",
+      "prompt": "Traces are now flowing for our checkout service (service.name=checkout). Now that data is landing in SigNoz, set me up end-to-end — I want a dashboard, alerts, and a couple of saved views. Success for users is checkout requests completing under 1s with no 5xx.",
+      "expected_output": "Runs the full orchestration in order, not a single artifact. Phase 1 triage captures what checkout does and whether it calls external services. Phase 1.5 inventories existing dashboards/alerts/views/channels via signoz_list_* before creating anything (prefers modify over duplicate). Phase 2 captures an explicit SLI (good/valid events) and SLO target (e.g. 99.9% over 30d) BEFORE designing — uses the stated '<1s, no 5xx' as the SLI seed. Phase 3 explores with RED coverage and prefers SigNoz-derived span metrics (signoz_calls_total, signoz_latency_*) over raw trace aggregation. Phase 5 confirms a real notification channel (never invents one) and proposes concrete burn-rate windows + recovery thresholds (concrete values, not open-ended). Dry-runs every non-trivial panel via signoz_execute_builder_query before save (enforced inside the dashboard/alert sub-skills). Builds dashboard (Phase 6), saved views (Phase 7), and burn-rate alert pairs (Phase 8, not static thresholds for the SLI). Hands back IDs (not fabricated frontend URLs) and notes an export-to-code path. Delegates mechanical work to signoz-creating-dashboards / signoz-managing-views / signoz-creating-alerts. Must NOT reference signoz-writing-clickhouse-queries.",
+      "files": []
+    },
+    {
+      "id": 1,
+      "eval_name": "service-with-external-dependencies",
+      "prompt": "payments service is fully instrumented and reporting to signoz now. it calls stripe and a postgres db. build me the whole observability setup for it — dashboards + alerts.",
+      "expected_output": "Phase 1 Q1 flags the Stripe + Postgres dependencies. Phase 3 discovers downstream topology FROM TRACES rather than trusting the description — filters client spans by kind_string='Client' (verifies it is not 'kind' / not 'SPAN_KIND_CLIENT') and groups by external_http_url / http_host for Stripe and db_name / db_operation for Postgres. Phase 6 dashboard includes a downstream-dependency row (client-span p99 + error rate per dependency). SLO/SLI captured before design; burn-rate alerts for the SLI; dependency error-rate/latency alerts proposed. Channel confirmed before any rule references it. Hands back IDs. No signoz-writing-clickhouse-queries reference.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "eval_name": "existing-dashboard-prefer-modify",
+      "prompt": "We've got cartservice telemetry flowing. Set up full observability for it — I think there might already be a cart dashboard floating around.",
+      "expected_output": "Phase 1.5 inventory runs FIRST: signoz_list_dashboards (+ get_dashboard) finds the existing cart dashboard, signoz_list_alert_rules and signoz_list_views surface existing artifacts. Surfaces the existing dashboard and prefers extending/modifying it (hands off to signoz-modifying-dashboards) over standing up a parallel duplicate. Still captures SLI/SLO and runs exploration so additions are SLO-aware. Reuses an existing notification channel from signoz_list_notification_channels before creating a new one. Does not silently create a second cart dashboard.",
+      "files": []
+    },
+    {
+      "id": 3,
+      "eval_name": "alerts-only-subset-burn-rate",
+      "prompt": "data's flowing for the auth service. i don't need a dashboard — just wire up good alerts so we get paged when users can't log in. SLO is 99.5% successful logins over 30 days.",
+      "expected_output": "Honors the alerts-only deliverable (Phase 1 Q2) and skips the dashboard build, but still gates on SLI/SLO capture (Phase 2) — uses the stated 99.5%/30d. Phase 5 proposes burn-rate windows with absolute thresholds computed as burnRate*(1-SLO) (e.g. 14.4x -> 7.2% at 99.5%) and recovery thresholds below firing, via AskUserQuestion with concrete values. Confirms/creates the notification channel first (test message confirmed) before any rule references it by NAME not UUID. Builds a burn-rate pair (fast+slow) as one ANDed rule where the version allows, preferring signoz_calls_total error/total over raw trace aggregation; falls back to a baseline-tuned threshold and says so if no clean bad/total split exists. Recognizes that burn-rate is blind to zero volume — a silent auth service never burns budget yet users still can't log in — and also schedules a telemetry-presence/absent-data alert on the auth signal (rule shape deferred to signoz-creating-alerts), not just the burn-rate pair. Mandatory annotations (summary/description/owning-team; runbook_url only if real). Delegates alert build mechanics to signoz-creating-alerts and the signoz://alert/* resources (does not restate alert payload schema). Does NOT emit a static threshold for the SLI.",
+      "files": []
+    },
+    {
+      "id": 4,
+      "eval_name": "infra-monitoring-join-verification",
+      "prompt": "inventory-service runs on our own k8s cluster and is now sending traces + metrics to signoz. set up observability including the pod-level resource stuff (cpu, memory, restarts), full dashboard and alerts.",
+      "expected_output": "Phase 1 Q3 opts into infra monitoring. Phase 3 USE half VERIFIES the metric->service join before building — does not assume service.name is on infra metrics; checks whether host/pod metrics carry host.name / k8s.pod.name / k8s.deployment.name and that k8s.deployment.name matches service.name, via get_field_keys(signal='traces', fieldContext='resource') then get_field_keys(signal='metrics', metricName=...). Scopes the USE row by the CONFIRMED attribute, and asks the user for the workload selector if nothing joins rather than guessing. Dashboard gets both a RED row (service) and a USE row (pod CPU/memory/restarts/network). Cardinality classification (Phase 4) keeps high-card attrs off metric series. Dry-runs panels before save; burn-rate alerts for the SLI plus resource-layer alerts (OOM/restarts). Hands back IDs.",
+      "files": []
+    }
+  ]
+}

--- a/skills/signoz-writing-clickhouse-queries/SKILL.md
+++ b/skills/signoz-writing-clickhouse-queries/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: signoz-writing-clickhouse-queries
+description: >-
+  Write raw ClickHouse SQL for a SigNoz dashboard panel — timeseries, value,
+  or table widgets that the builder UI cannot express (custom joins, window
+  functions, regex extraction over log bodies, aggregations beyond builder
+  syntax). Trigger when the user explicitly asks for a "ClickHouse query",
+  a "raw SQL panel", a "custom SQL widget", or describes a SigNoz dashboard
+  panel whose query needs SQL the builder cannot produce. Anchored to
+  dashboard-panel SQL specifically. For ad-hoc data exploration that does
+  not need to land in a panel, use `signoz-generating-queries` instead.
+---
+
+# Writing ClickHouse Queries for SigNoz Dashboards
+
+## When to Use
+
+Use this skill when the user asks for SigNoz queries involving:
+
+- Logs: severity, body text, log volume, structured fields, containers,
+  services, or environments.
+- Traces: spans, latency, duration, p95 or p99, HTTP operations, DB
+  operations, or error spans.
+- Dashboard panels: timeseries charts, value widgets, and table breakdowns.
+
+If the user asks for a dashboard panel but does not mention ClickHouse, still
+use this skill.
+
+## Signal Detection
+
+Identify whether the request is about logs or traces.
+
+- Logs: log lines, severity, body text, log volume, container logs, or
+  structured log fields.
+- Traces: spans, latency, duration, p99, trace analysis, HTTP operations, DB
+  operations, or error spans.
+
+If the request is ambiguous, ask the user to clarify.
+
+## Reference Routing
+
+- Logs: read
+  [`references/clickhouse-logs-reference.md`](./references/clickhouse-logs-reference.md)
+  before writing any query.
+- Traces: read
+  [`references/clickhouse-traces-reference.md`](./references/clickhouse-traces-reference.md)
+  before writing any query.
+
+Each reference covers table schemas, optimization patterns, attribute access
+syntax, dashboard templates, query examples, and a validation checklist.
+
+## Quick Reference
+
+- Timeseries panel: return rows of `(ts, value)` for a chart over time.
+- Value panel: return a single `value` for a stat or counter widget.
+- Table panel: return labelled columns for a grouped breakdown.
+
+## Key Variables by Signal
+
+### Logs
+
+- Timestamp type: `UInt64` in nanoseconds.
+- Time filter: `$start_timestamp_nano` and `$end_timestamp_nano`.
+- Bucket filter: `$start_timestamp` and `$end_timestamp`.
+- Display conversion: `fromUnixTimestamp64Nano(timestamp)`.
+- Main table: `signoz_logs.distributed_logs_v2`.
+- Resource table: `signoz_logs.distributed_logs_v2_resource`.
+
+### Traces
+
+- Timestamp type: `DateTime64(9)`.
+- Time filter: `$start_datetime` and `$end_datetime`.
+- Bucket filter: `$start_timestamp` and `$end_timestamp`.
+- Display conversion: use the timestamp directly.
+- Main table: `signoz_traces.distributed_signoz_index_v3`.
+- Resource table: `signoz_traces.distributed_traces_v3_resource`.
+
+## Top Anti-Patterns
+
+- Missing `ts_bucket_start BETWEEN $start_timestamp - 1800 AND $end_timestamp`.
+- Using plain `IN` instead of `GLOBAL IN` on the resource fingerprint subquery.
+- Adding a resource CTE when there is no resource attribute filter.
+- Logs query with `$start_datetime` or `$end_datetime`.
+- Traces query with `$start_timestamp_nano` or `$end_timestamp_nano`.
+- Traces query with `resources_string['service.name']` instead of
+  `resource_string_service$$name`.
+
+## Query Attribution
+
+Every generated query MUST end with a `SETTINGS` clause for monitoring:
+
+```sql
+SELECT ...
+FROM ...
+WHERE ...
+SETTINGS log_comment = 'signoz-writing-clickhouse-queries skill | YYYY-MM-DD'
+```
+
+Replace `YYYY-MM-DD` with today's date (e.g., `2026-04-03`). If the query
+already has a `SETTINGS` clause, append `log_comment` to it with a comma.
+
+## Workflow
+
+1. Detect the signal: logs or traces.
+2. Read the matching reference file before writing the query.
+3. Pick the panel type: timeseries, value, or table.
+4. Build the query using the required patterns from the reference.
+5. Append the `SETTINGS log_comment` attribution clause.
+6. Validate the result with the checklist in the reference.

--- a/skills/signoz-writing-clickhouse-queries/references/clickhouse-logs-reference.md
+++ b/skills/signoz-writing-clickhouse-queries/references/clickhouse-logs-reference.md
@@ -1,0 +1,379 @@
+# ClickHouse Logs Query Reference for SigNoz
+
+## Contents
+
+- Table Schemas (`distributed_logs_v2`, `distributed_logs_v2_resource`)
+- Mandatory Optimization Patterns
+  - Resource Filter CTE
+  - Timestamp Bucketing
+  - Use Indexed (Selected) Columns Over Map Access
+  - Use GLOBAL IN for Resource Fingerprint Subquery
+  - Body Text Search — Engaging Skip Indexes (predicate engagement,
+    anti-patterns, OR-of-LIKE, hyphens/punctuation, EXPLAIN, type traps)
+- Attribute Access Syntax (resource attributes, span/log attributes,
+  existence checks, timestamp conversion)
+- SigNoz Dashboard Variables
+- Dashboard Panel Query Examples (timeseries, table)
+- Query Examples (per-minute counts, filtered counts, top-N audit)
+- Query Optimization Checklist
+
+All tables live in the `signoz_logs` database.
+
+---
+
+## Table Schemas
+
+### distributed_logs_v2 (Primary Logs Table)
+
+```sql
+(
+    `timestamp` UInt64 CODEC(DoubleDelta, LZ4),          -- nanoseconds since epoch
+    `ts_bucket_start` UInt64 CODEC(DoubleDelta, LZ4),    -- 30-minute bucket start (seconds)
+    `observed_timestamp` UInt64 CODEC(DoubleDelta, LZ4),
+    `id` String CODEC(ZSTD(1)),                           -- KSUID for pagination/sorting
+    `trace_id` String CODEC(ZSTD(1)),
+    `span_id` String CODEC(ZSTD(1)),
+    `trace_flags` UInt32,
+    `severity_text` LowCardinality(String) CODEC(ZSTD(1)),
+    `severity_number` UInt8,
+    `body` String CODEC(ZSTD(2)),
+    `attributes_string` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    `attributes_number` Map(LowCardinality(String), Float64) CODEC(ZSTD(1)),
+    `attributes_bool` Map(LowCardinality(String), Bool) CODEC(ZSTD(1)),
+    `resources_string` Map(LowCardinality(String), String) CODEC(ZSTD(1)),  -- deprecated
+    `resource` JSON(max_dynamic_paths = 100) CODEC(ZSTD(1)),
+    `scope_name` String CODEC(ZSTD(1)),
+    `scope_version` String CODEC(ZSTD(1)),
+    `scope_string` Map(LowCardinality(String), String) CODEC(ZSTD(1))
+)
+```
+
+### distributed_logs_v2_resource (Resource Lookup Table)
+
+Used in the resource filter CTE pattern for efficient filtering by resource attributes.
+
+```sql
+(
+    `labels` String CODEC(ZSTD(5)),
+    `fingerprint` String CODEC(ZSTD(1)),
+    `seen_at_ts_bucket_start` Int64 CODEC(Delta(8), ZSTD(1))
+)
+```
+
+---
+
+## Mandatory Optimization Patterns
+
+### 1. Resource Filter CTE
+
+**Always** use a CTE to pre-filter resource fingerprints when filtering by resource attributes (service.name, environment, k8s.cluster.name, etc.). Do not add this if no resource attribute filter is required.
+
+```sql
+WITH __resource_filter AS (
+    SELECT fingerprint
+    FROM signoz_logs.distributed_logs_v2_resource
+    WHERE (simpleJSONExtractString(labels, 'service.name') = 'myservice')
+    AND seen_at_ts_bucket_start BETWEEN $start_timestamp - 1800 AND $end_timestamp
+)
+SELECT ...
+FROM signoz_logs.distributed_logs_v2
+WHERE resource_fingerprint GLOBAL IN __resource_filter
+    AND ...
+```
+
+- Multiple resource filters: chain with `AND` in the CTE `WHERE` clause.
+- Use `simpleJSONExtractString(labels, '<key>')` to extract resource attribute values in the CTE.
+- Examples of resource attributes: `service.name`, `host.name`, `k8s.cluster.name`, `k8s.deployment.name`, `cloud.provider`.
+
+### 2. Timestamp Bucketing
+
+**Always** include both the nanosecond timestamp filter AND the `ts_bucket_start` filter.
+
+```sql
+WHERE timestamp >= $start_timestamp_nano AND timestamp <= $end_timestamp_nano
+  AND ts_bucket_start BETWEEN $start_timestamp - 1800 AND $end_timestamp
+```
+
+- `$start_timestamp_nano` / `$end_timestamp_nano` — nanosecond precision, filters the `timestamp` column.
+- `$start_timestamp` / `$end_timestamp` — seconds precision, filters the `ts_bucket_start` column.
+- The `- 1800` is required because `ts_bucket_start` is rounded down to 30-minute intervals.
+
+### 3. Use Indexed (Selected) Columns Over Map Access
+
+When an attribute has been promoted to a selected (indexed) field, a dedicated materialized column is created:
+
+| Instead of | Use |
+|---|---|
+| `attributes_string['method']` | `attribute_string_method` |
+| `attributes_number['response.time']` | `attribute_number_response$$time` |
+| `attributes_bool['is_error']` | `attribute_bool_is_error` |
+
+**Naming convention**: prefix with `attribute_<dataType>_`, replace `.` with `$$` for dotted attribute names.
+
+An `_exists` variant is also created: `attribute_string_method_exists Bool` — use this to check existence of an indexed attribute.
+
+### 4. Use GLOBAL IN for Resource Fingerprint Subquery
+
+Always use `GLOBAL IN`, not plain `IN`:
+
+```sql
+WHERE resource_fingerprint GLOBAL IN __resource_filter
+```
+
+### 5. Body Text Search — Engaging Skip Indexes
+
+The `body` column has two skip indexes, **both on `lower(body)`**:
+
+```sql
+INDEX body_index_v2_token  lower(body) TYPE tokenbf_v1(10000, 2, 0)   GRANULARITY 1,
+INDEX body_index_v2_ngram  lower(body) TYPE ngrambf_v1(4, 15000, 3, 0) GRANULARITY 1
+```
+
+ClickHouse compares predicate ASTs to the index expression **literally**. A predicate must reference `lower(body)` to engage either index — `hasToken(body, …)` and `body LIKE '%x%'` prune nothing.
+
+#### Predicate engagement
+
+| Predicate | tokenbf | ngrambf | Notes |
+|---|:-:|:-:|---|
+| `hasToken(lower(body), 'tok')` | yes | no | Whole-token check; best for distinctive single words. |
+| `lower(body) = 'literal'` | yes | yes | Exact equality. |
+| `lower(body) LIKE '%substr%'` | no | yes | Substring must be ≥ 4 chars (ngrambf `N=4`). |
+| `lower(body) LIKE '%a%b%'` | no | yes | n-grams of each substring ANDed — more selective. |
+| `lower(body) ILIKE '%x%'` | no | sometimes | Prefer the explicit `lower(body) LIKE '%x%'` form. |
+| `position(body, 'x') > 0` | no | no | Always rewrite to `lower(body) LIKE`. |
+| `positionCaseInsensitive(body, 'X') > 0` | no | no | Biggest trap — engages neither even with `lower(body)` index. |
+| `match(lower(body), 'regex')` | no | partial | Only literal substrings inside the regex are usable. |
+
+#### Anti-patterns to rewrite
+
+| Replace | With |
+|---|---|
+| `positionCaseInsensitive(body, 'Foo')` | `lower(body) LIKE '%foo%'` |
+| `position(body, 'foo') > 0` | `lower(body) LIKE '%foo%'` |
+| `body LIKE '%Foo%'` | `lower(body) LIKE '%foo%'` |
+| `hasToken(body, 'foo')` | `hasToken(lower(body), 'foo')` |
+
+Lowercase the literal (the index value is lowercase). Escape `%` and `_` in the literal; pass other characters (hyphens, dots, parens, colons) through as-is.
+
+#### OR-of-LIKE — add a common AND-prefix
+
+OR'd `LIKE` patterns weaken ngrambf to nearly nothing: any branch matching keeps the granule. Find a token or substring shared by **all** branches and AND it before the OR block:
+
+```sql
+-- BEFORE: ngrambf keeps almost every granule
+WHERE lower(body) LIKE '%failed to send foo%'
+   OR lower(body) LIKE '%failed to send bar%'
+   OR lower(body) LIKE '%failed to send baz%'
+
+-- AFTER: tokenbf + ngrambf both prune; OR is now a per-row validator
+WHERE hasToken(lower(body), 'failed')               -- tokenbf engages
+  AND lower(body) LIKE '%failed to send%'           -- ngrambf engages
+  AND ( lower(body) LIKE '%failed to send foo%'
+     OR lower(body) LIKE '%failed to send bar%'
+     OR lower(body) LIKE '%failed to send baz%' )
+```
+
+Pick the AND-prefix in this order: (1) most distinctive single token via `hasToken`, (2) two ANDed `hasToken` calls, (3) distinctive shared substring via `LIKE`. Avoid common words like `the`, `user`, `error` — high false-positive rate on the bloom filter.
+
+#### Hyphens and punctuation split tokens
+
+`tokenbf` only stores `[A-Za-z0-9_]+` runs. Anything else (hyphens, dots, slashes, quotes, parens, colons) is a token boundary. So:
+
+- `hasToken(lower(body), 'settlement-requested')` matches **nothing** — there is no such token.
+- Use `hasToken(lower(body), 'settlement') AND hasToken(lower(body), 'requested')`, or
+- Use `lower(body) LIKE '%settlement-requested%'` (ngrambf handles punctuation).
+
+#### Verify with `EXPLAIN indexes=1`
+
+```sql
+EXPLAIN indexes=1
+<your query>;
+```
+
+Each `Skip` block under `ReadFromMergeTree` shows `Granules: kept/total`. For both `body_index_v2_token` and `body_index_v2_ngram`, kept should be `<` total. The `Combined` block is what feeds the actual scan — that's the number to drive down.
+
+Failure modes:
+- `Granules: 195/195` — predicate doesn't match the index expression, or the chosen token is too common.
+- `Skip` block missing — predicate engages no skip index at all.
+
+`tokenbf_v1(10000, …)` is small and saturates at high cardinality; `ngrambf_v1(4, 15000, …)` is the workhorse. If tokenbf looks idle even with a correct `hasToken(lower(body), …)`, lean on `lower(body) LIKE` rather than chasing tokenbf pruning the filter size won't deliver.
+
+#### Type traps in body-search queries
+
+- `toUnixTimestamp64Nano(now())` → `Code: 43, ILLEGAL_TYPE_OF_ARGUMENT`. Use `now64()` (or `toDateTime64(now(), 9)`). SigNoz dashboard macros like `$start_timestamp_nano` resolve to literal integers and sidestep this.
+- `max(fromUnixTimestamp64Nano(timestamp))` converts every row before aggregating. Use `fromUnixTimestamp64Nano(max(timestamp))` — `max` once on cheap UInt64, convert once at the end.
+
+---
+
+## Attribute Access Syntax
+
+### Resource attributes in SELECT / GROUP BY
+```sql
+resource.service.name::String
+resource.k8s.cluster.name::String
+```
+
+### Resource attributes in WHERE (via CTE)
+```sql
+simpleJSONExtractString(labels, 'service.name') = 'myservice'
+```
+
+### Span/log attributes in WHERE (map access)
+```sql
+attributes_string['method'] = 'GET'
+attributes_number['response.time'] > 1000
+attributes_bool['is_error'] = true
+```
+
+### Checking attribute existence
+```sql
+mapContains(attributes_string, 'container_name')
+```
+
+### Timestamp display conversion
+```sql
+fromUnixTimestamp64Nano(timestamp)  -- use in SELECT for human-readable time
+toStartOfInterval(fromUnixTimestamp64Nano(timestamp), INTERVAL 1 MINUTE) AS ts
+```
+
+---
+
+## SigNoz Dashboard Variables
+
+| Variable | Type | Description |
+|---|---|---|
+| `$start_timestamp_nano` | UInt64 | Start of selected time range (nanoseconds) |
+| `$end_timestamp_nano` | UInt64 | End of selected time range (nanoseconds) |
+| `$start_timestamp` | Int64 | Start as Unix timestamp (seconds) |
+| `$end_timestamp` | Int64 | End as Unix timestamp (seconds) |
+
+---
+
+## Dashboard Panel Query Examples
+
+### Timeseries Panel
+
+Aggregates data over time intervals for chart visualization.
+
+```sql
+WITH __resource_filter AS (
+    SELECT fingerprint
+    FROM signoz_logs.distributed_logs_v2_resource
+    WHERE (simpleJSONExtractString(labels, 'service.name') = 'service-name')
+    AND seen_at_ts_bucket_start BETWEEN $start_timestamp - 1800 AND $end_timestamp
+)
+SELECT
+    toStartOfInterval(fromUnixTimestamp64Nano(timestamp), INTERVAL 1 MINUTE) AS ts,
+    toFloat64(count()) AS value
+FROM signoz_logs.distributed_logs_v2
+WHERE
+    resource_fingerprint GLOBAL IN __resource_filter AND
+    timestamp >= $start_timestamp_nano AND timestamp <= $end_timestamp_nano AND
+    ts_bucket_start BETWEEN $start_timestamp - 1800 AND $end_timestamp
+GROUP BY ts
+ORDER BY ts ASC;
+```
+
+### Table Panel
+
+```sql
+SELECT
+    resource.service.name::String AS `service.name`,
+    toFloat64(count()) AS value
+FROM signoz_logs.distributed_logs_v2
+WHERE
+    timestamp >= $start_timestamp_nano AND timestamp <= $end_timestamp_nano AND
+    ts_bucket_start BETWEEN $start_timestamp - 1800 AND $end_timestamp
+GROUP BY `service.name`
+ORDER BY value DESC;
+```
+
+> Note: only add the resource CTE and `resource_fingerprint GLOBAL IN __resource_filter` when you need to filter on resource attributes. A plain table breakdown by service name does not require it.
+
+---
+
+## Query Examples
+
+### Timeseries — Count per minute grouped by container name
+
+Shows `mapContains` for attribute existence check and attribute in GROUP BY.
+
+```sql
+SELECT
+    toStartOfInterval(fromUnixTimestamp64Nano(timestamp), INTERVAL 1 MINUTE) AS ts,
+    attributes_string['container_name'] AS container_name,
+    toFloat64(count()) AS value
+FROM signoz_logs.distributed_logs_v2
+WHERE
+    timestamp >= $start_timestamp_nano AND timestamp <= $end_timestamp_nano AND
+    ts_bucket_start BETWEEN $start_timestamp - 1800 AND $end_timestamp AND
+    mapContains(attributes_string, 'container_name')
+GROUP BY container_name, ts
+ORDER BY ts ASC;
+```
+
+### Timeseries — Filtered by service, severity, and attribute
+
+Shows combining resource CTE with `severity_text` and attribute map access.
+
+```sql
+WITH __resource_filter AS (
+    SELECT fingerprint
+    FROM signoz_logs.distributed_logs_v2_resource
+    WHERE (simpleJSONExtractString(labels, 'service.name') = 'demo')
+    AND seen_at_ts_bucket_start BETWEEN $start_timestamp - 1800 AND $end_timestamp
+)
+SELECT
+    toStartOfInterval(fromUnixTimestamp64Nano(timestamp), INTERVAL 1 MINUTE) AS ts,
+    toFloat64(count()) AS value
+FROM signoz_logs.distributed_logs_v2
+WHERE
+    resource_fingerprint GLOBAL IN __resource_filter AND
+    timestamp >= $start_timestamp_nano AND timestamp <= $end_timestamp_nano AND
+    severity_text = 'INFO' AND
+    attributes_string['method'] = 'GET' AND
+    ts_bucket_start BETWEEN $start_timestamp - 1800 AND $end_timestamp
+GROUP BY ts
+ORDER BY ts ASC;
+```
+
+### Advanced — Top 10 largest logs for payload auditing
+
+Calculates per-log byte size from body + all attributes. Keep queries to ≤6 hour windows for this pattern.
+
+```sql
+SELECT
+    fromUnixTimestamp64Nano(timestamp) AS log_timestamp,
+    (OCTET_LENGTH(body) +
+     OCTET_LENGTH(toJSONString(attributes_string)) +
+     OCTET_LENGTH(toJSONString(attributes_number)) +
+     OCTET_LENGTH(toJSONString(attributes_bool))) AS size_bytes,
+    id
+FROM signoz_logs.distributed_logs_v2
+WHERE
+    timestamp >= $start_timestamp_nano AND timestamp <= $end_timestamp_nano AND
+    ts_bucket_start BETWEEN $start_timestamp - 1800 AND $end_timestamp
+ORDER BY size_bytes DESC
+LIMIT 10;
+```
+
+Use the returned `id` value in the SigNoz Logs Explorer filter `id=<log_id>` to view full log details.
+
+---
+
+## Query Optimization Checklist
+
+Before finalizing any query, verify:
+
+- [ ] **Resource filter CTE** is present when filtering by resource attributes (`service.name`, `k8s.*`, etc.)
+- [ ] Do **not** add the resource CTE if no resource attribute filtering is needed
+- [ ] **`ts_bucket_start`** filter is included: `BETWEEN $start_timestamp - 1800 AND $end_timestamp`
+- [ ] **Nanosecond variables** used for the `timestamp` column: `$start_timestamp_nano` / `$end_timestamp_nano`
+- [ ] **`fromUnixTimestamp64Nano(timestamp)`** used in SELECT when displaying timestamps
+- [ ] **`GLOBAL IN`** is used (not plain `IN`) for the any subquery
+- [ ] **Indexed columns** used over map access where the attribute is a selected field
+- [ ] **Body searches** use `lower(body)` (not raw `body`) and `LIKE` (not `position` / `positionCaseInsensitive`); for OR'd patterns, a shared `hasToken` or `LIKE` is ANDed before the OR block
+- [ ] **`seen_at_ts_bucket_start`** filter is included in the resource CTE
+- [ ] For timeseries: results are ordered by `ts ASC`
+- [ ] **Table Name**: Always use the `distributed_` prefix (`distributed_logs_v2`, not `logs_v2`)
+- [ ] If multiple tables are joined, ensure all tables have timestamp and bucket filter applied if applicable.

--- a/skills/signoz-writing-clickhouse-queries/references/clickhouse-traces-reference.md
+++ b/skills/signoz-writing-clickhouse-queries/references/clickhouse-traces-reference.md
@@ -1,0 +1,290 @@
+
+# ClickHouse Traces Query Reference for SigNoz
+
+## Contents
+
+- Table Schemas (`distributed_signoz_index_v3`,
+  `distributed_traces_v3_resource`, `distributed_signoz_error_index_v2`)
+- Mandatory Optimization Patterns
+  - Resource Filter CTE
+  - Timestamp Bucketing
+  - Use Indexed Columns Over Map Access
+  - Use Pre-extracted Columns
+- Attribute Access Syntax (resource attributes, existence checks)
+- Dashboard Panel Query Templates (timeseries, table)
+- Query Examples (error spans per service, average duration by method)
+- Query Optimization Checklist
+
+All tables live in the `signoz_traces` database.
+
+---
+
+## Table Schemas
+
+### distributed_signoz_index_v3 (Primary Spans Table)
+
+The main table for querying span data. 30+ columns following OpenTelemetry conventions.
+
+```sql
+(
+    `ts_bucket_start` UInt64 CODEC(DoubleDelta, LZ4),
+    `resource_fingerprint` String CODEC(ZSTD(1)),
+    `timestamp` DateTime64(9) CODEC(DoubleDelta, LZ4),
+    `trace_id` FixedString(32) CODEC(ZSTD(1)),
+    `span_id` String CODEC(ZSTD(1)),
+    `trace_state` String CODEC(ZSTD(1)),
+    `parent_span_id` String CODEC(ZSTD(1)),
+    `flags` UInt32 CODEC(T64, ZSTD(1)),
+    `name` LowCardinality(String) CODEC(ZSTD(1)),
+    `kind` Int8 CODEC(T64, ZSTD(1)),
+    `kind_string` String CODEC(ZSTD(1)),
+    `duration_nano` UInt64 CODEC(T64, ZSTD(1)),
+    `status_code` Int16 CODEC(T64, ZSTD(1)),
+    `status_message` String CODEC(ZSTD(1)),
+    `status_code_string` String CODEC(ZSTD(1)),
+    `attributes_string` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    `attributes_number` Map(LowCardinality(String), Float64) CODEC(ZSTD(1)),
+    `attributes_bool` Map(LowCardinality(String), Bool) CODEC(ZSTD(1)),
+    `resources_string` Map(LowCardinality(String), String) CODEC(ZSTD(1)),  -- deprecated
+    `resource` JSON(max_dynamic_paths = 100) CODEC(ZSTD(1)),
+    `events` Array(String) CODEC(ZSTD(2)),
+    `links` String CODEC(ZSTD(1)),
+    `response_status_code` LowCardinality(String) CODEC(ZSTD(1)),
+    `external_http_url` LowCardinality(String) CODEC(ZSTD(1)),
+    `http_url` LowCardinality(String) CODEC(ZSTD(1)),
+    `external_http_method` LowCardinality(String) CODEC(ZSTD(1)),
+    `http_method` LowCardinality(String) CODEC(ZSTD(1)),
+    `http_host` LowCardinality(String) CODEC(ZSTD(1)),
+    `db_name` LowCardinality(String) CODEC(ZSTD(1)),
+    `db_operation` LowCardinality(String) CODEC(ZSTD(1)),
+    `has_error` Bool CODEC(T64, ZSTD(1)),
+    `is_remote` LowCardinality(String) CODEC(ZSTD(1)),
+    -- Pre-indexed "selected" columns (use these instead of map access when available):
+    `resource_string_service$$name` LowCardinality(String) DEFAULT resources_string['service.name'] CODEC(ZSTD(1)),
+    `attribute_string_http$$route` LowCardinality(String) DEFAULT attributes_string['http.route'] CODEC(ZSTD(1)),
+    `attribute_string_messaging$$system` LowCardinality(String) DEFAULT attributes_string['messaging.system'] CODEC(ZSTD(1)),
+    `attribute_string_messaging$$operation` LowCardinality(String) DEFAULT attributes_string['messaging.operation'] CODEC(ZSTD(1)),
+    `attribute_string_db$$system` LowCardinality(String) DEFAULT attributes_string['db.system'] CODEC(ZSTD(1)),
+    `attribute_string_rpc$$system` LowCardinality(String) DEFAULT attributes_string['rpc.system'] CODEC(ZSTD(1)),
+    `attribute_string_rpc$$service` LowCardinality(String) DEFAULT attributes_string['rpc.service'] CODEC(ZSTD(1)),
+    `attribute_string_rpc$$method` LowCardinality(String) DEFAULT attributes_string['rpc.method'] CODEC(ZSTD(1)),
+    `attribute_string_peer$$service` LowCardinality(String) DEFAULT attributes_string['peer.service'] CODEC(ZSTD(1))
+)
+ORDER BY (ts_bucket_start, resource_fingerprint, has_error, name, timestamp)
+```
+
+### distributed_traces_v3_resource (Resource Lookup Table)
+
+Used in the resource filter CTE pattern for efficient filtering by resource attributes.
+
+```sql
+(
+    `labels` String CODEC(ZSTD(5)),
+    `fingerprint` String CODEC(ZSTD(1)),
+    `seen_at_ts_bucket_start` Int64 CODEC(Delta(8), ZSTD(1))
+)
+```
+
+### distributed_signoz_error_index_v2 (Error Events)
+
+```sql
+(
+    `timestamp` DateTime64(9) CODEC(DoubleDelta, LZ4),
+    `errorID` FixedString(32) CODEC(ZSTD(1)),
+    `groupID` FixedString(32) CODEC(ZSTD(1)),
+    `traceID` FixedString(32) CODEC(ZSTD(1)),
+    `spanID` String CODEC(ZSTD(1)),
+    `serviceName` LowCardinality(String) CODEC(ZSTD(1)),
+    `exceptionType` LowCardinality(String) CODEC(ZSTD(1)),
+    `exceptionMessage` String CODEC(ZSTD(1)),
+    `exceptionStacktrace` String CODEC(ZSTD(1)),
+    `exceptionEscaped` Bool CODEC(T64, ZSTD(1)),
+    `resourceTagsMap` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    INDEX idx_error_id errorID TYPE bloom_filter GRANULARITY 4,
+    INDEX idx_resourceTagsMapKeys mapKeys(resourceTagsMap) TYPE bloom_filter(0.01) GRANULARITY 64,
+    INDEX idx_resourceTagsMapValues mapValues(resourceTagsMap) TYPE bloom_filter(0.01) GRANULARITY 64
+)
+```
+
+---
+
+## Mandatory Optimization Patterns
+
+### 1. Resource Filter CTE
+
+**Always** use a CTE to pre-filter resource fingerprints when filtering by resource attributes (service.name, environment, etc.). This is the single most impactful optimization but do not add this if there is no resource attribute filter required.
+
+```sql
+WITH __resource_filter AS (
+    SELECT fingerprint
+    FROM signoz_traces.distributed_traces_v3_resource
+    WHERE (simpleJSONExtractString(labels, 'service.name') = 'myservice')
+    AND seen_at_ts_bucket_start BETWEEN $start_timestamp - 1800 AND $end_timestamp
+)
+SELECT ...
+FROM signoz_traces.distributed_signoz_index_v3
+WHERE resource_fingerprint GLOBAL IN __resource_filter
+    AND ...
+```
+
+- Multiple resource filters: chain with AND in the CTE WHERE clause.
+- Use `simpleJSONExtractString(labels, '<key>')` to extract resource attribute values.
+- Examples of resources attributes are service.name, host.name, cloud.provider, k8s.deployment.name, k8s.*, os.* etc
+
+### 2. Timestamp Bucketing
+
+**Always** include `ts_bucket_start` filter alongside `timestamp` filter. Data is bucketed in 30-minute (1800-second) intervals.
+
+```sql
+WHERE timestamp BETWEEN $start_datetime AND $end_datetime
+  AND ts_bucket_start BETWEEN $start_timestamp - 1800 AND $end_timestamp
+```
+
+Since the ts_bucket_start is rounded down to 30m, the `- 1800` is required to avoid filtering out the bucket with start timestamp.
+
+### 3. Use Indexed Columns Over Map Access
+
+When a pre-indexed ("selected") column exists, use it instead of map access:
+
+| Instead of | Use |
+|---|---|
+| `attributes_string['http.route']` | `attribute_string_http$$route` |
+| `attributes_string['db.system']` | `attribute_string_db$$system` |
+| `attributes_string['rpc.method']` | `attribute_string_rpc$$method` |
+| `attributes_string['peer.service']` | `attribute_string_peer$$service` |
+| `resources_string['service.name']` | `resource_string_service$$name` |
+
+The naming convention: replace `.` with `$$` in the attribute name and prefix with `attribute_string_`, `attribute_number_`, or `attribute_bool_`.
+
+### 4. Use Pre-extracted Columns
+
+These top-level columns are faster than map access and are derived from multiple similar attributes, 
+**always** prefer these if any of similar attributes are required:
+- `http_method`, `http_url`, `http_host`
+- `db_name`, `db_operation`
+- `has_error`, `duration_nano`, `name`, `kind`
+- `response_status_code`
+
+---
+
+## Attribute Access Syntax
+
+### Resource attributes in SELECT / GROUP BY
+```sql
+resource.service.name::String
+resource.namespace::String
+```
+
+### Resource attributes in WHERE (via CTE)
+```sql
+simpleJSONExtractString(labels, 'service.name') = 'myservice'
+```
+
+### Checking attribute existence
+```sql
+mapContains(attributes_string, 'http.route')
+```
+
+---
+
+## Dashboard Panel Query Templates
+
+### Timeseries Panel
+
+Aggregates data over time intervals for chart visualization.
+
+```sql
+WITH __resource_filter AS (
+    SELECT fingerprint
+    FROM signoz_traces.distributed_traces_v3_resource
+    WHERE (simpleJSONExtractString(labels, 'service.name') = '{{service}}')
+    AND seen_at_ts_bucket_start BETWEEN $start_timestamp - 1800 AND $end_timestamp
+)
+SELECT
+    toStartOfInterval(timestamp, INTERVAL 1 MINUTE) AS ts,
+    toFloat64(count()) AS value
+FROM signoz_traces.distributed_signoz_index_v3
+WHERE
+    resource_fingerprint GLOBAL IN __resource_filter AND
+    timestamp BETWEEN $start_datetime AND $end_datetime AND
+    ts_bucket_start BETWEEN $start_timestamp - 1800 AND $end_timestamp
+GROUP BY ts
+ORDER BY ts ASC;
+```
+
+### Table Panel
+
+```sql
+SELECT
+    resource.service.name::String as `service.name`,
+    toFloat64(count()) AS value
+FROM signoz_traces.distributed_signoz_index_v3
+WHERE
+    timestamp BETWEEN $start_datetime AND $end_datetime AND
+    ts_bucket_start BETWEEN $start_timestamp - 1800 AND $end_timestamp AND
+    `service.name` IS NOT NULL
+GROUP BY `service.name`
+ORDER BY value DESC;
+```
+
+---
+
+## Query Examples
+
+### Timeseries — Error spans per service per minute
+
+Shows `has_error` filtering, resource attribute in SELECT, and multi-series grouping.
+
+```sql
+SELECT
+    toStartOfInterval(timestamp, INTERVAL 1 MINUTE) AS ts,
+    resource.service.name::String as `service.name`,
+    toFloat64(count()) AS value
+FROM signoz_traces.distributed_signoz_index_v3
+WHERE
+    timestamp BETWEEN $start_datetime AND $end_datetime AND
+    has_error = true AND
+    `service.name` IS NOT NULL AND
+    ts_bucket_start BETWEEN $start_timestamp - 1800 AND $end_timestamp
+GROUP BY `service.name`, ts
+ORDER BY ts ASC;
+```
+
+### Table — Average duration by HTTP method
+
+```sql
+WITH __resource_filter AS (
+    SELECT fingerprint
+    FROM signoz_traces.distributed_traces_v3_resource
+    WHERE (simpleJSONExtractString(labels, 'service.name') = 'api-gateway')
+    AND seen_at_ts_bucket_start BETWEEN $start_timestamp - 1800 AND $end_timestamp
+)
+SELECT
+    http_method,
+    toFloat64(avg(duration_nano)) AS avg_duration_nano
+FROM signoz_traces.distributed_signoz_index_v3
+WHERE
+    resource_fingerprint GLOBAL IN __resource_filter AND
+    timestamp BETWEEN $start_datetime AND $end_datetime AND
+    ts_bucket_start BETWEEN $start_timestamp - 1800 AND $end_timestamp AND
+    http_method IS NOT NULL AND http_method != ''
+GROUP BY http_method
+ORDER BY avg_duration_nano DESC;
+```
+
+---
+
+## Query Optimization Checklist
+
+Before finalizing any query, verify:
+
+- [ ] **Resource filter CTE** is present when filtering by resource attributes (service.name, deployment.environment, etc.)
+- [ ] Do not add the resource filter CTE if filtering is not required on resource attributes
+- [ ] **`ts_bucket_start`** filter is included alongside `timestamp` filter, with `- 1800` on start
+- [ ] **`GLOBAL IN`** is used (not just `IN`) for the resource fingerprint subquery
+- [ ] **Indexed columns** are used over map access where available (e.g., `attribute_string_http$$route']` over `attributes_string['http.route']`)
+- [ ] **Pre-extracted columns** are used where available (`has_error`, `duration_nano`, `http_method`, `db_name`, `http_host`, etc.)
+- [ ] **`seen_at_ts_bucket_start`** filter is included in the resource CTE
+- [ ] For timeseries: results are ordered by time column ASC
+- [ ] **Table Name**: For distributed tables, always use table name with `distributed_` prefix to avoid running query in a local table of clickhouse node.
+- [ ] If multiple tables are joined, ensure all tables have timestamp and bucket filter applied if applicable.


### PR DESCRIPTION
The Gemini extension installed fine, but none of the skills were discovered. The root cause: skills/ was a symlink to plugins/signoz/skills. Gemini's installer clones the repo to a temp directory and copies it into ~/.gemini/extensions/, rewriting symlinks to absolute paths pointing at that temp clone — which is then deleted. The installed extension ended up with a dangling skills symlink, so skill discovery found nothing.

### Changes

Replaced the root skills/ symlink with a real copy of plugins/signoz/skills/ (12 skills). plugins/signoz/skills/ remains the source of truth.
Extended the auto CalVer bump workflow to rsync plugins/signoz/skills/ → skills/ whenever the signoz plugin changes, so the two copies can't drift. The sync lands in the same auto-bump commit.
Documented the convention in CONTRIBUTING.md: never edit root skills/ directly.

### Testing

gemini extensions validate . passes.
Installed from local path: ~/.gemini/extensions/signoz/skills/ now contains real skill directories (previously a dangling symlink), and /skills list shows all 12 skills.