### PR TITLE
fix(signoz-searching-docs): forbid guessed docs URLs

### DIFF
--- a/plugins/signoz/skills/signoz-searching-docs/SKILL.md
+++ b/plugins/signoz/skills/signoz-searching-docs/SKILL.md
@@ -23,6 +23,10 @@ Prefer the SigNoz MCP server tools when available; fall back to direct HTTP fetc
 - `signoz_search_docs` — BM25 search over the indexed docs corpus. Pass the user's natural-language query as `searchText`. Narrow with `section_slug` when the question maps cleanly to a single docs section (the tool's own schema lists valid slugs — defer to it rather than memorizing). Trust the ranking — the index handles relevance.
 - `signoz_fetch_doc` — full markdown for one indexed page. Pass the canonical URL or `/docs/...` path; optionally narrow to a section with `heading`.
 
+Never construct `/docs/...` URLs from memory. Only pass URLs returned by
+`signoz_search_docs` to `signoz_fetch_doc`; if you think you already know the
+page path, search first and fetch the canonical URL from the result.
+
 ### Fallback: direct HTTP fetch
 
 If the MCP tools are unavailable, SigNoz docs support `Accept: text/markdown` natively.
@@ -46,7 +50,7 @@ Accept: text/markdown
 2. **Check the heuristics table below**. If a heuristic matches, read it before answering — heuristics encode product decisions (which path/method fits the user's environment), useful in both paths.
 3. **Search and fetch** — pick the path based on tool availability:
    - **With MCP tools**: call `signoz_search_docs` with the user's query; pass `section_slug` if the domain maps cleanly to one. Read the top 1-3 results and call `signoz_fetch_doc` on the chosen URL (use `heading` to narrow if the page is large and the question is sub-section-specific).
-   - **Without MCP tools**: grep `sitemap.md` for candidate pages, rank the best 2-5 by how directly they answer the task, and `GET` the top page(s) with `Accept: text/markdown`. Heuristic coverage is sparse — for topics without a heuristic row, skim the sitemap by section path and prefer setup/troubleshooting/API-reference pages over overviews.
+   - **Without MCP tools**: grep `sitemap.md` for candidate pages, rank the best 2-5 by how directly they answer the task, and `GET` only URLs discovered in the sitemap with `Accept: text/markdown`. Heuristic coverage is sparse — for topics without a heuristic row, skim the sitemap by section path and prefer setup/troubleshooting/API-reference pages over overviews.
    - Fetch **one page** for narrow questions; fetch **multiple pages** when the task spans setup + troubleshooting, or method-selection + language guide. Keep the set small.
 4. **Answer from the fetched docs** and cite canonical `https://signoz.io/docs/...` URLs.
 5. **Handle ambiguity deliberately**: if multiple pages are plausible, prefer the one that completes the task most directly; mention alternates only when they materially change the answer.

--- a/plugins/signoz/skills/signoz-searching-docs/evals/evals.json
+++ b/plugins/signoz/skills/signoz-searching-docs/evals/evals.json
@@ -90,6 +90,20 @@
         {"id": "no_action_skill_handoff", "text": "Agent does NOT delegate to signoz-generating-queries; treats this as a docs lookup."},
         {"id": "cites_canonical_url", "text": "Answer cites at least one canonical https://signoz.io/docs/... URL."}
       ]
+    },
+    {
+      "id": 6,
+      "eval_name": "no-guessed-cost-meter-url",
+      "prompt": "Find the SigNoz docs for the Cost Meter meter explorer query guide and summarize how to use it.",
+      "expected_output": "Agent calls signoz:signoz_search_docs before calling signoz:signoz_fetch_doc, chooses the canonical Cost Meter meter explorer query guide URL returned by search, and fetches that URL. It must not construct or fetch a plausible `/docs/cost-meter/user-guides/meter-explorer-query-guide/` path from memory.",
+      "files": [],
+      "assertions": [
+        {"id": "search_before_fetch", "text": "Agent calls signoz_search_docs before the first signoz_fetch_doc call."},
+        {"id": "fetches_search_result_url", "text": "Agent calls signoz_fetch_doc only with a URL returned by signoz_search_docs."},
+        {"id": "no_guessed_user_guides_url", "text": "Agent does not fetch or cite `/docs/cost-meter/user-guides/meter-explorer-query-guide/`."},
+        {"id": "fetches_canonical_cost_meter_page", "text": "Agent fetches the canonical Cost Meter meter explorer query guide page."},
+        {"id": "cites_canonical_url", "text": "Answer cites the canonical https://signoz.io/docs/... URL."}
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add an explicit guardrail telling agents not to construct `/docs/...` URLs from memory.
- Require `signoz_fetch_doc` inputs to come from `signoz_search_docs` results, or from `sitemap.md` in the HTTP fallback path.
- Add a Cost Meter regression eval for the previously fabricated `user-guides` docs URL.

## Why

`SigNoz/nerve-pod#74` captured a production case where the agent guessed a plausible SigNoz docs URL before searching. The docs index rejected the URL and the agent recovered after a search, but the first fetch wasted a turn and several seconds.

## Validation

- `python3 -m json.tool plugins/signoz/skills/signoz-searching-docs/evals/evals.json`
- `git diff --check`
- `uv run pytest tests/test_golden -m golden_unit -v --tb=short` in `SigNoz/signoz-ai-assistant` (64 passed)