### PR TITLE
feat(claude): show self-hosted setup reminder immediately at session start

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ self-hosted HTTP `/mcp` URL (for example `http://localhost:8000/mcp`).
 > install the plugin mid-session, its `SessionStart` hook has no session-start
 > event to fire on yet. Start a new session to trigger it: run `/clear`, restart
 > Claude Code, or resume with `/resume` (or `claude --continue`). The reminder
-> then appears on your first prompt of the new session.
+> then appears immediately at the start of the new session — no prompt needed.
 
 To change the region later, reconfigure the plugin's options or run
 `signoz-mcp-setup`.
@@ -74,7 +74,7 @@ Update:
 /plugin update signoz@signoz-skills
 ```
 
-> The plugin ships a `PreToolUse` hook that auto-allows `WebFetch` to `signoz.io` domains. This does not affect `Bash`-based network calls (`curl`, `wget`), which follow the normal permission flow. It also ships a `SessionStart` hook that, only when **Self-hosted SigNoz?** is set to `yes` and the MCP endpoint still points at SigNoz Cloud, reminds you to finish setup with `signoz-mcp-setup`. Since `SessionStart` hooks only fire at session boundaries, this reminder appears on the next session after install — start one with `/clear`, a restart, or `/resume`.
+> The plugin ships a `PreToolUse` hook that auto-allows `WebFetch` to `signoz.io` domains. This does not affect `Bash`-based network calls (`curl`, `wget`), which follow the normal permission flow. It also ships a `SessionStart` hook that, only when **Self-hosted SigNoz?** is set to `yes` and the MCP endpoint still points at SigNoz Cloud, shows a reminder to finish setup with `signoz-mcp-setup` as soon as the session starts. Since `SessionStart` hooks only fire at session boundaries, this reminder appears on the next session after install — start one with `/clear`, a restart, or `/resume`.
 
 ### Codex
 

--- a/plugins/signoz/.claude-plugin/plugin.json
+++ b/plugins/signoz/.claude-plugin/plugin.json
@@ -19,7 +19,7 @@
     "SIGNOZ_SELF_HOSTED": {
       "type": "string",
       "title": "Self-hosted SigNoz? (type yes / no)",
-      "description": "Type yes if you run your own SigNoz instead of SigNoz Cloud; leave blank or type no for SigNoz Cloud. If yes, the region above is ignored: after install, start a new session (/clear or restart) and the plugin will remind you on your first prompt to point it at your MCP URL by running /signoz-mcp-setup (for example: /signoz-mcp-setup http://localhost:8000/mcp).",
+      "description": "Type yes if you run your own SigNoz instead of SigNoz Cloud; leave blank or type no for SigNoz Cloud. If yes, the region above is ignored: after install, start a new session (/clear or restart) and Claude will remind you to point it at your MCP URL by running /signoz-mcp-setup (for example: /signoz-mcp-setup http://localhost:8000/mcp).",
       "default": "",
       "required": false
     }

--- a/plugins/signoz/hooks/scripts/self-hosted-nudge.js
+++ b/plugins/signoz/hooks/scripts/self-hosted-nudge.js
@@ -38,9 +38,10 @@ function needsSelfHostedSetup(registrationPath) {
   return lowered.includes("signoz.cloud") || lowered.includes("not-setup");
 }
 
-function emitContext(context) {
+function emitContext(context, userMessage) {
   process.stdout.write(
     JSON.stringify({
+      systemMessage: userMessage,
       hookSpecificOutput: {
         hookEventName: "SessionStart",
         additionalContext: context,
@@ -66,4 +67,7 @@ emitContext(
     "points at SigNoz Cloud. Tell the user to finish setup by running " +
     "/signoz-mcp-setup with their self-hosted MCP URL, for example: " +
     "/signoz-mcp-setup http://localhost:8000/mcp",
+  "SigNoz plugin is in self-hosted mode but its MCP server isn't configured yet. " +
+    "Run /signoz-mcp-setup with your self-hosted MCP URL to finish setup, " +
+    "for example: /signoz-mcp-setup http://localhost:8000/mcp",
 );


### PR DESCRIPTION
## Problem

When the SigNoz plugin is installed with **Self-hosted SigNoz?** set to `yes`, the
`SessionStart` hook only emitted `additionalContext`. That context sits invisibly in
Claude's conversation until the user sends a message — so after `/clear` or a restart,
the user had to type a throwaway first prompt before Claude would surface the
"finish setup with /signoz-mcp-setup" instructions.

## Change

- **`hooks/scripts/self-hosted-nudge.js`** — emit a top-level `systemMessage` alongside
  the existing `additionalContext`. Claude Code displays `systemMessage` directly in the
  terminal the moment the hook runs, so the setup reminder now appears immediately at
  session start with no prompt needed. The `additionalContext` is kept so Claude also
  knows the setup state if the user asks a follow-up question instead of running the
  command.
- **`README.md`** — update the install notes to reflect that the reminder appears at
  session start rather than on the first prompt.
- **`.claude-plugin/plugin.json`** — same wording fix in the `SIGNOZ_SELF_HOSTED`
  option description.

Behavior is otherwise unchanged: the hook still only fires when self-hosted mode is on
and the MCP endpoint still points at SigNoz Cloud, and it stops once the user runs
`/signoz-mcp-setup` with their own URL.

## Testing

pushed tio ny own local fork, ran:
/plugin marketplace add gkarthi-signoz/agent-skills
/plugin install signoz@signoz-skills

and followed the README. 

🤖 Generated with [Claude Code](https://claude.com/claude-code)
