### PR TITLE
feat(antigravity): add Antigravity CLI plugin

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ npx skills add https://github.com/anthropics/skills --skill skill-creator
 - **Schema reference.** The MCP server is the source of truth for tool input schemas, alert/dashboard JSON shape, and validation rules. Read the `signoz://*` resources rather than transcribing schema into a skill — duplicated schema rots out of sync.
 - **Reference files.** Move material >300 lines into `references/`, `scripts/`, or `assets/`. Any reference file longer than 100 lines must start with a `## Contents` table-of-contents.
 - **SKILL.md length.** Keep the body under 500 lines. Use progressive disclosure — link to specific reference files with a clear "read this when X" pointer rather than burying detail inline.
-- **Plugin manifests.** Keep `plugins/signoz/.codex-plugin/plugin.json` and `plugins/signoz/.cursor-plugin/plugin.json` in sync with the Claude manifest when adding or removing skills.
+- **Plugin manifests.** Keep `plugins/signoz/.codex-plugin/plugin.json` and `plugins/signoz/.cursor-plugin/plugin.json` in sync with the Claude manifest when adding or removing skills. The **Antigravity** plugin is native to the **repo root**: `plugin.json` (marker) + `mcp_config.json` (MCP registration, remote key `serverUrl`) + the root `skills` symlink. This lets `agy plugin install https://github.com/SigNoz/agent-skills` stage the repo root as a native Antigravity plugin. Antigravity's `plugin.json` schema is strict (`name` + `description` only, `additionalProperties: false`), so it intentionally carries **no `version`** and is not part of the CalVer bump. Do not point the root `mcp_config.json` at `${...}` interpolation — Antigravity does not resolve it (unlike `gemini-extension.json`, which keeps its `${SIGNOZ_MCP_URL}` prompt for Gemini CLI).
 
 ### Further reading
 

--- a/README.md
+++ b/README.md
@@ -195,12 +195,20 @@ MCP server (default SigNoz Cloud `us` endpoint, `https://mcp.us.signoz.cloud/mcp
 and the SigNoz skills automatically. The installed plugin is staged at
 `~/.gemini/antigravity-cli/plugins/signoz/`.
 
+**Authenticate (SigNoz Cloud).** In the `agy` prompt, type `/mcp`, select the
+`signoz` server, and choose **Authenticate** to start the OAuth flow. Complete
+it in the browser (over SSH, `agy` prints an authorization URL to paste in and a
+code to paste back). Self-hosted endpoints need no OAuth unless the server runs
+with `OAUTH_ENABLED=true`.
+
+**Change the endpoint.**
+
 - **SigNoz Cloud:** for a non-`us` region, edit the `<region>` segment of
   `serverUrl` (`us`, `us2`, `eu`, `eu2`, `in`, `in2`) in the installed
-  `mcp_config.json`, then run `/mcp` to reload and complete OAuth when prompted.
+  `mcp_config.json`, then run `/mcp` to reload and re-authenticate.
 - **Self-hosted SigNoz:** set `serverUrl` to your own HTTP `/mcp` URL (for
-  example `http://localhost:8000/mcp`). No OAuth unless the server runs with
-  `OAUTH_ENABLED=true`. You can also run `signoz-mcp-setup` to repoint it.
+  example `http://localhost:8000/mcp`). You can also run `signoz-mcp-setup` to
+  repoint it.
 
 ### Other MCP Clients
 

--- a/README.md
+++ b/README.md
@@ -201,14 +201,17 @@ it in the browser (over SSH, `agy` prints an authorization URL to paste in and a
 code to paste back). Self-hosted endpoints need no OAuth unless the server runs
 with `OAUTH_ENABLED=true`.
 
-**Change the endpoint.**
+**Change the endpoint.** In the `agy` prompt, run the setup skill with your
+target — a SigNoz Cloud region or a self-hosted MCP URL:
 
-- **SigNoz Cloud:** for a non-`us` region, edit the `<region>` segment of
-  `serverUrl` (`us`, `us2`, `eu`, `eu2`, `in`, `in2`) in the installed
-  `mcp_config.json`, then run `/mcp` to reload and re-authenticate.
-- **Self-hosted SigNoz:** set `serverUrl` to your own HTTP `/mcp` URL (for
-  example `http://localhost:8000/mcp`). You can also run `signoz-mcp-setup` to
-  repoint it.
+```
+/signoz:signoz-mcp-setup <region>        # e.g. us, us2, eu, eu2, in, in2
+/signoz:signoz-mcp-setup <mcp-url>       # e.g. http://localhost:8000/mcp
+```
+
+This rewrites `serverUrl` in the installed `mcp_config.json`. Then run `/mcp` to
+reload and re-authenticate (self-hosted needs no OAuth unless the server runs
+with `OAUTH_ENABLED=true`). You can also edit the `serverUrl` value directly.
 
 ### Other MCP Clients
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # SigNoz Agent Skills
 
 Official SigNoz skills and MCP configuration for Claude Code, Codex, Cursor,
-Gemini CLI, Devin CLI, and the [skills.sh](https://skills.sh) ecosystem. The MCP setup skill also
+Gemini CLI, Devin CLI, Antigravity CLI, and the [skills.sh](https://skills.sh) ecosystem. The MCP setup skill also
 includes client-specific recipes for VS Code/GitHub Copilot, Claude Desktop,
-Gemini CLI, Devin CLI, Windsurf, Zed, Antigravity, OpenCode, and generic HTTP
+Gemini CLI, Devin CLI, Windsurf, Zed, Antigravity CLI, OpenCode, and generic HTTP
 MCP clients.
 
 ## Skills
 
 | Skill | Description |
 |-------|-------------|
-| [signoz-mcp-setup](plugins/signoz/skills/signoz-mcp-setup/SKILL.md) | Initialize or repair the SigNoz MCP server configuration for Claude Code, Codex, Cursor, VS Code/GitHub Copilot, Claude Desktop, Gemini CLI, Devin CLI, Windsurf, Zed, Antigravity, OpenCode, or another MCP client. |
+| [signoz-mcp-setup](plugins/signoz/skills/signoz-mcp-setup/SKILL.md) | Initialize or repair the SigNoz MCP server configuration for Claude Code, Codex, Cursor, VS Code/GitHub Copilot, Claude Desktop, Gemini CLI, Devin CLI, Windsurf, Zed, Antigravity CLI, OpenCode, or another MCP client. |
 | [signoz-creating-alerts](plugins/signoz/skills/signoz-creating-alerts/SKILL.md) | Create SigNoz alert rules for threshold breaches, error rates, latency, anomaly detection, and absent-data conditions across metrics, logs, and traces. |
 | [signoz-explaining-alerts](plugins/signoz/skills/signoz-explaining-alerts/SKILL.md) | Explain and interpret an existing SigNoz alert rule's configuration, evaluation behavior, notification routing, and recent fire frequency. |
 | [signoz-investigating-alerts](plugins/signoz/skills/signoz-investigating-alerts/SKILL.md) | Diagnose why a SigNoz alert fired by correlating its signal with neighbor metrics, traces, and logs around the fire window, and ranking likely causes. |
@@ -180,10 +180,32 @@ For SigNoz Cloud, start a new session and run `devin mcp login signoz` to
 complete OAuth. For self-hosted SigNoz, no OAuth step is needed unless the
 server runs with `OAUTH_ENABLED=true`.
 
+### Antigravity CLI
+
+Install directly from this repository — Antigravity CLI stages the repo root as
+a native plugin (`plugin.json` + `mcp_config.json` + `skills/`):
+
+```sh
+agy plugin install https://github.com/SigNoz/agent-skills
+agy plugin list   # confirm signoz is loaded
+```
+
+Reinstall with the same command to update. Antigravity registers the `signoz`
+MCP server (default SigNoz Cloud `us` endpoint, `https://mcp.us.signoz.cloud/mcp`)
+and the SigNoz skills automatically. The installed plugin is staged at
+`~/.gemini/antigravity-cli/plugins/signoz/`.
+
+- **SigNoz Cloud:** for a non-`us` region, edit the `<region>` segment of
+  `serverUrl` (`us`, `us2`, `eu`, `eu2`, `in`, `in2`) in the installed
+  `mcp_config.json`, then run `/mcp` to reload and complete OAuth when prompted.
+- **Self-hosted SigNoz:** set `serverUrl` to your own HTTP `/mcp` URL (for
+  example `http://localhost:8000/mcp`). No OAuth unless the server runs with
+  `OAUTH_ENABLED=true`. You can also run `signoz-mcp-setup` to repoint it.
+
 ### Other MCP Clients
 
 The setup skill includes native config recipes for VS Code/GitHub Copilot,
-Claude Desktop, Gemini CLI, Devin CLI, Windsurf, Zed, Antigravity, OpenCode,
+Claude Desktop, Gemini CLI, Devin CLI, Windsurf, Zed, Antigravity CLI, OpenCode,
 and generic HTTP MCP clients. These clients do not all consume this plugin
 automatically; install or copy the skill where your client supports skills, or
 use the client-specific setup snippets in the skill as a reference.
@@ -209,7 +231,9 @@ npx skills add SigNoz/agent-skills --skill signoz-writing-clickhouse-queries    
 ├── .cursor-plugin/marketplace.json         # Cursor marketplace
 ├── .devin-plugin/plugin.json               # Devin CLI plugin manifest
 ├── gemini-extension.json                   # Gemini CLI extension manifest
-├── skills -> plugins/signoz/skills         # Gemini CLI & Devin CLI skills (symlink)
+├── plugin.json                             # Antigravity plugin manifest (native, repo root)
+├── mcp_config.json                         # Antigravity MCP config (serverUrl)
+├── skills -> plugins/signoz/skills         # Gemini CLI, Devin CLI & Antigravity skills (symlink)
 ├── plugins/signoz/
 │   ├── .codex-plugin/plugin.json           # Codex plugin manifest
 │   ├── .claude-plugin/plugin.json          # Claude Code plugin manifest

--- a/mcp_config.json
+++ b/mcp_config.json
@@ -1,0 +1,7 @@
+{
+  "mcpServers": {
+    "signoz": {
+      "serverUrl": "https://mcp.us.signoz.cloud/mcp"
+    }
+  }
+}

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://antigravity.google/schemas/v1/plugin.json",
+  "name": "signoz",
+  "description": "Official SigNoz plugin for MCP setup, docs, queries, dashboards, and alerts"
+}

--- a/plugins/signoz/skills/signoz-mcp-setup/SKILL.md
+++ b/plugins/signoz/skills/signoz-mcp-setup/SKILL.md
@@ -3,7 +3,7 @@ name: signoz-mcp-setup
 description: >
   Initialize or repair SigNoz MCP server configuration for Claude Code, Codex,
   Cursor, VS Code/GitHub Copilot, Claude Desktop, Gemini CLI, Devin CLI,
-  Windsurf, Zed, Antigravity, OpenCode, or another MCP client. Use this skill before any
+  Windsurf, Zed, Antigravity CLI, OpenCode, or another MCP client. Use this skill before any
   SigNoz docs, query, dashboard, alert, or view workflow when
   `signoz_*` tools are unavailable, or when the user says "setup SigNoz
   MCP", "configure SigNoz plugin", "wrong region", "change SigNoz region",
@@ -45,7 +45,7 @@ on disk):
 - Claude Code, Codex, or Cursor plugin install: use the bundled plugin
   registration files.
 - VS Code / GitHub Copilot, Claude Desktop, Gemini CLI, Devin CLI, Windsurf,
-  Zed, Antigravity, or OpenCode: use the matching native client recipe in
+  Zed, Antigravity CLI, or OpenCode: use the matching native client recipe in
   `client-configs.md`.
 - Unknown or unsupported client: use the generic HTTP MCP recipe and point the
   user to the SigNoz MCP Server docs for their client's exact config surface.
@@ -197,8 +197,10 @@ client-specific authentication step:
 - **Windsurf** — reload Windsurf and complete authentication when prompted.
 - **Zed** — reload Zed after config changes; self-hosted stdio mode reads the
   configured environment from the context server entry.
-- **Antigravity** — reload the agent window and complete OAuth when prompted.
-  If authentication is stuck, clear cached dynamic auth providers and retry.
+- **Antigravity CLI** — run `/mcp` to reload the server. For SigNoz Cloud,
+  complete OAuth when prompted. Self-hosted endpoints need no OAuth unless the
+  server runs with `OAUTH_ENABLED=true`. If authentication is stuck, clear cached
+  dynamic auth providers and retry.
 - **OpenCode** — run `opencode mcp auth signoz` if authentication does not
   start automatically, then verify with `opencode mcp list`.
 

--- a/plugins/signoz/skills/signoz-mcp-setup/SKILL.md
+++ b/plugins/signoz/skills/signoz-mcp-setup/SKILL.md
@@ -197,10 +197,10 @@ client-specific authentication step:
 - **Windsurf** — reload Windsurf and complete authentication when prompted.
 - **Zed** — reload Zed after config changes; self-hosted stdio mode reads the
   configured environment from the context server entry.
-- **Antigravity CLI** — run `/mcp` to reload the server. For SigNoz Cloud,
-  complete OAuth when prompted. Self-hosted endpoints need no OAuth unless the
-  server runs with `OAUTH_ENABLED=true`. If authentication is stuck, clear cached
-  dynamic auth providers and retry.
+- **Antigravity CLI** — type `/mcp`, select the `signoz` server, and choose
+  **Authenticate** to start the OAuth flow (complete it in the browser). Self-hosted
+  endpoints need no OAuth unless the server runs with `OAUTH_ENABLED=true`. If
+  authentication is stuck, clear cached dynamic auth providers and retry.
 - **OpenCode** — run `opencode mcp auth signoz` if authentication does not
   start automatically, then verify with `opencode mcp list`.
 

--- a/plugins/signoz/skills/signoz-mcp-setup/references/client-configs.md
+++ b/plugins/signoz/skills/signoz-mcp-setup/references/client-configs.md
@@ -467,8 +467,9 @@ Edit `opencode.json` or `opencode.jsonc`.
   is expected.
 - Windsurf: reload and complete authentication when prompted.
 - Zed: reload after stdio config changes.
-- Antigravity CLI: run `/mcp` to reload and complete OAuth. If auth is stuck,
-  clear dynamic authentication providers and retry.
+- Antigravity CLI: type `/mcp`, select the `signoz` server, and choose
+  **Authenticate** to start the OAuth flow. If auth is stuck, clear dynamic
+  authentication providers and retry.
 - OpenCode: run `opencode mcp auth signoz` if auth does not start
   automatically, then verify with `opencode mcp list`.
 - Header-based auth: no OAuth step is expected; verify the `signoz` tools after

--- a/plugins/signoz/skills/signoz-mcp-setup/references/client-configs.md
+++ b/plugins/signoz/skills/signoz-mcp-setup/references/client-configs.md
@@ -242,9 +242,17 @@ Edit `~/.codeium/windsurf/mcp_config.json`.
 }
 ```
 
-### Antigravity
+### Antigravity CLI
 
-Edit `mcp_config.json` from the agent panel's MCP server manager.
+Remote servers must use the `serverUrl` key — Antigravity does not support
+the legacy `url` or `httpUrl` fields.
+
+If the SigNoz plugin is installed (`agy plugin install https://github.com/SigNoz/agent-skills`),
+it already ships this `mcp_config.json` (default `us` Cloud endpoint), staged at
+`~/.gemini/antigravity-cli/plugins/signoz/`. To repoint it, edit the `serverUrl`
+value in that installed copy, then run `/mcp` to reload. Without the plugin, add
+the server directly to the global `~/.gemini/config/mcp_config.json` (or workspace
+`.agents/mcp_config.json`).
 
 ```json
 {
@@ -323,7 +331,7 @@ Avoid storing real API keys in tracked project files.
 
 ### JSON clients using `mcpServers`
 
-Cursor, Claude Desktop, Windsurf, Gemini CLI, Devin CLI, and Antigravity can
+Cursor, Claude Desktop, Windsurf, Gemini CLI, Devin CLI, and Antigravity CLI can
 use this basic stdio shape, with client-specific file locations from the HTTP
 section. For Devin CLI, prefer `.devin/config.local.json` and its
 `${env:VAR_NAME}` interpolation syntax over literal secrets.
@@ -459,7 +467,7 @@ Edit `opencode.json` or `opencode.jsonc`.
   is expected.
 - Windsurf: reload and complete authentication when prompted.
 - Zed: reload after stdio config changes.
-- Antigravity: reload the agent window and complete OAuth. If auth is stuck,
+- Antigravity CLI: run `/mcp` to reload and complete OAuth. If auth is stuck,
   clear dynamic authentication providers and retry.
 - OpenCode: run `opencode mcp auth signoz` if auth does not start
   automatically, then verify with `opencode mcp list`.

--- a/plugins/signoz/skills/signoz-mcp-setup/references/mcp-settings.md
+++ b/plugins/signoz/skills/signoz-mcp-setup/references/mcp-settings.md
@@ -5,7 +5,7 @@ registration files, editing the endpoint default, or mapping user input to a
 hosted SigNoz Cloud MCP URL.
 
 For native client config shapes such as VS Code, Gemini CLI, Windsurf, Zed,
-Antigravity, or OpenCode, read
+Antigravity CLI, or OpenCode, read
 [client-configs.md](client-configs.md) after resolving the endpoint.
 
 ## Contents


### PR DESCRIPTION
## What

Adds **Google Antigravity CLI** as a supported host for the SigNoz plugin, installable directly from this repository:

```sh
agy plugin install https://github.com/SigNoz/agent-skills
agy plugin list   # confirm signoz is loaded
```

Antigravity stages the **repo root** as a native plugin and auto-discovers three components already present (or newly added) at the root:

| File | Purpose |
|------|---------|
| `plugin.json` (new) | Native Antigravity marker — `name` + `description` only. The manifest schema is strict (`additionalProperties: false`), so it intentionally carries **no `version`** and is out of the CalVer bump. |
| `mcp_config.json` (new) | Registers the `signoz` MCP server via the required **`serverUrl`** key, defaulting to the SigNoz Cloud `us` endpoint. Uses a **literal** URL (no `${...}` interpolation, which Antigravity does not resolve). |
| `skills/` (existing symlink) | The existing root `skills -> plugins/signoz/skills` symlink, reused as-is. |

## Why root-native

Antigravity's `agy plugin install <git-url>` clones the repo and stages the **repo root** as the plugin (same model the Gemini-extension flow uses). Placing the native `plugin.json` + `mcp_config.json` at the root — rather than under `plugins/signoz/` — is what enables the one-line remote install, verified end-to-end with `agy`.

## No impact on other hosts

`gemini-extension.json` (keeps its `${SIGNOZ_MCP_URL}` prompt for Gemini CLI) and every `.{claude,codex,cursor}-plugin` / `.devin-plugin` manifest are untouched. Each of those hosts scopes its plugin root to `plugins/signoz/` (or a specific file), so a bare root `plugin.json` / `mcp_config.json` is read only by Antigravity — no collision. Claude Code, Codex, Cursor, Gemini CLI, Devin CLI, and skills.sh behave exactly as before.

## Docs

- `README.md` — new **Antigravity CLI** install section, intro host list, and repo-structure tree.
- `signoz-mcp-setup` skill (`SKILL.md`, `client-configs.md`, `mcp-settings.md`) — Antigravity CLI recipe + repoint/OAuth via `/mcp`.
- `CONTRIBUTING.md` — notes the root-native layout and the "no `${...}` in root `mcp_config.json`" rule.

Docs are scoped to the **Antigravity CLI** flow that was verified; the 2.0 desktop GUI is intentionally left out for now.

## Verification

- `agy plugin install https://github.com/SigNoz/agent-skills` loads the `signoz` server + skills (verified with `agy`).
- Root `plugin.json` / `mcp_config.json` are valid, schema-compliant, use `serverUrl`, and are not gitignored.
- Simulated clone confirms the `skills` symlink survives and resolves to all 12 `SKILL.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)