### PR TITLE
fix(signoz-generating-queries): require verbatim execute_builder_query payload for apply_filter

### DIFF
--- a/plugins/signoz/skills/signoz-generating-queries/SKILL.md
+++ b/plugins/signoz/skills/signoz-generating-queries/SKILL.md
@@ -172,14 +172,21 @@ from context (e.g., from a dashboard or @mention), skip redundant discovery.
   query into a recurring alert, redirect to `signoz-creating-alerts`.
 - **Emit `apply_filter` on the final message.** When the user asks you to
   write, build, generate, or show a query, include an `apply_filter` action
-  on your final assistant message with the resolved `compositeQuery` from
-  the tool result and the appropriate `signal` field (`metrics`, `logs`, or
-  `traces`). This signals to the SigNoz UI that the user wants to apply the
-  query to an explorer page. Only emit `apply_filter` when the user's primary
-  intent is to obtain a runnable query — not when the user is asking a
-  one-shot data question that the analysis text already answers. For a Cost
-  Meter query keep `signal: metrics` and ensure the resolved `compositeQuery`
-  spec carries `source: meter`.
+  on your final assistant message with the exact full v5 `query` object you
+  passed to a successful `signoz_execute_builder_query` call in this turn. The
+  chip carries the entire query-range envelope (`schemaVersion`, `start`,
+  `end`, `requestType`, `compositeQuery`), not just the inner
+  `compositeQuery`, and you must copy it verbatim rather than reconstructing
+  it. If you answered via simplified tools (`signoz_search_logs`,
+  `signoz_search_traces`, `signoz_aggregate_*`, `signoz_query_metrics`), run
+  one validating `signoz_execute_builder_query` with a small `limit` and copy
+  that exact query object, or skip the chip. Use the appropriate `signal`
+  field (`metrics`, `logs`, or `traces`). This signals to the SigNoz UI that
+  the user wants to apply the query to an explorer page. Only emit
+  `apply_filter` when the user's primary intent is to obtain a runnable query
+  — not when the user is asking a one-shot data question that the analysis text
+  already answers. For a Cost Meter query keep `signal: metrics` and ensure the
+  copied query spec carries `source: meter`.
 
 ## Examples
 


### PR DESCRIPTION
## Problem

The skill instructed the agent to emit `apply_filter` chips "with the resolved `compositeQuery` from the tool result" — but the simplified tools (`signoz_search_*`, `signoz_aggregate_*`, `signoz_query_metrics`) do not return a resolved query. An agent following the skill faithfully has nothing to copy, so it fabricates the payload.

Production RCA (assistant thread `2342f4d1`): the agent hand-wrote a v4/v5 chimera (`compositeQuery.queryData[].filters.items` inside a v5 envelope). The SigNoz frontend could not hydrate it and silently reset the user's Traces Explorer to a blank metrics query. Pressed on it, the agent emitted three different schemas across three turns — no source of truth existed.

## Fix

Rewrite the `apply_filter` bullet to a single executable rule, matching the assistant system prompt (signoz-ai-assistant `fix/apply-filter-chip-contract`):

- The chip carries the **exact full v5 `query` object passed to a successful `signoz_execute_builder_query` call** in the turn — the entire query-range envelope (`schemaVersion`, `start`, `end`, `requestType`, `compositeQuery`), not just the inner `compositeQuery`, copied verbatim.
- Turns answered via simplified tools run one validating `signoz_execute_builder_query` with a small `limit` and copy that exact query object — or skip the chip.
- Existing guidance preserved: emit only when the user's primary intent is a runnable query; Cost Meter keeps `signal: metrics` with `source: meter` in the spec.

The assistant backend now also validates chip payloads server-side and drops malformed ones with a WARN + rejection metric, so payloads violating this rule no longer reach users.

https://claude.ai/code/session_01HxJRBVAyYUPKjRCSgtVCto