### PR TITLE
fix(skills): teach `searchText` (not `query`) for signoz_search_docs

### DIFF
--- a/plugins/signoz/skills/signoz-searching-docs/SKILL.md
+++ b/plugins/signoz/skills/signoz-searching-docs/SKILL.md
@@ -20,7 +20,7 @@ Prefer the SigNoz MCP server tools when available; fall back to direct HTTP fetc
 
 ### Preferred: MCP tools
 
-- `signoz_search_docs` — BM25 search over the indexed docs corpus. Pass the user's natural-language query as `query`. Narrow with `section_slug` when the question maps cleanly to a single docs section (the tool's own schema lists valid slugs — defer to it rather than memorizing). Trust the ranking — the index handles relevance.
+- `signoz_search_docs` — BM25 search over the indexed docs corpus. Pass the user's natural-language query as `searchText`. Narrow with `section_slug` when the question maps cleanly to a single docs section (the tool's own schema lists valid slugs — defer to it rather than memorizing). Trust the ranking — the index handles relevance.
 - `signoz_fetch_doc` — full markdown for one indexed page. Pass the canonical URL or `/docs/...` path; optionally narrow to a section with `heading`.
 
 ### Fallback: direct HTTP fetch


### PR DESCRIPTION
## What

`signoz-searching-docs` told the agent to pass the user's query as `query`. The `signoz_search_docs` free-text parameter has been renamed **`query` → `searchText`** (canonical name) in [SigNoz/signoz-mcp-server#220](https://github.com/SigNoz/signoz-mcp-server/pull/220). This updates the skill to teach the canonical `searchText`.

```diff
- Pass the user's natural-language query as `query`.
+ Pass the user's natural-language query as `searchText`.
```

## Why this is the only change

`signoz-searching-docs/SKILL.md:23` was the only place that named the parameter. Other references (`signoz-setting-up-observability`, `signoz-mcp-setup`, the workflow step "call `signoz_search_docs` with the user's query") only name the tool or use *query* as plain English for the search text — none teach the param name, so they need no change. `list_metrics`/`search_logs` already use `searchText`/`filter` correctly (unrelated tools).

## ⚠️ Merge ordering — gated on signoz-mcp-server#220

`searchText` only becomes a valid parameter once **#220 merges and ships**. The currently-deployed server reads `query`, so merging this skill change *before* #220 is released would break docs search (the agent would send `searchText`, which today's server ignores → "is required" error).

- **Do not merge until #220 is released.**
- After #220, `query` remains a permanent **silent legacy alias** on the server, so this change is forward-compatible and breaks no existing caller.

Companion PR: SigNoz/signoz-mcp-server#220
