### PR TITLE
feat(devin): add Devin CLI plugin port

### DIFF
--- a/.devin-plugin/plugin.json
+++ b/.devin-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "signoz",
-  "version": "2026.7.1",
+  "version": "2026.7.100",
   "description": "Official SigNoz plugin for MCP setup, docs, queries, dashboards, and alerts",
   "author": {
     "name": "SigNoz"

--- a/.devin-plugin/plugin.json
+++ b/.devin-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "signoz",
+  "version": "2026.7.1",
+  "description": "Official SigNoz plugin for MCP setup, docs, queries, dashboards, and alerts",
+  "author": {
+    "name": "SigNoz"
+  },
+  "homepage": "https://signoz.io",
+  "repository": "https://github.com/SigNoz/agent-skills",
+  "license": "MIT",
+  "keywords": [
+    "signoz",
+    "opentelemetry",
+    "observability",
+    "mcp",
+    "clickhouse",
+    "tracing",
+    "logging"
+  ]
+}

--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -114,16 +114,43 @@ jobs:
             COUNT=$((COUNT + 1))
             echo "Bumped $PLUGIN_NAME: $CURRENT -> $NEW"
 
-            # The root Gemini CLI extension manifest mirrors the signoz
-            # plugin, so keep its version in lockstep with the same bump.
-            if [[ "$PLUGIN_NAME" == "signoz" && -f "gemini-extension.json" ]]; then
-              if ! jq --arg v "$NEW" '.version = $v' "gemini-extension.json" > "gemini-extension.json.tmp"; then
-                echo "ERROR: jq failed on gemini-extension.json"
-                rm -f "gemini-extension.json.tmp"
-                exit 1
+            # The root Gemini CLI extension manifest and Devin CLI plugin
+            # manifest mirror the signoz plugin, so keep their versions in
+            # lockstep with the same bump.
+            if [[ "$PLUGIN_NAME" == "signoz" ]]; then
+              if [[ -f "gemini-extension.json" ]]; then
+                if ! jq --arg v "$NEW" '.version = $v' "gemini-extension.json" > "gemini-extension.json.tmp"; then
+                  echo "ERROR: jq failed on gemini-extension.json"
+                  rm -f "gemini-extension.json.tmp"
+                  exit 1
+                fi
+                mv "gemini-extension.json.tmp" "gemini-extension.json"
+                echo "Bumped gemini-extension.json -> $NEW (lockstep with signoz)"
               fi
-              mv "gemini-extension.json.tmp" "gemini-extension.json"
-              echo "Bumped gemini-extension.json -> $NEW (lockstep with signoz)"
+
+              if [[ -f ".devin-plugin/plugin.json" ]]; then
+                # Devin's plugin loader enforces strict semver, which forbids
+                # leading zeros in numeric identifiers — CalVer's MM/DD segments
+                # have one whenever the month or day is under 10. Strip them
+                # (base-10 forced via `10#` so bash doesn't misread "08"/"09" as
+                # invalid octal) and fold any same-day micro suffix into build
+                # metadata instead of a fourth dot segment, e.g.:
+                #   2026.07.02   -> 2026.7.2
+                #   2026.07.02.1 -> 2026.7.2+1
+                IFS='.' read -ra VER_PARTS <<< "$NEW"
+                DEVIN_VERSION="${VER_PARTS[0]}.$((10#${VER_PARTS[1]})).$((10#${VER_PARTS[2]}))"
+                if [[ -n "${VER_PARTS[3]:-}" ]]; then
+                  DEVIN_VERSION="${DEVIN_VERSION}+${VER_PARTS[3]}"
+                fi
+
+                if ! jq --arg v "$DEVIN_VERSION" '.version = $v' ".devin-plugin/plugin.json" > ".devin-plugin/plugin.json.tmp"; then
+                  echo "ERROR: jq failed on .devin-plugin/plugin.json"
+                  rm -f ".devin-plugin/plugin.json.tmp"
+                  exit 1
+                fi
+                mv ".devin-plugin/plugin.json.tmp" ".devin-plugin/plugin.json"
+                echo "Bumped .devin-plugin/plugin.json -> $DEVIN_VERSION (semver form of $NEW, lockstep with signoz)"
+              fi
             fi
           done
 
@@ -142,7 +169,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add plugins/**/.claude-plugin/plugin.json plugins/**/.codex-plugin/plugin.json plugins/**/.cursor-plugin/plugin.json gemini-extension.json
+          git add plugins/**/.claude-plugin/plugin.json plugins/**/.codex-plugin/plugin.json plugins/**/.cursor-plugin/plugin.json gemini-extension.json .devin-plugin/plugin.json
           git commit -m "chore: auto-bump CalVer for ${{ steps.bump.outputs.count }} plugin(s)"
           git pull --rebase origin main || { git rebase --abort 2>/dev/null; echo "ERROR: rebase failed"; exit 1; }
           git push

--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -131,17 +131,24 @@ jobs:
               if [[ -f ".devin-plugin/plugin.json" ]]; then
                 # Devin's plugin loader enforces strict semver, which forbids
                 # leading zeros in numeric identifiers — CalVer's MM/DD segments
-                # have one whenever the month or day is under 10. Strip them
-                # (base-10 forced via `10#` so bash doesn't misread "08"/"09" as
-                # invalid octal) and fold any same-day micro suffix into build
-                # metadata instead of a fourth dot segment, e.g.:
-                #   2026.07.02   -> 2026.7.2
-                #   2026.07.02.1 -> 2026.7.2+1
+                # have one whenever the month or day is under 10 (base-10 forced
+                # via `10#` so bash doesn't misread "08"/"09" as invalid octal).
+                # Fold the day and any same-day micro suffix into the patch
+                # number itself (day*100 + micro) rather than build metadata:
+                # semver explicitly excludes build metadata (+x) from precedence
+                # comparisons, so a same-day micro bump encoded that way would
+                # compare equal to the base version and a strict-semver update
+                # path could skip it. Encoding it in patch keeps same-day bumps
+                # strictly increasing, e.g.:
+                #   2026.07.02   -> 2026.7.200
+                #   2026.07.02.1 -> 2026.7.201
+                #   2026.07.02.2 -> 2026.7.202
                 IFS='.' read -ra VER_PARTS <<< "$NEW"
-                DEVIN_VERSION="${VER_PARTS[0]}.$((10#${VER_PARTS[1]})).$((10#${VER_PARTS[2]}))"
-                if [[ -n "${VER_PARTS[3]:-}" ]]; then
-                  DEVIN_VERSION="${DEVIN_VERSION}+${VER_PARTS[3]}"
-                fi
+                DEVIN_DAY=$((10#${VER_PARTS[2]}))
+                DEVIN_MICRO="${VER_PARTS[3]:-0}"
+                DEVIN_MICRO=$((10#$DEVIN_MICRO))
+                DEVIN_PATCH=$((DEVIN_DAY * 100 + DEVIN_MICRO))
+                DEVIN_VERSION="${VER_PARTS[0]}.$((10#${VER_PARTS[1]})).${DEVIN_PATCH}"
 
                 if ! jq --arg v "$DEVIN_VERSION" '.version = $v' ".devin-plugin/plugin.json" > ".devin-plugin/plugin.json.tmp"; then
                   echo "ERROR: jq failed on .devin-plugin/plugin.json"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ Users of Claude Code, Codex, and Cursor receive updates based on these versions.
 
 ### Auto-bump workflow
 
-A GitHub Actions workflow (`.github/workflows/auto-version-bump.yml`) automatically bumps all three manifests on push to `main`. It detects which plugins have changed files and sets the version to today's date (or appends a micro suffix for multiple bumps in the same day).
+A GitHub Actions workflow (`.github/workflows/auto-version-bump.yml`) automatically bumps all three manifests on push to `main`. It detects which plugins have changed files and sets the version to today's date (or appends a micro suffix for multiple bumps in the same day). The root `gemini-extension.json` and `.devin-plugin/plugin.json` manifests mirror the `signoz` plugin and are bumped in lockstep with it.
 
 **You do not need to manually bump versions** — the workflow handles it when your PR is merged to `main`.
 

--- a/README.md
+++ b/README.md
@@ -170,10 +170,11 @@ devin plugins install SigNoz/agent-skills
 
 This installs at user level and works across all projects. Devin's plugin
 system does not support bundled MCP servers or install-time config prompts, so
-run `signoz-mcp-setup` in a Devin session afterward with your SigNoz Cloud
+run `/signoz:signoz-mcp-setup` (Devin namespaces plugin skills as
+`/<plugin>:<skill>`) in a Devin session afterward with your SigNoz Cloud
 region (`us`, `us2`, `eu`, `eu2`, `in`, `in2`) or a self-hosted HTTP MCP URL.
-This writes a `signoz` entry into `.devin/config.json` (or
-`.devin/config.local.json` for a personal/self-hosted endpoint).
+This writes a `signoz` entry into the highest-precedence Devin config scope
+that already has one, or `~/.config/devin/config.json` by default.
 
 For SigNoz Cloud, start a new session and run `devin mcp login signoz` to
 complete OAuth. For self-hosted SigNoz, no OAuth step is needed unless the

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # SigNoz Agent Skills
 
 Official SigNoz skills and MCP configuration for Claude Code, Codex, Cursor,
-Gemini CLI, and the [skills.sh](https://skills.sh) ecosystem. The MCP setup skill also
+Gemini CLI, Devin CLI, and the [skills.sh](https://skills.sh) ecosystem. The MCP setup skill also
 includes client-specific recipes for VS Code/GitHub Copilot, Claude Desktop,
-Gemini CLI, Windsurf, Zed, Antigravity, OpenCode, and generic HTTP MCP
-clients.
+Gemini CLI, Devin CLI, Windsurf, Zed, Antigravity, OpenCode, and generic HTTP
+MCP clients.
 
 ## Skills
 
 | Skill | Description |
 |-------|-------------|
-| [signoz-mcp-setup](plugins/signoz/skills/signoz-mcp-setup/SKILL.md) | Initialize or repair the SigNoz MCP server configuration for Claude Code, Codex, Cursor, VS Code/GitHub Copilot, Claude Desktop, Gemini CLI, Windsurf, Zed, Antigravity, OpenCode, or another MCP client. |
+| [signoz-mcp-setup](plugins/signoz/skills/signoz-mcp-setup/SKILL.md) | Initialize or repair the SigNoz MCP server configuration for Claude Code, Codex, Cursor, VS Code/GitHub Copilot, Claude Desktop, Gemini CLI, Devin CLI, Windsurf, Zed, Antigravity, OpenCode, or another MCP client. |
 | [signoz-creating-alerts](plugins/signoz/skills/signoz-creating-alerts/SKILL.md) | Create SigNoz alert rules for threshold breaches, error rates, latency, anomaly detection, and absent-data conditions across metrics, logs, and traces. |
 | [signoz-explaining-alerts](plugins/signoz/skills/signoz-explaining-alerts/SKILL.md) | Explain and interpret an existing SigNoz alert rule's configuration, evaluation behavior, notification routing, and recent fire frequency. |
 | [signoz-investigating-alerts](plugins/signoz/skills/signoz-investigating-alerts/SKILL.md) | Diagnose why a SigNoz alert fired by correlating its signal with neighbor metrics, traces, and logs around the fire window, and ranking likely causes. |
@@ -33,6 +33,10 @@ such as `us`, `us2`, `eu`, `eu2`, `in`, or `in2`, any hosted MCP URL, or a
 self-hosted HTTP `/mcp` endpoint. Plugin updates can reset bundled MCP
 registration files to the placeholder; if that happens, rerun
 `signoz-mcp-setup`.
+
+The Devin CLI plugin ships skills only — Devin's plugin system does not bundle
+MCP servers or prompt for install-time config. Run `signoz-mcp-setup` after
+installing to write the `signoz` MCP server into `.devin/config.json`.
 
 The skills are authored against the current SigNoz MCP server contract. If a
 tool call fails because a parameter or schema looks different from what a skill
@@ -158,13 +162,30 @@ Then authenticate:
 
 Follow the prompts to enter your SigNoz instance URL and API key.
 
+### Devin CLI
+
+```sh
+devin plugins install SigNoz/agent-skills
+```
+
+This installs at user level and works across all projects. Devin's plugin
+system does not support bundled MCP servers or install-time config prompts, so
+run `signoz-mcp-setup` in a Devin session afterward with your SigNoz Cloud
+region (`us`, `us2`, `eu`, `eu2`, `in`, `in2`) or a self-hosted HTTP MCP URL.
+This writes a `signoz` entry into `.devin/config.json` (or
+`.devin/config.local.json` for a personal/self-hosted endpoint).
+
+For SigNoz Cloud, start a new session and run `devin mcp login signoz` to
+complete OAuth. For self-hosted SigNoz, no OAuth step is needed unless the
+server runs with `OAUTH_ENABLED=true`.
+
 ### Other MCP Clients
 
 The setup skill includes native config recipes for VS Code/GitHub Copilot,
-Claude Desktop, Gemini CLI, Windsurf, Zed, Antigravity, OpenCode, and generic
-HTTP MCP clients. These clients do not all consume this plugin automatically;
-install or copy the skill where your client supports skills, or use the
-client-specific setup snippets in the skill as a reference.
+Claude Desktop, Gemini CLI, Devin CLI, Windsurf, Zed, Antigravity, OpenCode,
+and generic HTTP MCP clients. These clients do not all consume this plugin
+automatically; install or copy the skill where your client supports skills, or
+use the client-specific setup snippets in the skill as a reference.
 
 For SigNoz Cloud, prefer the hosted MCP URL and client OAuth flow. For
 self-hosted SigNoz, the skill supports HTTP `/mcp` endpoints and stdio
@@ -185,8 +206,9 @@ npx skills add SigNoz/agent-skills --skill signoz-writing-clickhouse-queries    
 ├── .agents/plugins/marketplace.json        # Codex marketplace
 ├── .claude-plugin/marketplace.json         # Claude Code marketplace
 ├── .cursor-plugin/marketplace.json         # Cursor marketplace
+├── .devin-plugin/plugin.json               # Devin CLI plugin manifest
 ├── gemini-extension.json                   # Gemini CLI extension manifest
-├── skills -> plugins/signoz/skills         # Gemini CLI skills (symlink)
+├── skills -> plugins/signoz/skills         # Gemini CLI & Devin CLI skills (symlink)
 ├── plugins/signoz/
 │   ├── .codex-plugin/plugin.json           # Codex plugin manifest
 │   ├── .claude-plugin/plugin.json          # Claude Code plugin manifest

--- a/plugins/signoz/skills/signoz-mcp-setup/SKILL.md
+++ b/plugins/signoz/skills/signoz-mcp-setup/SKILL.md
@@ -2,8 +2,8 @@
 name: signoz-mcp-setup
 description: >
   Initialize or repair SigNoz MCP server configuration for Claude Code, Codex,
-  Cursor, VS Code/GitHub Copilot, Claude Desktop, Gemini CLI, Windsurf, Zed,
-  Antigravity, OpenCode, or another MCP client. Use this skill before any
+  Cursor, VS Code/GitHub Copilot, Claude Desktop, Gemini CLI, Devin CLI,
+  Windsurf, Zed, Antigravity, OpenCode, or another MCP client. Use this skill before any
   SigNoz docs, query, dashboard, alert, or view workflow when
   `signoz_*` tools are unavailable, or when the user says "setup SigNoz
   MCP", "configure SigNoz plugin", "wrong region", "change SigNoz region",
@@ -32,14 +32,49 @@ stdio/local-binary setup is requested.
 
 ## Configuration procedure
 
-### Step 1: Check state
+### Step 1: Identify the client
 
-Silently determine the SigNoz MCP server state using the reference flow:
+Determine this before checking state — it decides where state is allowed to be
+checked from.
+
+Use the client named in `$ARGUMENTS` or the user's latest message. If no
+client is named, infer it only when the active environment is obvious (which
+agent CLI or editor is running this skill, not just what files happen to exist
+on disk):
+
+- Claude Code, Codex, or Cursor plugin install: use the bundled plugin
+  registration files.
+- VS Code / GitHub Copilot, Claude Desktop, Gemini CLI, Devin CLI, Windsurf,
+  Zed, Antigravity, or OpenCode: use the matching native client recipe in
+  `client-configs.md`.
+- Unknown or unsupported client: use the generic HTTP MCP recipe and point the
+  user to the SigNoz MCP Server docs for their client's exact config surface.
+
+If you need to edit a native client config and the client is still ambiguous,
+ask which client they want to configure.
+
+### Step 2: Check state
+
+Silently determine the SigNoz MCP server state using the reference flow,
+**scoped to the client identified in Step 1**:
+
+- For a Claude Code, Codex, or Cursor bundled plugin install, the reference
+  flow's registration-file fallback applies.
+- For every other client — including Devin CLI — do not read or search for
+  `.signoz_claude_mcp.json`, `.mcp.json`, or `.signoz_cursor_mcp.json`. Those
+  are bundled files for a different client's plugin distribution and are
+  irrelevant here even if a file-search tool happens to find them (for
+  example when this skill is linked from a local checkout of the
+  `agent-skills` source repo itself, which ships all three files side by
+  side). Check that client's own native config location instead, per
+  `client-configs.md`.
+
+State outcomes:
 
 - **working** — continue with the user's original SigNoz request.
-- **not-setup** — run Step 2.
+- **not-setup** — run Step 3.
 - **configured-but-not-working** — if the user provided a new region or MCP URL,
-  run Step 2. Otherwise tell them the SigNoz MCP server is configured but not
+  run Step 3. Otherwise tell them the SigNoz MCP server is configured but not
   connected, then ask for the SigNoz Cloud region or MCP URL to repair it. If
   they believe the endpoint is already correct, tell them to complete the
   client authentication step in Step 5.
@@ -52,22 +87,6 @@ The workflow skills assume the current SigNoz MCP server contract. If a
 SigNoz tool reports schema or parameter errors that contradict the skill
 instructions, repair or update the MCP server connection instead of inventing
 alternate raw HTTP calls or teaching legacy parameters.
-
-### Step 2: Identify the client
-
-Use the client named in `$ARGUMENTS` or the user's latest message. If no
-client is named, infer it only when the active environment is obvious:
-
-- Claude Code, Codex, or Cursor plugin install: use the bundled plugin
-  registration files.
-- VS Code / GitHub Copilot, Claude Desktop, Gemini CLI, Windsurf, Zed,
-  Antigravity, or OpenCode: use the matching native client recipe in
-  `client-configs.md`.
-- Unknown or unsupported client: use the generic HTTP MCP recipe and point the
-  user to the SigNoz MCP Server docs for their client's exact config surface.
-
-If you need to edit a native client config and the client is still ambiguous,
-ask which client they want to configure.
 
 ### Step 3: Resolve the endpoint
 
@@ -172,6 +191,9 @@ client-specific authentication step:
 - **Claude Desktop** — restart Claude Desktop or reconnect the custom
   connector, then complete authentication when prompted.
 - **Gemini CLI** — restart Gemini CLI if needed, then run `/mcp auth signoz`.
+- **Devin CLI** — start a new session so the updated `.devin/config.json` is
+  picked up. For SigNoz Cloud, run `devin mcp login signoz` to complete OAuth.
+  For a self-hosted or header-based endpoint, no OAuth step is expected.
 - **Windsurf** — reload Windsurf and complete authentication when prompted.
 - **Zed** — reload Zed after config changes; self-hosted stdio mode reads the
   configured environment from the context server entry.

--- a/plugins/signoz/skills/signoz-mcp-setup/references/client-configs.md
+++ b/plugins/signoz/skills/signoz-mcp-setup/references/client-configs.md
@@ -27,8 +27,22 @@ SigNoz MCP Server docs and adds OpenCode's native config shape.
   servers. Update only the existing SigNoz server entry, and do not rename its
   key.
 - If the client supports both project and user/global config, prefer the scope
-  the user requested. If they did not choose, prefer user/global for secrets
-  and project scope for non-secret hosted MCP URLs.
+  the user requested. If they did not choose:
+  1. **Check every scope the client supports for an existing `signoz` (or
+     equivalently-purposed) entry first.** If one exists anywhere, edit that
+     same file in place — do not pick a different scope for the new value.
+     This matters most for CLI clients like Devin CLI, Codex, and Claude Code
+     that support multiple config layers (user/global, project, project-local):
+     re-deriving the scope from scratch on every repair can silently create a
+     second, shadowing or shadowed entry in a different file, or make the
+     skill go looking for a project file in whatever directory the current
+     session happens to be in — even an unrelated project that has nothing to
+     do with the endpoint being configured.
+  2. Only when no existing entry is found in any scope, choose a scope: prefer
+     user/global for secrets and for CLI tools in general (they are
+     typically configured per developer machine, not per project), and
+     project scope only when the user asks for a team-shared, project-committed
+     value.
 
 ## Cloud or Self-Hosted HTTP
 
@@ -176,6 +190,34 @@ Or edit `~/.gemini/settings.json`:
 }
 ```
 
+### Devin CLI
+
+Check these three files, in this order, for an existing `signoz` entry before
+picking where to write the new one — edit whichever one already has it:
+
+1. `~/.config/devin/config.json` (`%APPDATA%\devin\config.json` on Windows) —
+   user/global, applies to every project.
+2. `.devin/config.json` in the current project root — team-shared, committed.
+3. `.devin/config.local.json` in the current project root — gitignored,
+   project-local.
+
+If none has a `signoz` entry yet, default to user/global
+(`~/.config/devin/config.json`): Devin CLI is a personal developer tool, so a
+per-machine endpoint is the sane default. Only use `.devin/config.json`
+instead when the user explicitly asks for a team-shared, project-committed
+value, and only use `.devin/config.local.json` when the user is in a specific
+project and wants a project-local (not machine-global) override.
+
+```json
+{
+  "mcpServers": {
+    "signoz": {
+      "url": "https://mcp.us.signoz.cloud/mcp"
+    }
+  }
+}
+```
+
 ### Windsurf
 
 Edit `~/.codeium/windsurf/mcp_config.json`.
@@ -271,8 +313,10 @@ Avoid storing real API keys in tracked project files.
 
 ### JSON clients using `mcpServers`
 
-Cursor, Claude Desktop, Windsurf, Gemini CLI, and Antigravity can use this
-basic stdio shape, with client-specific file locations from the HTTP section.
+Cursor, Claude Desktop, Windsurf, Gemini CLI, Devin CLI, and Antigravity can
+use this basic stdio shape, with client-specific file locations from the HTTP
+section. For Devin CLI, prefer `.devin/config.local.json` and its
+`${env:VAR_NAME}` interpolation syntax over literal secrets.
 
 ```json
 {
@@ -399,6 +443,10 @@ Edit `opencode.json` or `opencode.jsonc`.
   `OAUTH_ENABLED=true`; skip `codex mcp login` and verify the already-authenticated
   `signoz` server with `/mcp`.
 - Gemini CLI: run `/mcp auth signoz`.
+- Devin CLI (SigNoz Cloud): start a new session, then run
+  `devin mcp login signoz` to complete OAuth.
+- Devin CLI (self-hosted or header-based): start a new session; no OAuth step
+  is expected.
 - Windsurf: reload and complete authentication when prompted.
 - Zed: reload after stdio config changes.
 - Antigravity: reload the agent window and complete OAuth. If auth is stuck,

--- a/plugins/signoz/skills/signoz-mcp-setup/references/client-configs.md
+++ b/plugins/signoz/skills/signoz-mcp-setup/references/client-configs.md
@@ -192,16 +192,26 @@ Or edit `~/.gemini/settings.json`:
 
 ### Devin CLI
 
-Check these three files, in this order, for an existing `signoz` entry before
-picking where to write the new one — edit whichever one already has it:
+Devin merges MCP servers by name across scopes, with later-checked scopes
+overriding earlier ones: user/global is overridden by project, which is
+overridden by project-local. Check these three files in **precedence
+order — highest first** — for an existing `signoz` entry, since that is the
+one actually in effect:
 
-1. `~/.config/devin/config.json` (`%APPDATA%\devin\config.json` on Windows) —
-   user/global, applies to every project.
+1. `.devin/config.local.json` in the current project root — gitignored,
+   project-local. Highest precedence.
 2. `.devin/config.json` in the current project root — team-shared, committed.
-3. `.devin/config.local.json` in the current project root — gitignored,
-   project-local.
+3. `~/.config/devin/config.json` (`%APPDATA%\devin\config.json` on Windows) —
+   user/global, applies to every project. Lowest precedence.
 
-If none has a `signoz` entry yet, default to user/global
+Edit the **first (highest-precedence) file that already has a `signoz`
+entry** — editing a lower-precedence file while a higher one still defines
+`signoz` would be silently shadowed and the active endpoint would not change.
+If more than one scope defines `signoz`, tell the user which scope is
+currently winning and ask whether to update that one or remove the
+override so a lower scope takes effect instead.
+
+If no scope has a `signoz` entry yet, default to user/global
 (`~/.config/devin/config.json`): Devin CLI is a personal developer tool, so a
 per-machine endpoint is the sane default. Only use `.devin/config.json`
 instead when the user explicitly asks for a team-shared, project-committed

--- a/plugins/signoz/skills/signoz-mcp-setup/references/mcp-settings.md
+++ b/plugins/signoz/skills/signoz-mcp-setup/references/mcp-settings.md
@@ -17,15 +17,27 @@ Antigravity, or OpenCode, read
 
 ## State Check
 
-Silently determine `signoz-server-state`:
+Silently determine `signoz-server-state`, **only after the client is known**
+(see `SKILL.md` Step 1 — identify the client before checking state):
 
 1. If `signoz_*` MCP tools are available, try a lightweight read-only
    call such as `signoz_search_docs` for `mcp setup` or
    `signoz_list_services` with a small lookback.
 2. If the call returns SigNoz-specific content, state is **working**.
-3. If the call fails, returns no tools, or only generic/empty content, read the
-   plugin registration files below.
-4. If any registration file contains `not-setup`, state is **not-setup**.
+3. If the call fails, returns no tools, or only generic/empty content:
+   - **Claude Code, Codex, or Cursor bundled plugin install** — read the
+     plugin registration files below.
+   - **Any other client** — do not read or file-search for the bundled
+     registration files below. They belong to a different client's plugin
+     distribution and can exist on disk for unrelated reasons — most
+     notably, if this skill is running from a local checkout of the
+     `agent-skills` source repo itself (e.g. a Devin CLI local-path plugin
+     install), the bundled files genuinely exist a few directories up
+     because that's where the *source* repo keeps them, not because they
+     configure the current client. Check that client's own native config
+     location from `client-configs.md` instead.
+4. If any registration file consulted in step 3 contains `not-setup`, state is
+   **not-setup**.
 5. Otherwise state is **configured-but-not-working**.
 
 Do not tell the user which checks ran or what file contents were found. Explain
@@ -33,21 +45,28 @@ only the plain outcome: working, not set up, or configured but not connected.
 
 ## Registration Files
 
-The SigNoz plugin may ship these bundled registration files in the plugin root:
+These bundled registration files exist only for the Claude Code, Codex, and
+Cursor plugin installs — never read or edit them for any other client, even if
+a file search finds them:
 
 - `.signoz_claude_mcp.json` for Claude Code
 - `.mcp.json` for Codex
 - `.signoz_cursor_mcp.json` for Cursor
 
 This reference file lives at `skills/signoz-mcp-setup/references/mcp-settings.md`,
-so the plugin root is two directories up from `skills/signoz-mcp-setup/`.
+so the plugin root is two directories up from `skills/signoz-mcp-setup/`. That
+relative path also happens to resolve inside the `agent-skills` source repo
+itself (this plugin's own monorepo), which ships all three files side by side
+for their respective bundled installs — resolving to a real file there does
+not mean it is the active client's configuration.
 
-Update every registration file that exists. Replace only the `url` value and
-preserve each file's existing server key and `type`: the Claude Code file
-(`.signoz_claude_mcp.json`) ships the server key `mcp`, while the Codex and
-Cursor files ship `signoz`. Do not create duplicate MCP server entries, and do
-not rename the existing server — renaming the Claude Code key changes the tool
-namespace (`plugin:signoz:mcp`) and forces re-authentication.
+Update every registration file that exists **for the identified client only**.
+Replace only the `url` value and preserve each file's existing server key and
+`type`: the Claude Code file (`.signoz_claude_mcp.json`) ships the server key
+`mcp`, while the Codex and Cursor files ship `signoz`. Do not create duplicate
+MCP server entries, and do not rename the existing server — renaming the
+Claude Code key changes the tool namespace (`plugin:signoz:mcp`) and forces
+re-authentication.
 
 ## Editing Rules
 


### PR DESCRIPTION
## Summary
- Ships the SigNoz skills to Devin CLI via `.devin-plugin/plugin.json`, reusing the existing root `skills/` symlink (Devin auto-discovers a sibling `skills/` dir; no per-skill changes needed since `name`/`description`/`argument-hint` frontmatter is already Devin-compatible).
- Devin's plugin manifest has no documented support for bundling MCP servers or install-time config prompts (unlike the Claude/Codex/Cursor/Gemini ports), so `signoz-mcp-setup` gains a Devin recipe that writes the `signoz` MCP entry directly into Devin's own config (`~/.config/devin/config.json`, `.devin/config.json`, or `.devin/config.local.json`).
- `auto-version-bump.yml` keeps `.devin-plugin/plugin.json`'s version in lockstep with the `signoz` plugin's CalVer, transformed to strict semver (Devin's plugin loader rejects CalVer's leading zeros, e.g. `2026.07.02` → `2026.7.2`, with same-day micro bumps folded into build metadata: `2026.07.02.1` → `2026.7.2+1`).

## Bug fixes (found by dogfooding the port end-to-end in Devin CLI)
- **State check ran before client identification.** `signoz-mcp-setup`'s state check had an unconditional bundled-registration-file fallback that didn't know which client was active. When Devin CLI was locally linked into this source repo, the fallback's relative-path lookup resolved to the real (but irrelevant) Claude/Codex/Cursor bundled files shipped alongside it, and the skill tried to edit those instead of Devin's own config. Fixed by making "identify the client" the first step and gating the bundled-file check to only the Claude Code/Codex/Cursor bundled installs.
- **Scope selection ignored existing config.** For multi-scope CLI clients (Devin, Codex, Claude Code), the skill picked user/global-vs-project scope from a secret/non-secret heuristic on every repair, with no check for where a working `signoz` entry already lived. Repeat setup runs (e.g. switching SigNoz Cloud regions) could pick a different scope than the first run, writing a second, disconnected entry in an unrelated file/directory instead of updating the existing one. Fixed by requiring an existing-entry check across all supported scopes before falling back to the heuristic.

## Test plan
- [x] Installed the plugin locally in Devin CLI (`devin plugins install <local path>`) and confirmed skills load (`devin plugins list` / `devin plugins info signoz`)
- [x] Ran `/signoz-mcp-setup` end-to-end for both a self-hosted (`localhost`) and SigNoz Cloud (`in2`) endpoint, confirmed `signoz_*` tools become available and scope selection now reuses the existing config entry
- [x] Validated `.devin-plugin/plugin.json` and the auto-bump workflow's semver transform for several sample CalVer inputs (leading month/day, with and without a micro suffix)