### PR TITLE
feat(gemini): add self-hosted MCP option to install-time endpoint setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,12 @@ reload Cursor.
 gemini extensions install https://github.com/SigNoz/agent-skills
 ```
 
-When prompted, enter your SigNoz Cloud region (`us`, `us2`, `eu`, `eu2`, `in`, or `in2`).
+When prompted for the **SigNoz MCP endpoint**, enter:
+
+- **SigNoz Cloud:** `https://mcp.<region>.signoz.cloud/mcp` — replace `<region>` with
+  your region (`us`, `us2`, `eu`, `eu2`, `in`, or `in2`). The default is the `us`
+  Cloud endpoint.
+- **Self-hosted SigNoz:** your own `/mcp` URL, for example `http://localhost:8000/mcp`.
 
 Then authenticate:
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -4,19 +4,19 @@
   "description": "Query SigNoz observability data(metrics, traces, logs, alerts, dashboards, services) via the SigNoz Cloud hosted MCP server.",
   "mcpServers": {
     "signoz": {
-      "httpUrl": "https://mcp.${SIGNOZ_REGION}.signoz.cloud/mcp",
+      "httpUrl": "${SIGNOZ_MCP_URL}",
       "timeout": 30000
     }
   },
   "settings": [
     {
-      "name": "SIGNOZ_REGION",
-      "label": "SigNoz Cloud region",
-      "description": "Your SigNoz Cloud region. Find it under Settings → Ingestion in SigNoz, or see https://signoz.io/docs/ingestion/signoz-cloud/overview/#endpoint. Values: us, in, eu, us2, in2, eu2",
-      "envVar": "SIGNOZ_REGION",
+      "name": "SIGNOZ_MCP_URL",
+      "label": "SigNoz MCP endpoint",
+      "description": "SigNoz Cloud: https://mcp.<region>.signoz.cloud/mcp (regions: us, in, eu, us2, in2, eu2; find yours under Settings → Ingestion, or see https://signoz.io/docs/ingestion/signoz-cloud/overview/#endpoint). Self-hosted SigNoz: your own /mcp URL, e.g. http://localhost:8000/mcp",
+      "envVar": "SIGNOZ_MCP_URL",
       "sensitive": false,
       "required": true,
-      "default": "us"
+      "default": "https://mcp.us.signoz.cloud/mcp"
     }
   ]
 }


### PR DESCRIPTION
## What

Adds a self-hosted MCP option to the Gemini CLI extension, mirroring the self-hosted support already in the Claude and Cursor plugins (#50).

The manifest previously modeled **Cloud only** — it hardcoded the Cloud URL shape and substituted a region into it:

```json
"httpUrl": "https://mcp.${SIGNOZ_REGION}.signoz.cloud/mcp"
```

Self-hosted endpoints (e.g. `http://localhost:8000/mcp`) are a *different URL structure*, not just a different region, so `${SIGNOZ_REGION}` substitution can't reach them.

## How

Gemini's manifest does plain string substitution with **no conditionals**, so a single full-URL field is the cleanest way to support both Cloud and self-hosted from one install-time prompt:

- `httpUrl` is now `${SIGNOZ_MCP_URL}`.
- The `SIGNOZ_REGION` setting is replaced by a required `SIGNOZ_MCP_URL` setting, defaulting to `https://mcp.us.signoz.cloud/mcp`.
- The setting description documents both the Cloud `https://mcp.<region>.signoz.cloud/mcp` shape and the self-hosted `/mcp` URL shape.
- README Gemini CLI section updated to match.

## Trade-off

Cloud users on a non-`us` region now edit the URL rather than typing just a region code — the deliberate cost of a single-field approach that handles both cases without conditionals.

## Testing

- `python3 -m json.tool gemini-extension.json` — valid JSON.
- Linked locally via `gemini extensions link .`, verified the install prompt asks for **SigNoz MCP endpoint** and both Cloud (default) and self-hosted (`http://localhost:8000/mcp`) values connect via `/mcp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)