### PR TITLE
fix(signoz): make signoz-generating-queries Cost Meter-aware (PR #47 follow-up)

### DIFF
--- a/plugins/signoz/skills/signoz-generating-queries/SKILL.md
+++ b/plugins/signoz/skills/signoz-generating-queries/SKILL.md
@@ -51,7 +51,7 @@ Map the user's intent to the right signal:
 | Find specific log entries, error messages, stack traces | **logs** | Text search, pattern matching, severity filtering. |
 | Find specific traces, slow requests, error spans | **traces** | Per-request detail, span attributes, duration filtering. |
 | Infrastructure metrics (CPU, memory, disk, network) | **metrics** | Always metrics for resource utilization. |
-| Ingestion volume (bytes or count), cost, or billing usage | **metrics** with `source=meter` (Cost Meter) | `signoz.meter.*` ingestion metrics (logs/spans/datapoints by count **and** bytes) live only in the meter store; bytes are unavailable on the raw signals. groupBy/filter work like a normal metric, but only over the limited attribute set the meter retains (not arbitrary log/trace fields). For a *count* sliced by an attribute the meter doesn't carry, aggregate logs/traces directly instead. |
+| Ingestion volume (bytes or count), cost, or billing usage | **metrics** with `source=meter` (Cost Meter) | `signoz.meter.*` ingestion metrics (logs/spans/datapoints by count **and** bytes) live only in the meter store; bytes are unavailable on the raw signals. Dollar **cost is not a metric** — derive it from volume × per-unit price (see Step 2). groupBy/filter work like a normal metric, but only over the limited attribute set the meter retains (not arbitrary log/trace fields). For a *count* sliced by an attribute the meter doesn't carry, aggregate logs/traces directly instead. |
 | "How many X per Y" (count/rate grouped by dimension) | **traces** or **logs** (aggregate) | Use `signoz_aggregate_traces` or `signoz_aggregate_logs` for grouped counts. |
 
 If the signal is genuinely ambiguous, ask the user before proceeding. The
@@ -73,12 +73,16 @@ Run discovery calls in parallel where possible:
 - **For Cost Meter** (ingestion volume, cost, billing): pass `source=meter` to
   `signoz_list_metrics` to discover the metrics (`signoz.meter.*`) — they're
   invisible in the default store and the set evolves, so don't hardcode it.
-  groupBy/filters/aggregations then work like any metric, with two caveats:
-  *bytes and cost exist only here* (count is also available via direct
-  `signoz_aggregate_logs`/`_traces`), and the meter retains only a *limited
+  groupBy/filters/aggregations then work like any metric, with three caveats:
+  *bytes exist only here* (count is also available via direct
+  `signoz_aggregate_logs`/`_traces`); the meter retains only a *limited
   attribute set* — discover groupable keys via `signoz_get_field_keys(signal:
   "metrics", source: "meter")`, and fall back to a direct count (no bytes) to
-  slice by an attribute it lacks.
+  slice by an attribute it lacks; and **dollar cost is not a meter metric** —
+  the store holds only volume, so don't `searchText: "cost"` expecting a hit.
+  For a cost question, query the volume metric (bytes for logs/traces, count
+  for metric datapoints) and multiply by the per-unit price from Settings →
+  Billing — ask the user for the price if you don't have it.
 - **For traces**: Call `signoz_list_services` to confirm the service name exists.
   Optionally call `signoz_get_service_top_operations` for the service to find
   operation names. Call `signoz_get_field_keys(signal: "traces")` if you need

--- a/plugins/signoz/skills/signoz-generating-queries/SKILL.md
+++ b/plugins/signoz/skills/signoz-generating-queries/SKILL.md
@@ -51,6 +51,7 @@ Map the user's intent to the right signal:
 | Find specific log entries, error messages, stack traces | **logs** | Text search, pattern matching, severity filtering. |
 | Find specific traces, slow requests, error spans | **traces** | Per-request detail, span attributes, duration filtering. |
 | Infrastructure metrics (CPU, memory, disk, network) | **metrics** | Always metrics for resource utilization. |
+| Ingestion volume (bytes or count), cost, or billing usage | **metrics** with `source=meter` (Cost Meter) | `signoz.meter.*` ingestion metrics (logs/spans/datapoints by count **and** bytes) live only in the meter store; bytes are unavailable on the raw signals. groupBy/filter work like a normal metric, but only over the limited attribute set the meter retains (not arbitrary log/trace fields). For a *count* sliced by an attribute the meter doesn't carry, aggregate logs/traces directly instead. |
 | "How many X per Y" (count/rate grouped by dimension) | **traces** or **logs** (aggregate) | Use `signoz_aggregate_traces` or `signoz_aggregate_logs` for grouped counts. |
 
 If the signal is genuinely ambiguous, ask the user before proceeding. The
@@ -69,6 +70,15 @@ Run discovery calls in parallel where possible:
   matching the user's intent (e.g., `searchText: "http"`, `searchText: "latency"`).
   The response includes metric type, temporality, and isMonotonic — pass these to
   `signoz_query_metrics` to avoid extra lookups.
+- **For Cost Meter** (ingestion volume, cost, billing): pass `source=meter` to
+  `signoz_list_metrics` to discover the metrics (`signoz.meter.*`) — they're
+  invisible in the default store and the set evolves, so don't hardcode it.
+  groupBy/filters/aggregations then work like any metric, with two caveats:
+  *bytes and cost exist only here* (count is also available via direct
+  `signoz_aggregate_logs`/`_traces`), and the meter retains only a *limited
+  attribute set* — discover groupable keys via `signoz_get_field_keys(signal:
+  "metrics", source: "meter")`, and fall back to a direct count (no bytes) to
+  slice by an attribute it lacks.
 - **For traces**: Call `signoz_list_services` to confirm the service name exists.
   Optionally call `signoz_get_service_top_operations` for the service to find
   operation names. Call `signoz_get_field_keys(signal: "traces")` if you need
@@ -112,6 +122,9 @@ from context (e.g., from a dashboard or @mention), skip redundant discovery.
   are ANDed together.
 - For `signoz_query_metrics`, pass `metricType`, `temporality`, and `isMonotonic`
   from the `signoz_list_metrics` response to avoid an extra auto-fetch round trip.
+- For **Cost Meter**, carry `source=meter` on `signoz_query_metrics` too (signal
+  stays `metrics`); meter data is bucketed hourly, so set `stepInterval: 3600`
+  over a window of at least a few hours.
 
 ### Step 5: Handle results
 
@@ -160,7 +173,9 @@ from context (e.g., from a dashboard or @mention), skip redundant discovery.
   `traces`). This signals to the SigNoz UI that the user wants to apply the
   query to an explorer page. Only emit `apply_filter` when the user's primary
   intent is to obtain a runnable query — not when the user is asking a
-  one-shot data question that the analysis text already answers.
+  one-shot data question that the analysis text already answers. For a Cost
+  Meter query keep `signal: metrics` and ensure the resolved `compositeQuery`
+  spec carries `source: meter`.
 
 ## Examples
 
@@ -211,3 +226,15 @@ from context (e.g., from a dashboard or @mention), skip redundant discovery.
 2. Presents: "Error count for frontend over the last 6 hours. Spike at 11:30 UTC
    — error count jumped from ~5/min to ~45/min, returning to baseline by 12:15."
 3. Offers: "Want me to check what error types appeared during the spike?"
+
+---
+
+**User:** "How much log data is each service ingesting?"
+
+**Agent:**
+1. Bytes by service → Cost Meter. `signoz_list_metrics(searchText: "log",
+   source: "meter")` finds `signoz.meter.log.size`.
+2. Calls `signoz_query_metrics(metricName: "signoz.meter.log.size",
+   source: "meter", groupBy: "service.name", stepInterval: 3600, timeRange: "24h")`.
+3. Presents per-service ingestion bytes. (Bytes live only in the meter; to slice
+   by an attribute it lacks, fall back to a direct count.)

--- a/plugins/signoz/skills/signoz-generating-queries/evals/evals.json
+++ b/plugins/signoz/skills/signoz-generating-queries/evals/evals.json
@@ -35,6 +35,13 @@
       "prompt": "My users are reporting the app is slow, can you investigate?",
       "expected_output": "Agent does NOT scatter-shot many queries. Either asks a clarifying question to scope (which service/endpoint/time) OR starts with one focused overview query (e.g., overall p99 latency or error rate by service) and presents findings before drilling.",
       "files": []
+    },
+    {
+      "id": 5,
+      "eval_name": "metrics-cost-meter-ingestion-by-service",
+      "prompt": "How much log data is each service ingesting?",
+      "expected_output": "Agent recognizes ingestion *bytes* live only in the Cost Meter store, so it uses the metrics signal with source=meter. Discovers the metric via signoz_list_metrics with source=meter (e.g. signoz.meter.log.size) rather than assuming a fixed list, then signoz_query_metrics with source=meter, groupBy service.name, stepInterval 3600 (meter buckets hourly). groupBy works like a normal metric here because service is an attribute the meter retains. Does NOT omit source=meter (which would hit the empty default store). Reports per-service ingested bytes over the window. Understands that slicing by an attribute the meter does not retain would fall back to a direct count aggregation (signoz_aggregate_logs) — bytes are only in the meter.",
+      "files": []
     }
   ]
 }

--- a/plugins/signoz/skills/signoz-managing-views/SKILL.md
+++ b/plugins/signoz/skills/signoz-managing-views/SKILL.md
@@ -96,6 +96,8 @@ optional.
    checks and service-name resolution that catch silent 400s before they
    become permanent bad views. Skipping it means a malformed filter becomes
    a saved view that must be deleted and recreated.
+   For a `meter` view, tell `signoz-generating-queries` it's a **Cost Meter**
+   query (`source=meter`) so discovery hits the meter store, not the default one.
 4. **Enforce the signal rule** in every `builder_query` spec.
    - For `traces` / `logs` / `metrics`: `signal == sourcePage`. A
      `sourcePage:"traces"` view with `signal:"logs"` is a server-side error.
@@ -125,7 +127,8 @@ optional.
 6. **Preview before writing — this step is not optional.** Before calling
    `signoz_create_view`, show the user a summary: name, sourcePage,
    panelType, the full filter expression, and the Step 5 probe result
-   ("sample fetch: N rows in last 1h"). For a human in the loop, wait
+   ("sample fetch: N rows in last 1h" — for a `meter` view the probe window
+   is 24h, so report it as such). For a human in the loop, wait
    for confirmation. For an autonomous agent, log the preview and proceed.
 7. Call `signoz_create_view`. The server populates `id`,
    `createdAt/By`, `updatedAt/By` — never send those.
@@ -168,7 +171,9 @@ upstream). Sending a partial body wipes the unspecified fields. The flow:
    `compositeQuery` from the user's description — the same Step 4 signal
    rule applies (including the `meter` case: `signal:"metrics"` +
    `source:"meter"`), and `panelType` changes often imply a `stepInterval`
-   change too. For pure metadata tweaks (rename,
+   change too. For a `meter` view, tell `signoz-generating-queries` it is a
+   **Cost Meter** query (`source=meter`) so it discovers and validates against
+   the meter store. For pure metadata tweaks (rename,
    recategorize), skip this step and do not touch `compositeQuery`.
 4. Modify only the field(s) the user asked to change.
 5. **Mandatory pre-save sample fetch — when `compositeQuery` changed.**
@@ -232,10 +237,11 @@ call.
   tenant, even when emitted by the same service. Lifting an attribute
   from a sibling dashboard panel, alert rule, or view that targets a
   different signal is the most common source of empty saved views.
-  `signoz_get_field_keys signal=<sourcePage>` is necessary but
+  `signoz_get_field_keys signal=<destination signal>` is necessary but
   not sufficient — sparse emission still produces zero-result views.
-  Only the sample fetch confirms. (For a `meter` view, field keys live on
-  `signal=metrics` with `source=meter`, not `signal=meter`.)
+  Only the sample fetch confirms. The destination signal equals `sourcePage`
+  for traces/logs/metrics; for a `meter` view it is `signal=metrics` with
+  `source=meter` (never `signal=meter`).
 
   A saved view returning zero rows under its own filter is a
   permanent artifact in a shared workspace; the human preview can't
@@ -257,7 +263,7 @@ call.
 | Mistake | Fix |
 |---------|-----|
 | Hand-composing `compositeQuery` from examples or memory (even after reading `signoz://view/examples`) | Use the `Skill` tool to invoke `signoz-generating-queries` — reading examples and validating with `signoz_search_traces` is not a substitute |
-| Lifting an attribute name from a metric, alert rule, or sibling view and using it in a `sourcePage=traces` / `=logs` view filter without re-verifying on the destination signal | Field keys are signal-scoped; an attribute on metrics may not exist on traces or logs. Always re-check via `signoz_get_field_keys signal=<sourcePage>` **and** run the mandatory pre-save sample fetch — the key check is necessary but not sufficient |
+| Lifting an attribute name from a metric, alert rule, or sibling view and using it in a `sourcePage=traces` / `=logs` view filter without re-verifying on the destination signal | Field keys are signal-scoped; an attribute on metrics may not exist on traces or logs. Always re-check via `signoz_get_field_keys signal=<destination signal>` (for a `meter` view, `signal=metrics source=meter` — never `signal=meter`) **and** run the mandatory pre-save sample fetch — the key check is necessary but not sufficient |
 | Skipping the pre-save sample fetch because `signoz-generating-queries` already validated the query | The sub-skill validates the query *it* authored; the filter you persist may have been edited or lifted since then. The Step 5 sample fetch is mandatory regardless |
 | Skipping `signoz_get_view` before delete (relying on list UUID alone) | Always call `signoz_get_view` to confirm name+sourcePage before `signoz_delete_view` |
 | Sending legacy fields: `builder`, `promql`, `unit`, top-level `id`, `queryFormulas` | Read schema resources; server returns HTTP 400 silently |

--- a/plugins/signoz/skills/signoz-managing-views/evals/evals.json
+++ b/plugins/signoz/skills/signoz-managing-views/evals/evals.json
@@ -150,12 +150,16 @@
       "id": 5,
       "name": "create-cost-meter-view",
       "prompt": "Save a view that tracks our log ingestion volume from the Cost Meter so I can find it later.",
-      "expected_output": "Agent recognizes this is a Cost Meter view and resolves sourcePage=meter (not metrics). Reads the schema resources, builds a builder_query with signal=metrics and source=meter against a meter metric (e.g. signoz.meter.log.size), sets panelType=graph. Runs the mandatory pre-save sample fetch via signoz:signoz_query_metrics with source=meter, the metricName, timeRange=24h, requestType=scalar. Shows a preview (name, sourcePage=meter, metric/filter, sample-fetch result), confirms, and calls signoz:signoz_create_view. Reports name, UUID, and sourcePage=meter.",
+      "expected_output": "Agent recognizes this is a Cost Meter view and resolves sourcePage=meter (not metrics). Reads the schema resources, then builds the query via signoz-generating-queries told it is a Cost Meter query (source=meter) so discovery hits the meter store and finds a meter metric (e.g. signoz.meter.log.size). The resulting builder_query has signal=metrics and source=meter, panelType=graph. Runs the mandatory pre-save sample fetch via signoz:signoz_query_metrics with source=meter, the metricName, timeRange=24h, requestType=scalar. Shows a preview (name, sourcePage=meter, metric/filter, sample-fetch result), confirms, and calls signoz:signoz_create_view. Reports name, UUID, and sourcePage=meter.",
       "files": [],
       "assertions": [
         {
           "text": "sourcePage is set to 'meter' (not 'metrics')",
           "description": "Cost Meter views file under the distinct 'meter' Explorer page; using 'metrics' mis-files them so they're invisible in the Meter Explorer"
+        },
+        {
+          "text": "Query construction is delegated to signoz-generating-queries with the Cost Meter context (source=meter), so metric discovery hits the meter store rather than the default metrics store",
+          "description": "Create-flow Step 3 mandates signoz-generating-queries; for a meter view the agent must pass the source=meter context so the meter-unaware default discovery path doesn't miss signoz.meter.* metrics"
         },
         {
           "text": "Every builder_query spec has signal='metrics' AND source='meter'",


### PR DESCRIPTION
## What & why

Follow-up to the [PR #47 review comment](https://github.com/SigNoz/agent-skills/pull/47#discussion_r3420554643).

Cost Meter queries run on the **metrics** signal with `source=meter` against a separate store. `signoz-managing-views` makes delegation to `signoz-generating-queries` **mandatory** for query construction (create-flow Step 3), but that sub-skill had **no meter awareness** — its discovery/validation never passed `source=meter`. So for a Cost Meter view it queried the *default* metrics store and the meter metric (e.g. `signoz.meter.log.size`) read as missing. The same gap existed at a second site (update-flow Step 3).

This teaches `signoz-generating-queries` about Cost Meter and routes the meter context through `signoz-managing-views`.

## Changes

**`signoz-generating-queries`**
- Signal table: route ingestion volume / cost / billing → metrics + `source=meter`.
- Discovery: `signoz_list_metrics source=meter` (don't hardcode the evolving set); **bytes/cost live only in the meter, count is also available via direct aggregation**; the meter retains only a **limited attribute set** — discover groupable keys via `signoz_get_field_keys(signal=metrics, source=meter)`.
- Execute: carry `source=meter` on `signoz_query_metrics`, `signal` stays `metrics`, hourly bucketing → `stepInterval=3600`.
- `apply_filter` note + a Cost Meter worked example.
- New eval: `metrics-cost-meter-ingestion-by-service`.

**`signoz-managing-views`**
- Both Step-3 sites (create + update) pass the Cost Meter (`source=meter`) context to the sub-skill.
- Field-keys guidance: `signal=<destination signal>` — for a meter view that's `signal=metrics source=meter`, never `signal=meter`.
- Preview reports the 24h meter probe window.
- Clarifies the scalar pre-save probe is distinct from the view's graph query (an observed conflation point).
- `create-cost-meter-view` eval asserts the meter-aware delegation.

## Validation

Run with **Claude Sonnet** end-to-end against a local `signoz-mcp-server` (with [PR #200](https://github.com/SigNoz/signoz-mcp-server/pull/200), so `sourcePage=meter` is accepted):

| Eval | Result |
|---|---|
| `signoz-generating-queries` — "How much log data is each service ingesting?" | **5/5** — `source=meter` discovery + query, `groupBy service.name`, `stepInterval 3600`; 47 services |
| `signoz-managing-views` — create Cost Meter view | **6/6** — create (`sourcePage=meter`) → `get_view` + `list_views(meter)` round-trip (`signal=metrics`/`source=meter` preserved) → delete cleanup |

The test view was created and deleted, leaving no residue.

## Notes
- Docs/schema unchanged in this repo; the MCP server already supports meter (PR #200 / #186).
- Plugin version intentionally not bumped — handled by the CalVer auto-bump workflow on merge.
