### PR TITLE
changing name from 'signoz' to 'mcp'

### DIFF
--- a/plugins/signoz/.signoz_claude_mcp.json
+++ b/plugins/signoz/.signoz_claude_mcp.json
@@ -1,6 +1,6 @@
 {
   "mcpServers": {
-    "signoz": {
+    "mcp": {
       "type": "http",
       "url": "https://mcp.${user_config.SIGNOZ_REGION}.signoz.cloud/mcp"
     }


### PR DESCRIPTION
Rename the MCP server key in .signoz_claude_mcp.json from 'signoz' to 'mcp' so the server registers under the generic 'mcp' name.