### PR TITLE
fix(skills): align MCP v0.6 contract guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ connected. It accepts a SigNoz Cloud region such as `us`, `us2`, `eu`, `eu2`,
 Plugin updates can reset bundled MCP registration files to the placeholder; if
 that happens, rerun `signoz-mcp-setup`.
 
+The skills are authored against the current SigNoz MCP server contract. If a
+tool call fails because a parameter or schema looks different from what a skill
+describes, update or reconfigure the SigNoz MCP server before changing the
+workflow.
+
 See the full setup guide in the [SigNoz MCP Server docs](https://signoz.io/docs/ai/signoz-mcp-server/).
 
 ### Claude Code

--- a/plugins/signoz/skills/signoz-creating-dashboards/SKILL.md
+++ b/plugins/signoz/skills/signoz-creating-dashboards/SKILL.md
@@ -188,9 +188,9 @@ stated technology. Pick up to ~5 representative signals and check them
   prefix (e.g. `searchText="postgresql"`). Empty result → metric family
   is not being ingested. *Early out:* if this returns empty, declare
   "None present" and skip the rest of the metric probes — they will all
-  return zero. Note: `signoz_list_metrics` has no `timeRange` parameter;
-  pass `start`/`end` (unix-ms strings) only if you need a window other
-  than the server default.
+  return zero. Use `timeRange` for a relative window, or pass
+  `start`/`end` (unix-ms strings) when you need an exact window instead
+  of the server default.
 - **Trace-based templates** (APM-style): call
   `signoz_aggregate_traces` with `aggregation=count`,
   `timeRange=1h`. No filter is needed for the "is anything flowing"

--- a/plugins/signoz/skills/signoz-managing-views/SKILL.md
+++ b/plugins/signoz/skills/signoz-managing-views/SKILL.md
@@ -187,7 +187,7 @@ upstream). Sending a partial body wipes the unspecified fields. The flow:
    prevents silent mistakes and gives the user a chance to catch a wrong
    target view. Wait for confirmation on any change to `compositeQuery`,
    since that changes what the view actually shows.
-7. Call `signoz_update_view` with `{ "viewId": "<id>", "view": <modified data> }`.
+7. Call `signoz_update_view` with `{ "id": "<id>", "view": <modified data> }`.
 
 ### Delete a view
 
@@ -254,7 +254,7 @@ call.
 |-----------|-------------|-----------|
 | Create | read `signoz://view/instructions` + `signoz://view/examples` → `signoz-generating-queries` → **sample fetch on exact filter** → preview → `signoz_create_view` | Mandatory pre-save sample fetch; preview before write; no legacy fields |
 | List | `signoz_list_views` (× 4 if no sourcePage given: traces/logs/metrics/meter) | Check `pagination.hasMore` |
-| Get | `signoz_get_view(viewId)` | Returns canonical body for update |
+| Get | `signoz_get_view(id)` | Returns canonical body for update |
 | Update | `signoz_get_view` → modify → **sample fetch if `compositeQuery` changed** → diff preview → `signoz_update_view` | Full-body replace; sample fetch when compositeQuery changes; diff preview required |
 | Delete | `signoz_list_views` → `signoz_get_view` → confirm → `signoz_delete_view` | Get-before-delete mandatory; fresh confirmation |
 

--- a/plugins/signoz/skills/signoz-mcp-setup/SKILL.md
+++ b/plugins/signoz/skills/signoz-mcp-setup/SKILL.md
@@ -48,6 +48,11 @@ Do not fall back to raw HTTP calls for SigNoz data when MCP is unavailable.
 The MCP server is the supported API surface for this plugin's live SigNoz
 workflows.
 
+The workflow skills assume the current SigNoz MCP server contract. If a
+SigNoz tool reports schema or parameter errors that contradict the skill
+instructions, repair or update the MCP server connection instead of inventing
+alternate raw HTTP calls or teaching legacy parameters.
+
 ### Step 2: Identify the client
 
 Use the client named in `$ARGUMENTS` or the user's latest message. If no


### PR DESCRIPTION
## Summary
- Teach `signoz-managing-views` to call saved-view tools with canonical `id` instead of legacy `viewId`.
- Update `signoz-creating-dashboards` metric probe guidance now that `signoz_list_metrics` supports `timeRange` as well as `start`/`end`.
- Document that the skills expect the current SigNoz MCP server contract, with `signoz-mcp-setup` as the repair/update path when schema or parameter behavior looks stale.

## Why
The latest `SigNoz/signoz-mcp-server` release (`v0.6.0`) standardized resource handle params on `id` and added time-range support to `signoz_list_metrics`. The skills should teach the canonical MCP contract instead of stale legacy guidance, and users/agents should know to update or repair MCP when tool schemas drift.

## Validation
- Ran `git diff --check`.
- Ran targeted stale-reference grep for legacy `viewId` saved-view calls and old `signoz_list_metrics` time-range guidance.
- Verified the new MCP contract expectation appears in `README.md` and `signoz-mcp-setup`.