### PR TITLE
fix(dashboard-skills): align create and modify contracts

### DIFF
--- a/docs/signoz-creating-dashboards-evals.md
+++ b/docs/signoz-creating-dashboards-evals.md
@@ -10,10 +10,17 @@ plugins/signoz/skills/signoz-creating-dashboards/evals/evals.json
 
 ## How the suite was built
 
-1. **Mapped the skill surface** from `SKILL.md`, the SigNoz dashboard MCP resources (`signoz://dashboard/instructions`, `widgets-instructions`, `widgets-examples`, `query-builder-example`, `traces/query-builder-guide`, `clickhouse-{schema,example}-for-{metrics,traces,logs}`), and the SigNoz repo (`frontend/src/constants/queryBuilder.ts` for the panel-type enum).
+1. **Mapped the skill surface** from `SKILL.md`, the core dashboard resources,
+   `signoz://promql/instructions`, the metrics/traces/logs Query Builder guides,
+   and the six exact ClickHouse resources: `clickhouse-schema-for-metrics`,
+   `clickhouse-metrics-example`, `clickhouse-schema-for-traces`,
+   `clickhouse-traces-example`, `clickhouse-schema-for-logs`, and
+   `clickhouse-logs-example` under `signoz://dashboard/`.
 2. **Verified template-catalog claims** against [SigNoz/dashboards](https://github.com/SigNoz/dashboards) — every template reference in the evals points to a real file.
 3. **Verified data assumptions** against the live SigNoz instance via the MCP server (`signoz_list_dashboards`, `signoz_list_metrics`, `signoz_list_services`, `signoz_get_field_keys`, `signoz_get_field_values`, `signoz_aggregate_logs`). Evals that assume "no existing dashboard" were corrected to acknowledge the duplicates that are actually present.
 4. **Pairwise duplicate audit** across all evals — removed `custom-build-payment-pipeline` whose unique elements were strict subsets of other evals.
+5. **Offline branch fixtures** under `evals/files/` make pagination and prior-turn
+   simulations deterministic without depending on a live tenant's ordering.
 
 ## Surface covered
 
@@ -21,15 +28,15 @@ plugins/signoz/skills/signoz-creating-dashboards/evals/evals.json
 
 | Signal | Evals |
 |---|---|
-| metrics | 0, 1, 7, 9 |
-| traces | 8, 10, 12, 15, 16 |
+| metrics | 0, 1, 7, 9, 18 |
+| traces | 8, 10, 12, 15, 16, 17, 19 |
 | logs | 14 |
 
 ### Panel types (from `PANEL_TYPES` enum in `frontend/src/constants/queryBuilder.ts`)
 
 | Panel type | Evals |
 |---|---|
-| graph (timeseries) | 7, 9, 10, 12, 14, 17 |
+| graph (timeseries) | 7, 9, 10, 12, 14, 17, 19 |
 | value | 9, 14, 16 |
 | table | 14, 16 |
 | list | 15 |
@@ -46,15 +53,16 @@ plugins/signoz/skills/signoz-creating-dashboards/evals/evals.json
 | Duplicate found → user picks "create new" → template import + no-data warning | 1 |
 | Duplicate found → user picks "create new" → template import → server failure → fallback | 13 |
 | Duplicate found → user picks "modify" → hand off to `signoz-modifying-dashboards` | 11 |
+| Duplicate found on a later page → present choices before any write | 18 |
 | Broad/ambiguous request → present multiple template options | 2 |
 | Vague request → emit `needs_input` / clarify scope | 5 |
-| No template match → custom build | 6, 7, 8, 9, 10, 12, 14, 15, 16, 17 |
+| No template match → custom build | 6, 7, 8, 9, 10, 12, 14, 15, 16, 17, 19 |
 
 ### Guardrails exercised
 
 | Guardrail | Eval(s) |
 |---|---|
-| Always paginate `signoz_list_dashboards` before any write | 0, 1, 11, 13 |
+| Always paginate `signoz_list_dashboards` before any write | 0, 1, 11, 13, 18 |
 | `list_dashboard_templates` before custom build | 6, 7, 8, 9, 10, 14, 15, 16, 17 |
 | No-data probe before save | 1, 6, 14 |
 | Don't shortcut to a near-neighbour template | 6 |
@@ -68,9 +76,11 @@ plugins/signoz/skills/signoz-creating-dashboards/evals/evals.json
 | Error-rate formula `A*100/B` with `disabled:true` on base queries | 9, 16 |
 | Non-default time range for SLO windows (28d) | 9 |
 | Variable-application prompt before injecting `$var` into panels | 17 |
-| `DYNAMIC` variable shape (`DynamicVariablesAttribute` / `DynamicVariablesSource`) | 17 |
+| Selected-panel variable wiring and dry-run | 19 |
+| `DYNAMIC` variable shape (`DynamicVariablesAttribute` / `DynamicVariablesSource`) | 17, 19 |
 | No `JSON.stringify` on `layout` / `widgets` / `variables` | 12 |
-| Per-widget required fields (`id`, `panelTypes`, `title`, `query`, `selectedLogFields`, `selectedTracesFields`, `thresholds`, `contextLinks`) | 12, 14, 15 |
+| Per-widget required fields and active query payload | 12, 14, 15 |
+| 12-column bounds and exact `panelMap` membership/layout parity | 16 |
 | Scope boundary — don't call `signoz_update_dashboard` from this skill | 11 |
 | Surface import failures, don't silently retry | 13 |
 
@@ -88,20 +98,22 @@ plugins/signoz/skills/signoz-creating-dashboards/evals/evals.json
 | 9 | `custom-build-slo-error-budget-formula` | SLO availability + error-budget burn-rate; builder mode only | metrics | graph, value | error-rate formula, non-default 28d time range, `service.name` (dotted, resource), no PromQL |
 | 10 | `custom-build-multi-service-user-journey` | Per-hop latency + error rate across multiple services | traces | graph | `service.name` discovery (`signoz_list_services` / `signoz_get_field_values`), IN-list filter, per-service `groupBy=service.name`, error-rate formula |
 | 11 | `duplicate-modify-hands-off` | Existing dashboard + user picks "modify" → handoff | (any) | n/a | scope boundary — no `signoz_update_dashboard` from this skill |
-| 12 | `shape-check-no-stringify` | Top-level fields are native JSON, every widget has required keys | traces | graph | `layout` / `widgets` / `variables` not stringified, query has `queryType` + `builder` + `promql` + `clickhouse_sql` sub-keys |
+| 12 | `shape-check-no-stringify` | Top-level fields are native JSON, every widget has required keys | traces | graph | `layout` / `widgets` / `variables` not stringified, query has `queryType` + complete active Builder payload |
 | 13 | `import-failure-falls-back-to-custom` | Duplicate-check → "create new" → template import fails → surface error + fallback | metrics | (template) | no silent retry, no fabricated payload, custom-build fallback or stop |
 | 14 | `custom-build-logs-signal-volume-and-errors` | Logs-signal dashboard with severity breakdown | logs | graph, value, table | `dataSource=logs`, `severity_text` (not `severity`/`level`), value-no-`groupBy`, `selectedLogFields` per widget |
 | 15 | `custom-build-list-panel-selectColumns-required` | Recent-error-traces list panel | traces | list | `selectColumns` uses `name` not `key`, each entry has `fieldContext` + `signal`, `orderBy` + `pageSize` set, no `groupBy` on lists |
 | 16 | `custom-build-multi-panel-types-mixed` | One dashboard exercising row + value + pie + bar + table | traces | row, value, pie, bar, table | per-panel-type shape rules (value-no-`groupBy`, pie-needs-legend, bar-not-graph, table-`as`-aliases), formula with `disabled:true`, KPI-row layout |
-| 17 | `custom-build-variable-application-prompt` | User asks for `service.name` dropdown; one panel is intentionally global | traces | graph | `DYNAMIC` variable shape, ask-which-panels-before-injection, don't over-filter the global panel |
+| 17 | `custom-build-variable-application-prompt` | User asks for `service.name` dropdown; agent stops at panel-scope clarification | traces | graph | `DYNAMIC` variable shape, ask before injection |
+| 18 | `duplicate-dashboard-on-second-page` | Matching dashboard appears only after following `pagination.nextOffset` | metrics | n/a | later-page duplicate detection, no write before user choice |
+| 19 | `custom-build-variable-application-selected-panels` | Follow-up selects two panels and keeps the global panel unfiltered | traces | graph | targeted `$service_name` wiring, representative-value dry-runs |
 
 ## Intentionally uncovered
 
 | Surface | Reason |
 |---|---|
 | `histogram` panel | Niche distribution panel; low-risk shape |
-| PromQL widgets | Skill explicitly forbids PromQL in builder mode (eval 9 tests the negative); not a primary user path for this skill |
-| Raw ClickHouse SQL panels | Owned by sibling skill `signoz-writing-clickhouse-queries`; out of scope per `SKILL.md` |
+| PromQL widgets | Supported via `signoz://promql/instructions`; no dedicated creation eval yet |
+| Raw ClickHouse SQL panels | Supported via the signal-specific MCP resources and `signoz-writing-clickhouse-queries`; no dedicated creation eval yet |
 | `CUSTOM` / `TEXTBOX` / `QUERY` variable types | `DYNAMIC` is the recommended default per `signoz://dashboard/instructions`; eval 17 covers the recommended path |
 | Threshold formats (`Text` / `Background`) | Edge feature — failure mode is cosmetic, not data-correctness |
 

--- a/plugins/signoz/skills/signoz-creating-dashboards/SKILL.md
+++ b/plugins/signoz/skills/signoz-creating-dashboards/SKILL.md
@@ -107,8 +107,8 @@ create a new one.
 
 Call `signoz_list_dashboards`. Most installs fit in the default
 page (`limit=50`); only paginate when `pagination.hasMore=true`. Use
-string values for `limit` / `offset` (e.g. `"50"`, `"0"`) — the schema
-expects strings, not integers.
+`pagination.nextOffset` directly for the next page; the schema accepts
+integer or string `limit` / `offset` values.
 
 **Match by relevance** Compare each existing
 dashboard's lowercased `name`, `description`, and `tags` against the
@@ -329,6 +329,7 @@ Add signal-specific resources as needed:
   `signoz://metrics-aggregation-guide` — required for picking valid
   `timeAggregation` / `spaceAggregation` per metric type.
 - Traces (Query Builder): `signoz://traces/query-builder-guide`.
+- Logs (Query Builder): `signoz://logs/query-builder-guide`.
 - Traces (ClickHouse): `signoz://dashboard/clickhouse-schema-for-traces`
   + `signoz://dashboard/clickhouse-traces-example`.
 - Logs (ClickHouse): `signoz://dashboard/clickhouse-schema-for-logs`
@@ -341,8 +342,8 @@ semantic attribute names (not shorthand) in filters, groupBy, and
 variables. Apply the defaults below unless the user specified otherwise.
 
 All panels are validated in Step 3b-ii.6 via the mandatory dry-run
-before save. Author the JSON here as you intend to save it — the
-dry-run uses the exact shape from `queryData`.
+before save. Author the saved query semantics first, then use the
+lossless dry-run translation below.
 
 **Defaults the skill applies (and surfaces in the preview):**
 
@@ -357,7 +358,7 @@ dry-run uses the exact shape from `queryData`.
 | Counter render unit (rate vs. count) | per-second rate | per-interval **increase** count over a wider window (24h–7d) for any low-volume / bursty / human-paced counter — requests, **error counts**, restarts, OOM kills — where `/sec` renders as tiny decimals (e.g. `0.03/s`); gauges (CPU/mem/queue depth) are already absolute and unaffected; note `increase` rescales its y-axis with the selected range, so prefer it deliberately, not by reflex |
 | Variables (services) | `service.name`, `deployment.environment` (or `deployment.environment.name` — verify which exists via `signoz_get_field_keys`) | add `k8s.cluster.name` / `k8s.namespace.name` when k8s-flavored |
 | Variables (k8s/infra) | `k8s.cluster.name`, `k8s.namespace.name` (or `host.name` for hostmetrics) | drop `service.name` — it is rarely populated on infra signals |
-| Layout | 2-column grid (`w: 6`), 12 columns wide | full-width (`w: 12`) for tables and time-series with many series |
+| Layout | 2-column grid (`w: 6`), 12 columns wide; every item has `0 <= x < 12`, `1 <= w <= 12`, `x + w <= 12` | full-width (`x: 0, w: 12`) for tables and time-series with many series |
 | GroupBy on per-service panels | `service.name` resource attribute | drop when filtering to a single service |
 
 **Sections and `panelMap`** A section is a `panelTypes: "row"` widget
@@ -365,7 +366,8 @@ followed in `widgets[]` by the panels under it. Mirror that grouping in
 `panelMap`: one entry per row, keyed by the row id, listing only the
 panels that follow it up to the next row. Do not put every panel under
 a single row id — that renders on load but collapses the whole
-dashboard when one section is toggled.
+dashboard when one section is toggled. Each child must match its top-level
+layout entry's `x`, `y`, `w`, and `h` and satisfy the same horizontal bounds.
 
 **Title and description** The dashboard title should name the
 technology and the scope clearly: "PostgreSQL — prod-us-east-1", not
@@ -391,22 +393,14 @@ Call `signoz_execute_builder_query` per panel. The dry-run
 validates the query is well-formed *and* confirms data flows under
 that filter — the per-panel data probe folds in here.
 
-**Envelope translation** Widget JSON wraps queries in
-`compositeQuery.builder.queryData[]` and `queryFormulas[]`, but
-`signoz_execute_builder_query` takes
-`compositeQuery.queries[].{type, spec}`. Translate per panel: each
-`queryData[i]` → `{ type: "builder_query", spec: { name, signal,
-filter: {expression}, groupBy, aggregations } }`; each
-`queryFormulas[i]` → `{ type: "builder_formula", spec: { name,
-expression } }`. **Preserve the original `name`** (`A`, `B`, …) on
-every `builder_query.spec` — formula expressions reference inputs
-by that name (e.g., `A * 100 / B`), and dropping it makes the
-dry-run shape diverge from the saved panel so formulas can't
-resolve their inputs. The endpoint cannot consume widget JSON
-directly.
+Build the complete payload from the current tool schema; do not pass
+widget JSON. Translate the active Builder, PromQL, or ClickHouse query
+losslessly into its matching envelope, preserving every semantic field
+and query name (`A`, `B`, `F1`, etc.). Supply representative values for
+referenced dashboard variables.
 
-Non-empty response = pass; server error, "filter type mismatch", or
-unexpected zero rows = fail (fix the panel JSON before save).
+Server or validation error = fail. Unexpected zero rows also fail,
+unless the user already chose to build despite confirmed missing telemetry.
 
 Coverage: dry-run **every query-bearing panel**, regardless of count
 or shape. Trivial panels fail silently too (wrong severity filter,
@@ -421,13 +415,13 @@ instead and skip them here.
 1. **Preview** Emit a one-paragraph plain-language summary of what
    will be created — no JSON dump. A 20–30 widget payload is hundreds
    of lines the user cannot meaningfully review in chat, and the
-   dry-run has already validated every query-bearing panel against
-   live data.
+   dry-run has already validated every query-bearing panel; data was
+   confirmed except where the user accepted missing telemetry.
 
    > **Summary**: This dashboard tracks [signals] for [scope], with
    > sections [list]. Variables: [list]. Time range default 1h.
-   > Dry-run: all [N] query-bearing panels validated against live
-   > data (any failures have been fixed pre-save).
+   > Dry-run: all [N] query-bearing panels passed validation. Data:
+   > [confirmed / pending ingestion by explicit user choice].
 
 2. **Save** Call `signoz_create_dashboard` with the payload.
 
@@ -462,10 +456,9 @@ instead and skip them here.
   explicitly opted out for this request.
 - **Mandatory dry-run before save on custom builds** Before
   `signoz_create_dashboard`, run
-  `signoz_execute_builder_query` per Step 3b-ii.6 — translate
-  each panel's `builder.queryData[]` / `queryFormulas[]` into the
-  endpoint's `queries[].{type, spec}` envelope (mapping in Step
-  3b-ii.6). Skipping is equivalent to skipping the duplicate check.
+  `signoz_execute_builder_query` per Step 3b-ii.6 using the current
+  tool schema and lossless active-query translation. Skipping is
+  equivalent to skipping the duplicate check.
   The create-dashboard schema accepts queries that 500 at query time
   — a `groupBy` on a numeric attribute, an
   aggregation incompatible with the metric type — and the result

--- a/plugins/signoz/skills/signoz-creating-dashboards/evals/evals.json
+++ b/plugins/signoz/skills/signoz-creating-dashboards/evals/evals.json
@@ -138,12 +138,12 @@
       "id": 12,
       "eval_name": "shape-check-no-stringify",
       "prompt": "Create a dashboard with one timeseries panel showing service request rate for the checkout service. Walk me through the create call.",
-      "expected_output": "Agent walks the standard custom-build path: list_dashboards, list_dashboard_templates (no exact 'request rate one panel' template), discovery via list_metrics + get_field_keys, reads dashboard MCP resources. Builds the JSON, dry-runs the panel via signoz_execute_builder_query, then emits a plain-language summary and calls signoz_create_dashboard. CRITICAL: the payload sent to signoz_create_dashboard must have layout, widgets, and variables as native JSON arrays/objects — NOT as JSON.stringify'd strings. Required top-level fields are title, layout (array of {x,y,w,h,i}), widgets (array). Each widget must include id, panelTypes, title, query (with builder/promql/clickhouse_sql sub-keys), selectedLogFields, selectedTracesFields, thresholds, contextLinks. Agent must NOT wrap any of these in a JSON string.",
+      "expected_output": "Agent walks the standard custom-build path: list_dashboards, list_dashboard_templates (no exact 'request rate one panel' template), discovery via list_metrics + get_field_keys, reads dashboard MCP resources. Builds the JSON, dry-runs the panel via signoz_execute_builder_query, then emits a plain-language summary and calls signoz_create_dashboard. CRITICAL: the payload sent to signoz_create_dashboard must have layout, widgets, and variables as native JSON arrays/objects — NOT as JSON.stringify'd strings. Required top-level fields are title, layout (array of {x,y,w,h,i}), widgets (array). Each widget must include id, panelTypes, title, query with queryType and its active payload, selectedLogFields, selectedTracesFields, thresholds, and contextLinks. Agent must NOT wrap any of these in a JSON string.",
       "expectations": [
         "Payload sent to signoz_create_dashboard has layout as an array of objects (not a stringified JSON string)",
         "Payload sent to signoz_create_dashboard has widgets as an array of objects (not a stringified JSON string)",
         "Each widget in the payload includes id, panelTypes, title, query, selectedLogFields, selectedTracesFields, thresholds, and contextLinks",
-        "The widget's query object includes queryType, builder, promql, and clickhouse_sql sub-keys (with promql and clickhouse_sql passed as empty arrays for builder-mode widgets)",
+        "The widget's query object includes queryType and the complete active Builder payload; inactive PromQL and ClickHouse payloads need not be authored",
         "Agent runs signoz_execute_builder_query as a dry-run for the panel before signoz_create_dashboard"
       ],
       "files": []
@@ -183,11 +183,12 @@
       "id": 14,
       "eval_name": "custom-build-logs-signal-volume-and-errors",
       "prompt": "Create a dashboard for our application log analytics — I want a timeseries of log volume per service, a value panel showing total ERROR/WARN count in the last hour, and a table of top 10 services by log volume broken down by severity. Use logs as the data source.",
-      "expected_output": "Logs-signal dashboard with NO catalog template — must custom build on the LOGS signal, not metrics or traces. Agent paginates signoz_list_dashboards (no log-analytics dashboard). signoz_list_dashboard_templates returns no match. Falls through to custom build. CRITICAL: agent must recognise the signal is LOGS (dataSource=logs in queryData), not metrics. Calls signoz_get_field_keys with signal=logs to discover available log attributes (severity_text, service.name as resource attr, body, severity_number). Optionally calls signoz_aggregate_logs at discovery time to gauge log volume. The mandatory per-panel dry-run before save goes through signoz_execute_builder_query (signal=logs in each builder_query.spec), not signoz_aggregate_logs. Reads signoz://dashboard/widgets-instructions, signoz://dashboard/widgets-examples, AND signoz://dashboard/clickhouse-logs-example or query-builder-example for log-specific patterns. Builds three panels: (a) timeseries panel with dataSource=logs, aggregation count(), groupBy service.name, legend {{service.name}}; (b) value panel with dataSource=logs, aggregation count(), filter severity_text IN ('ERROR','WARN','FATAL') — NO groupBy on value panels; (c) table panel with dataSource=logs, aggregation count() as 'Log Count', groupBy service.name AND severity_text (both with isColumn:true on at least one). Each widget includes the required selectedLogFields array (timestamp, body) per the widgets-examples shape. Variables use service.name (DYNAMIC type, source=Logs or 'All telemetry'). Emits plain-language summary (no JSON dump) before signoz_create_dashboard.",
+      "expected_output": "Logs-signal dashboard with NO catalog template — must custom build on the LOGS signal, not metrics or traces. Agent paginates signoz_list_dashboards (no log-analytics dashboard). signoz_list_dashboard_templates returns no match. Falls through to custom build. CRITICAL: agent must recognise the signal is LOGS (dataSource=logs in queryData), not metrics. Calls signoz_get_field_keys with signal=logs to discover available log attributes (severity_text, service.name as resource attr, body, severity_number). Optionally calls signoz_aggregate_logs at discovery time to gauge log volume. The mandatory per-panel dry-run before save goes through signoz_execute_builder_query (signal=logs in each builder_query.spec), not signoz_aggregate_logs. Reads signoz://dashboard/widgets-instructions, signoz://dashboard/widgets-examples, signoz://dashboard/query-builder-example, and signoz://logs/query-builder-guide. Builds three panels: (a) timeseries panel with dataSource=logs, aggregation count(), groupBy service.name, legend {{service.name}}; (b) value panel with dataSource=logs, aggregation count(), filter severity_text IN ('ERROR','WARN','FATAL') — NO groupBy on value panels; (c) table panel with dataSource=logs, aggregation count() as 'Log Count', groupBy service.name AND severity_text (both with isColumn:true on at least one). Each widget includes the required selectedLogFields array (timestamp, body) per the widgets-examples shape. Variables use service.name (DYNAMIC type, source=Logs or 'All telemetry'). Emits plain-language summary (no JSON dump) before signoz_create_dashboard.",
       "expectations": [
         "Agent calls signoz_list_dashboard_templates and finds no matching log-analytics template before custom build",
         "Agent uses dataSource='logs' in queryData (not 'metrics' or 'traces') for the log panels",
         "Agent calls signoz_get_field_keys with signal=logs to discover log attributes before authoring",
+        "Agent reads signoz://logs/query-builder-guide before authoring Builder log queries",
         "Agent uses severity_text in a filter for the ERROR/WARN value panel (not a guessed key like 'severity' or 'level')",
         "Value panel does NOT include groupBy (would produce multiple values instead of one)",
         "Table panel includes groupBy with at least 'service.name' AND 'severity_text' to satisfy the per-service / per-severity breakdown",
@@ -219,9 +220,9 @@
       "id": 16,
       "eval_name": "custom-build-multi-panel-types-mixed",
       "prompt": "Create an APM-style dashboard for the checkoutservice with: (1) a row section called 'Overview', (2) three value panels in a KPI row (total requests, error rate %, p99 latency), (3) a row section called 'Breakdowns', (4) a pie panel showing request distribution by operation, (5) a bar panel showing error count by status code, and (6) a table panel with operation, request count, and avg latency.",
-      "expected_output": "Multi-panel-type dashboard exercises all six non-graph panel types (row, value, pie, bar, table) PLUS the standard graph type if any timeseries is added. No catalog template — custom build on traces signal. Agent paginates signoz_list_dashboards (none — no checkout APM dashboard with this exact layout). signoz_list_dashboard_templates returns the apm category but the user asked for a specific layout, so falls through to custom build. CRITICAL panel-shape rules per widgets-examples: (a) row panels have panelTypes='row' and a title, no query needed; (b) value panels MUST NOT have groupBy (causes multiple values instead of one); (c) pie panels MUST have groupBy AND legend matching the groupBy key; (d) bar panels behave like graph and need groupBy+legend when grouped; (e) table panels need groupBy and SHOULD use 'as' aliases on aggregations (e.g. count() as 'Requests' avg(duration_nano) as 'Latency'); (f) error rate must use A*100/B formula with disabled:true on base queries. Reads signoz://dashboard/widgets-examples for each panel-type shape. Discovers the operation attribute (likely 'name' span column or rpc.method/http.route) via signoz_get_field_keys with signal=traces. Emits a plain-language summary (no JSON dump) before signoz_create_dashboard, after running a per-panel signoz_execute_builder_query dry-run for every authored panel. Layout must place the two row sections at full width (w=12) with appropriate Y progression, and the KPI value panels in a single horizontal row (e.g. three w=4 panels at the same Y).",
+      "expected_output": "Multi-panel-type dashboard exercises the five requested non-graph panel types (row, value, pie, bar, table). No catalog template — custom build on traces signal. Agent paginates signoz_list_dashboards (none — no checkout APM dashboard with this exact layout). signoz_list_dashboard_templates returns the apm category but the user asked for a specific layout, so falls through to custom build. CRITICAL panel-shape rules per widgets-examples: (a) row panels have panelTypes='row' and a title, no query needed; (b) value panels MUST NOT have groupBy (causes multiple values instead of one); (c) pie panels MUST have groupBy AND legend matching the groupBy key; (d) bar panels behave like graph and need groupBy+legend when grouped; (e) table panels need groupBy and SHOULD use 'as' aliases on aggregations (e.g. count() as 'Requests' avg(duration_nano) as 'Latency'); (f) error rate must use A*100/B formula with disabled:true on base queries. Reads signoz://dashboard/widgets-examples for each panel-type shape. Discovers the operation attribute (likely 'name' span column or rpc.method/http.route) via signoz_get_field_keys with signal=traces. Emits a plain-language summary (no JSON dump) before signoz_create_dashboard, after running a per-panel signoz_execute_builder_query dry-run for every authored panel. Layout must place the two row sections at full width (w=12) with appropriate Y progression, and the KPI value panels in a single horizontal row (e.g. three w=4 panels at the same Y).",
       "expectations": [
-        "Dashboard payload includes at least one row panel (panelTypes='row') for section headers",
+        "Dashboard payload includes exactly the two requested row panels titled Overview and Breakdowns",
         "Value panels do NOT include groupBy in queryData",
         "Pie panel includes groupBy AND legend with {{<key>}} matching the groupBy key",
         "Bar panel uses panelTypes='bar' (not 'graph') and includes groupBy on status_code or equivalent",
@@ -229,6 +230,8 @@
         "Error-rate value panel uses an A*100/B formula with disabled:true on base queries (per widgets-examples error-rate pattern)",
         "Agent reads signoz://dashboard/widgets-examples before authoring (panel shapes vary per type)",
         "Layout places row panels at full width (w=12) and KPI value panels side-by-side at consistent y",
+        "Every layout item satisfies 0 <= x < 12, 1 <= w <= 12, and x+w <= 12",
+        "panelMap has exactly the Overview and Breakdowns row entries; Overview contains only the three KPI widget IDs, Breakdowns only the pie, bar, and table widget IDs, and every child's x, y, w, h matches its top-level layout entry",
         "Agent emits a plain-language summary (no JSON dump) before signoz_create_dashboard",
         "Agent runs signoz_execute_builder_query as a per-panel dry-run for every authored panel (rows excluded — they have no query) before signoz_create_dashboard"
       ],
@@ -238,17 +241,42 @@
       "id": 17,
       "eval_name": "custom-build-variable-application-prompt",
       "prompt": "Create a dashboard for our backend services with three panels: (1) request rate timeseries grouped by service, (2) p99 latency timeseries grouped by service, and (3) a global system health panel showing total error count across all services. I want a service.name dropdown variable to filter the dashboard.",
-      "expected_output": "Custom-build dashboard with a DYNAMIC variable. The user has explicitly asked for a service.name dropdown. Agent's standard custom-build flow applies (duplicate check, list_templates no match, discovery, MCP resource read, build JSON). CRITICAL guardrail per signoz://dashboard/instructions ('Applying Variables to Panels'): before wiring the service.name variable into panel queries, the agent MUST present the panel list (id+title) and ASK the user which panels the variable should apply to — offering (a) all panels, or (b) a subset. The agent must NOT silently inject $service_name into every panel. In this case the third panel is intentionally a 'global' health panel that should NOT carry the service.name filter (over-filtering would hide the global view). The agent should detect this from the user's wording or, at minimum, ask. Variable is DYNAMIC type, DynamicVariablesAttribute='service.name', DynamicVariablesSource='Traces' or 'All telemetry'. Runs per-panel signoz_execute_builder_query dry-runs, then emits a plain-language summary (no JSON dump) before signoz_create_dashboard, calling out which panels the variable applies to.",
+      "expected_output": "Agent follows the custom-build discovery and resource-read flow, proposes a DYNAMIC service_name variable, lists all three planned panels, and asks whether the variable should apply to all or a subset. It stops before wiring $service_name, dry-running, or creating the dashboard.",
       "expectations": [
-        "Agent creates the variable with type='DYNAMIC' (not CUSTOM/TEXTBOX/QUERY) and DynamicVariablesAttribute='service.name'",
-        "Agent either explicitly asks the user which panels the service.name variable should apply to, OR justifies in the preview which panels it applies to and which it intentionally skips (specifically the 'global system health' panel)",
-        "Variable reference $service_name appears in the filter expression of the per-service request-rate AND latency panels",
-        "Variable reference $service_name does NOT appear in the filter expression of the global error-count panel (over-filtering would defeat the 'across all services' intent)",
-        "Variable references use the $-prefix syntax in filter expressions (e.g. 'service.name in $service_name'), not bare 'service_name'",
-        "Agent emits a plain-language summary (no JSON dump) before signoz_create_dashboard",
-        "Agent runs signoz_execute_builder_query as a per-panel dry-run for every authored panel before signoz_create_dashboard"
+        "Agent proposes type='DYNAMIC' with DynamicVariablesAttribute='service.name'",
+        "Agent explicitly lists the panels and asks which the service.name variable should apply to before wiring any query",
+        "Agent does not wire $service_name into any panel before the user answers",
+        "Agent does not call signoz_execute_builder_query or signoz_create_dashboard before the user answers"
       ],
       "files": []
+    },
+    {
+      "id": 18,
+      "eval_name": "duplicate-dashboard-on-second-page",
+      "prompt": "Create a PostgreSQL dashboard for prod.",
+      "expected_output": "In an offline simulated tool trace using the attached fixture, the first list response has hasMore=true and no PostgreSQL match. Agent follows pagination.nextOffset, finds the existing dashboard on page two, and presents modify / create new / stop before any template lookup or write.",
+      "expectations": [
+        "The simulated trace invokes signoz_list_dashboards again with offset equal to pagination.nextOffset using an accepted integer or string value",
+        "Agent surfaces the second-page PostgreSQL dashboard as a duplicate",
+        "Agent presents modify / create new / stop before signoz_list_dashboard_templates, signoz_import_dashboard, or signoz_create_dashboard",
+        "Agent performs no dashboard write before the user chooses"
+      ],
+      "files": ["evals/files/duplicate-on-second-page.json"]
+    },
+    {
+      "id": 19,
+      "eval_name": "custom-build-variable-application-selected-panels",
+      "prompt": "Apply it to Request Rate by Service and P99 Latency by Service, but keep Global System Health unfiltered.",
+      "expected_output": "Using the prior-turn fixture, agent wires $service_name only into the two selected per-service panel drafts, leaves Global System Health global, and produces an offline simulated dry-run trace for all three complete active queries with the representative variable value. It prepares the plain-language summary but does not create a live dashboard in this offline eval.",
+      "expectations": [
+        "Variable reference $service_name appears in the Request Rate by Service and P99 Latency by Service filters",
+        "Variable reference $service_name does not appear in the Global System Health filter",
+        "Variable references use $service_name in filter expressions rather than bare service_name",
+        "The simulated trace runs signoz_execute_builder_query for every complete active query with service_name=checkoutservice",
+        "Agent prepares a plain-language summary that states which panels the variable filters",
+        "Agent does not call signoz_create_dashboard in the offline eval"
+      ],
+      "files": ["evals/files/service-variable-scope-context.json"]
     }
   ]
 }

--- a/plugins/signoz/skills/signoz-creating-dashboards/evals/files/duplicate-on-second-page.json
+++ b/plugins/signoz/skills/signoz-creating-dashboards/evals/files/duplicate-on-second-page.json
@@ -1,0 +1,20 @@
+{
+  "mode": "offline_mcp_fixture",
+  "instructions": "Use these ordered responses to produce an offline simulated tool trace; do not query a live tenant.",
+  "responses": [
+    {
+      "request": {"limit": 50, "offset": 0},
+      "response": {
+        "data": [{"uuid": "11111111-1111-4111-8111-111111111111", "name": "Redis Overview"}],
+        "pagination": {"total": 51, "offset": 0, "limit": 50, "hasMore": true, "nextOffset": 50}
+      }
+    },
+    {
+      "request": {"limit": 50, "offset": 50},
+      "response": {
+        "data": [{"uuid": "22222222-2222-4222-8222-222222222222", "name": "PostgreSQL - prod"}],
+        "pagination": {"total": 51, "offset": 50, "limit": 50, "hasMore": false, "nextOffset": -1}
+      }
+    }
+  ]
+}

--- a/plugins/signoz/skills/signoz-creating-dashboards/evals/files/service-variable-scope-context.json
+++ b/plugins/signoz/skills/signoz-creating-dashboards/evals/files/service-variable-scope-context.json
@@ -1,0 +1,55 @@
+{
+  "mode": "offline_conversation_fixture",
+  "instructions": "Treat the eval prompt as the user's reply to the prior applicability question.",
+  "representativeVariables": {"service_name": "checkoutservice"},
+  "draft": {
+    "variable": {
+      "mapKey": "service_name",
+      "name": "service_name",
+      "type": "DYNAMIC",
+      "dynamicVariablesAttribute": "service.name",
+      "dynamicVariablesSource": "Traces"
+    },
+    "panels": [
+      {
+        "id": "request-rate",
+        "title": "Request Rate by Service",
+        "query": {
+          "queryType": "builder",
+          "builder": {
+            "queryData": [{"queryName": "A", "dataSource": "traces", "expression": "A", "aggregations": [{"expression": "count()"}], "filter": {"expression": ""}, "groupBy": [{"key": "service.name", "type": "resource", "dataType": "string"}]}],
+            "queryFormulas": []
+          }
+        }
+      },
+      {
+        "id": "p99-latency",
+        "title": "P99 Latency by Service",
+        "query": {
+          "queryType": "builder",
+          "builder": {
+            "queryData": [{"queryName": "A", "dataSource": "traces", "expression": "A", "aggregations": [{"expression": "p99(duration_nano)"}], "filter": {"expression": ""}, "groupBy": [{"key": "service.name", "type": "resource", "dataType": "string"}]}],
+            "queryFormulas": []
+          }
+        }
+      },
+      {
+        "id": "global-health",
+        "title": "Global System Health",
+        "query": {
+          "queryType": "builder",
+          "builder": {
+            "queryData": [{"queryName": "A", "dataSource": "traces", "expression": "A", "aggregations": [{"expression": "count()"}], "filter": {"expression": "has_error = true"}, "groupBy": []}],
+            "queryFormulas": []
+          }
+        }
+      }
+    ]
+  },
+  "dryRunResponses": [
+    {"panelId": "request-rate", "response": {"isError": false, "rows": 2}},
+    {"panelId": "p99-latency", "response": {"isError": false, "rows": 2}},
+    {"panelId": "global-health", "response": {"isError": false, "rows": 1}}
+  ],
+  "priorAgentQuestion": "Apply service_name to all panels, or choose a subset?"
+}

--- a/plugins/signoz/skills/signoz-modifying-dashboards/SKILL.md
+++ b/plugins/signoz/skills/signoz-modifying-dashboards/SKILL.md
@@ -18,7 +18,9 @@ description: >
 ## Prerequisites
 
 This skill calls SigNoz MCP server tools (`signoz_get_dashboard`,
-`signoz_update_dashboard`, `signoz_list_dashboards`, `signoz_list_metrics`).
+`signoz_update_dashboard`, `signoz_list_dashboards`, `signoz_list_metrics`,
+`signoz_get_field_keys`, `signoz_get_field_values`,
+`signoz_execute_builder_query`).
 Before running the workflow, confirm the `signoz_*` tools are available.
 If they are not, the SigNoz MCP server is not installed or configured —
 run `signoz-mcp-setup` first to initialize or repair the MCP connection. Do not
@@ -38,21 +40,16 @@ Use this skill when the user asks to:
 
 Do NOT use when:
 - User wants to understand what a dashboard shows → `signoz-explaining-dashboards`
+- User wants to create a new dashboard → `signoz-creating-dashboards`
 
 ## Instructions
 
 ### Step 1: Identify the target dashboard
 
-Determine which dashboard the user wants to modify. If the user provides a
-dashboard name, UUID, or it is clear from context (e.g., an @mention or auto-context
-providing a dashboard resource), use that.
-
-If the target dashboard is ambiguous:
-1. Call `signoz_list_dashboards` to list existing dashboards. **Paginate through
-   all pages** — check `pagination.hasMore` in the response. If `hasMore` is true,
-   call again with `offset` set to `pagination.nextOffset` and repeat until all
-   pages are exhausted. Never stop at the first page.
-2. Present matching candidates to the user and ask which one to modify.
+Use a UUID supplied directly or by dashboard resource context. A name is not an
+ID: resolve every name-only request with `signoz_list_dashboards`, paginating via
+`pagination.nextOffset` while `pagination.hasMore` is true. If multiple dashboards
+match, present them and ask which one to modify; if one matches, use its UUID.
 
 ### Step 2: Fetch the current dashboard state
 
@@ -84,9 +81,9 @@ Based on the user's request, plan the changes.
 permanently — OK?") takes seconds and prevents irreversible mistakes. User urgency
 does not override this guardrail.
 
-**Non-destructive changes proceed directly:** renaming, adding a single panel,
-changing a unit, adding a variable, changing panel type (the query is preserved),
-adjusting layout, adding thresholds.
+**Non-destructive changes need no destructive confirmation:** renaming, adding a
+panel or variable, changing a unit or panel type, adjusting layout, and adding
+thresholds. Variable additions still require the panel-applicability prompt below.
 
 **Compound modifications:** When a request involves multiple changes (e.g., remove a
 panel + add a panel + rename), plan all changes against the fetched state and apply
@@ -98,34 +95,34 @@ Merge the planned changes into the full dashboard JSON from Step 2.
 
 **Modification rules:**
 
-- **Preserve everything you are not changing.** Copy the entire dashboard object
-  and only modify the specific fields the user asked about. Do not drop widgets,
-  variables, layout items, or panelMap entries that are not part of the change.
+- **Preserve supported mutable state.** Copy the fetched dashboard, change only
+  what the user requested, and compare semantics after MCP normalization. Do not
+  drop unrelated widgets, variables, layout items, or panelMap entries.
+
+- **Read schemas before every update.** Read all required and applicable
+  conditional resources named by `signoz_update_dashboard`. For Query Builder,
+  also read `signoz://metrics-aggregation-guide`,
+  `signoz://traces/query-builder-guide`, or
+  `signoz://logs/query-builder-guide` for the signal. MCP is the source of truth.
 
 - **Adding a panel:**
-  1. Create a new widget with a UUID for its `id` (use `crypto.randomUUID()` format).
-  2. Include **all** required widget fields: `id`, `title`, `description`,
-     `panelTypes`, `query`, `opacity` ("1"), `nullZeroValues` ("zero"),
-     `timePreferance` ("GLOBAL_TIME" — note the deliberate misspelling),
-     `stepSize` (60), `yAxisUnit`, `isStacked` (false), `fillSpans` (false),
-     `isLogScale` (false), `mergeAllActiveQueries` (false), `thresholds` ([]),
-     `softMin` (0), `softMax` (0), `legendPosition` ("bottom"), `columnUnits` ({}),
-     `customLegendColors` ({}), `selectedLogFields` ([]), `selectedTracesFields`
-     ([]), `contextLinks` ({"linksData": []}).
-  3. Add a layout entry with `i` matching the widget ID, and appropriate `x`, `y`,
-     `w`, `h` values in the 12-column grid.
-  4. If the dashboard uses rows, add the panel's layout to the appropriate row's
-     `panelMap[rowId].widgets` array. If the dashboard has no rows (empty
-     `panelMap`), skip panelMap — the panel lives at the top level.
-  5. For query construction, read the `signoz://dashboard/query-builder-example`
-     MCP resource for the v5 builder query format. Use the signal-specific
-     resources as needed (`signoz://dashboard/promql-example`,
-     `signoz://dashboard/clickhouse-*`, `signoz://traces/query-builder-guide`).
-  6. All modified panels are validated below as a hard requirement —
+  1. Build the widget from `signoz://dashboard/widgets-examples`, with a UUID for
+     its `id`.
+  2. Detect rows from `widgets[].panelTypes == "row"`. Unless side-by-side
+     placement is explicit, append at `x: 0`, `y: max(y + h)` only when rowless
+     or targeting the final row. For an earlier row, insert the widget and layout
+     before the next row at `x: 0`, `y: <next row's old y>` (the target row's
+     current bottom), then shift that row and all later top-level and `panelMap`
+     `y` positions down by the new panel's height.
+  3. Add a layout entry whose `i` matches the widget ID and obeys the bounds below.
+     If rows exist, add it to the intended row's `panelMap[rowId].widgets`,
+     creating that entry when absent. An empty `panelMap` does not prove the
+     dashboard is rowless.
+  4. All modified panels are validated below as a hard requirement —
      see the "Dry-run modified panels" step before
      `signoz_update_dashboard` and the "Mandatory dry-run
-     before update" guardrail. Author the JSON here as you intend to
-     save it — the dry-run uses the exact shape from `queryData`.
+     before update" guardrail. Author the saved query semantics first, then use
+     the lossless dry-run translation below.
 
 - **Removing a panel:** Remove the widget from `widgets`, its entry from `layout`,
   and its entry from the parent row's `panelMap.widgets` (if it exists in panelMap).
@@ -142,22 +139,24 @@ Merge the planned changes into the full dashboard JSON from Step 2.
   change the user will only notice after the panel goes empty.
 
 - **Changing panel type:** Update `panelTypes` and handle type-specific fields:
-  - `graph` → `table`: add `columnUnits` ({}) and `columnWidths` ({}) if missing.
-    Graph-only fields like `isStacked`, `fillSpans`, `isLogScale` become inert but
-    are harmless to leave.
-  - `graph`/`table` → `histogram`: add `bucketCount` (30) and `bucketWidth` (0).
-  - Any → `list` (logs): add `selectedLogFields` array.
-  - Any → `list` (traces): add `selectedTracesFields` array.
-  - Keep the existing query intact — the data source and query are independent of
-    the visualization type.
+  follow the target type's complete shape in `widgets-examples`. Preserve the
+  existing query and data source; change only visualization-specific fields.
 
-- **Adding/editing variables:** Add or update entries in the `variables` map. Use
-  OTel attribute names for the underlying attribute (e.g., `service.name`,
-  `deployment.environment.name`). Use DYNAMIC type when the values come from a
-  standard telemetry attribute. Each variable needs a UUID for `id` and `key`.
+- **Adding/editing variables:**
+  1. For ambiguous or version-sensitive attributes, call `signoz_get_field_keys`
+     and optionally `signoz_get_field_values` with the relevant signal and
+     `fieldContext=resource`. Trust the discovered key (for example,
+     `deployment.environment` versus `deployment.environment.name`).
+  2. Show the panel list and ask whether the variable applies to all panels or a
+     selected subset.
+  3. Use a DYNAMIC variable for an attribute-backed dropdown, with a UUID `id`.
+     Keep its human-readable variables-map key and `name` identical.
+  4. Add `$<key>` only to the selected panel filters, preserve unselected panels,
+     and dry-run every query changed by the variable.
 
 - **Rearranging layout / side-by-side placement:**
-  - Dashboard uses a **12-column grid**. `x` ranges 0–11, `w` ranges 1–12.
+  - SigNoz uses a **12-column grid**, never 24: every entry must satisfy
+    `0 <= x < 12`, `1 <= w <= 12`, and `x + w <= 12`.
   - Two panels side-by-side: each gets `w: 6`, first at `x: 0`, second at `x: 6`,
     same `y` and `h`.
   - Three panels in a row: `w: 4` at `x: 0`, `x: 4`, `x: 8`.
@@ -169,21 +168,14 @@ Merge the planned changes into the full dashboard JSON from Step 2.
     top-level `layout` array, apply the same change to the matching entry in
     `panelMap[rowId].widgets`. These are duplicated and must stay consistent.
 
-**Dry-run modified panels (mandatory).** Before
-`signoz_update_dashboard`, call
-`signoz_execute_builder_query` for each modified panel.
-Translate the widget's `builder.queryData[]` / `queryFormulas[]` into
-the endpoint's `queries[].{type, spec}` envelope: each `queryData[i]`
-→ `{ type: "builder_query", spec: { name, signal, filter:
-{expression}, groupBy, aggregations } }`; each `queryFormulas[i]` →
-`{ type: "builder_formula", spec: { name, expression } }`. **Preserve
-the original `name`** (`A`, `B`, …) on every `builder_query.spec` —
-formula expressions reference inputs by that name (e.g., `A * 100 /
-B`), and dropping it makes the dry-run diverge from the saved panel.
-The endpoint cannot consume widget JSON directly. See the "Mandatory
-dry-run before update" guardrail for the conditions, the bool-filter
-footgun, and why this catches what the JSON diff cannot. Server
-error or unexpected empty result = fix the panel JSON before update.
+**Dry-run modified panels (mandatory).** Before `signoz_update_dashboard`, call
+`signoz_execute_builder_query` for each modified query-bearing panel. Build its
+complete payload from the current tool schema; do not pass widget JSON. Translate
+the active Builder, PromQL, or ClickHouse query losslessly into its matching
+envelope, preserving every semantic field and query name (`A`, `B`, `F1`, etc.).
+Supply representative values for referenced dashboard variables. A server error
+or unexpected empty result must be fixed before update, unless the user explicitly
+accepted confirmed missing telemetry.
 
 Call `signoz_update_dashboard` with the dashboard UUID and the **complete** modified
 dashboard JSON.
@@ -199,9 +191,9 @@ Briefly tell the user what was changed. Offer further modifications if relevant.
   to get the current state, merge your changes into that full object, and pass
   the result to `signoz_update_dashboard`. Never construct an update payload from
   scratch.
-- **Preserve what you don't change**: Never drop or overwrite widgets, variables,
-  layout items, or panelMap entries that are outside the scope of the user's request.
-  Diff-and-merge, do not rebuild.
+- **Preserve what you don't change**: Preserve supported mutable semantics for
+  widgets, variables, layout, and panelMap outside the request. Diff-and-merge;
+  do not rebuild or promise byte-for-byte equality after MCP normalization.
 - **Confirm destructive changes**: Before removing panels, replacing queries, or
   deleting variables, confirm with the user — even if they say "just do it" or
   express urgency. Additions, renames, type changes, and variable additions do not
@@ -217,24 +209,22 @@ Briefly tell the user what was changed. Offer further modifications if relevant.
   attribute swap is the worst failure mode for this skill.
 - **Valid JSON only**: Follow the v5 schema documented in the
   `signoz://dashboard/*` MCP resources (`instructions`, `widgets-instructions`,
-  `widgets-examples`, `query-builder-example`). Include all required widget
-  fields (see "Adding a panel" above). Never generate malformed queries or
-  layouts.
-- **OTel attribute names**: Always use OpenTelemetry semantic conventions for
-  attribute names in filters, groupBy, and variables. Use `service.name` not
-  `service`, `host.name` not `host`, `deployment.environment.name` not `env`.
+  `widgets-examples`, `query-builder-example`). Never generate malformed queries
+  or layouts.
+- **OTel attribute names**: Use `service.name` not `service` and `host.name` not
+  `host`, but discover version-sensitive keys such as `deployment.environment`
+  versus `deployment.environment.name` instead of forcing one form.
 - **No metric guessing**: If adding or changing queries and you are not sure what
   metrics are available, ask the user or call `signoz_list_metrics` to discover
   available metrics. Wrong metric names produce empty panels.
 - **Paginate dashboard listing**: When searching for a dashboard by name, always
   paginate through all pages of `signoz_list_dashboards` before concluding a
   dashboard does not exist.
-- **UUIDs for new objects**: Every new widget, layout item, variable, and query
-  needs a unique UUID (`crypto.randomUUID()` format). Never use sequential IDs
-  or short strings.
-- **Scope boundary**: This skill modifies existing dashboards. To create a new
-  dashboard from scratch, point the user at the SigNoz dashboard editor in the
-  UI — there is no creation skill in this plugin yet.
+- **Identifiers**: Use UUIDs for new widget and variable IDs. Reuse the widget ID
+  as `layout.i`; keep each variable map key identical to its human-readable `name`,
+  and keep query names such as `A`, `B`, and `F1` stable.
+- **Scope boundary**: This skill modifies existing dashboards. Hand new-dashboard
+  requests to `signoz-creating-dashboards`.
 
 ## Examples
 
@@ -247,10 +237,12 @@ Briefly tell the user what was changed. Offer further modifications if relevant.
    8 existing panels.
 3. Calls `signoz_list_metrics` to find available Redis error metrics.
 4. Creates a new graph widget (with UUID, all required fields, and a formula query
-   for error rate), adds a layout entry at the next available `y` position, and
-   adds it to the appropriate row's `panelMap`.
-5. Calls `signoz_update_dashboard` with the full modified JSON (all 9 panels).
-6. Reports: "Added an 'Error Rate' graph panel to your Redis Overview dashboard
+   for error rate), appends it below the current layout, and adds it to the
+   appropriate row's `panelMap`.
+5. Dry-runs the new panel with `signoz_execute_builder_query`; fixes any error or
+   unexpected empty result.
+6. Calls `signoz_update_dashboard` with the full modified JSON (all 9 panels).
+7. Reports: "Added an 'Error Rate' graph panel to your Redis Overview dashboard
    under the Overview section. Want me to adjust anything?"
 
 ---
@@ -258,11 +250,12 @@ Briefly tell the user what was changed. Offer further modifications if relevant.
 **User:** "Change the latency panel from a graph to a table on my API dashboard"
 
 **Agent:**
-1. Identifies "API Monitoring" dashboard from context, calls `signoz_get_dashboard`.
+1. Resolves "API Monitoring" through paginated `signoz_list_dashboards`, then calls
+   `signoz_get_dashboard` with its UUID.
 2. Finds the panel titled "Request Latency" — if multiple panels could match,
    confirms with user: "I found 'Request Latency'. Convert that one to a table?"
-3. Changes `panelTypes` from `"graph"` to `"table"`, adds `columnUnits` and
-   `columnWidths` if missing, keeps the query intact.
+3. Changes `panelTypes` from `"graph"` to `"table"`, matches the table shape in
+   `widgets-examples`, and keeps the query intact.
 4. Calls `signoz_update_dashboard` with the full modified JSON (all panels
    preserved).
 5. Reports: "Changed 'Request Latency' from a graph to a table. Want me to adjust
@@ -280,7 +273,7 @@ Briefly tell the user what was changed. Offer further modifications if relevant.
 3. User confirms.
 4. Removes the widget from `widgets`, its layout entry, and its panelMap reference.
    Leaves all other panel positions unchanged (the frontend grid closes gaps
-   automatically). Updates `title` and `name` to "Service Health".
+   automatically). Updates `title` to "Service Health".
 5. Calls `signoz_update_dashboard` with the full modified JSON.
 6. Reports: "Removed the 'CPU Usage' panel and renamed the dashboard to 'Service
    Health'. Anything else to adjust?"

--- a/plugins/signoz/skills/signoz-modifying-dashboards/evals/evals.json
+++ b/plugins/signoz/skills/signoz-modifying-dashboards/evals/evals.json
@@ -3,27 +3,31 @@
   "evals": [
     {
       "id": 0,
-      "name": "add-panel-to-existing-dashboard",
-      "prompt": "Add a panel showing p99 latency by service to my 'API Monitoring' dashboard. Group by service.name.",
-      "expected_output": "Agent paginates list_dashboards to find 'API Monitoring', fetches it, builds a new graph widget with all required fields and a UUID, places it in the layout (and panelMap if rows exist), preserves all existing panels/variables, and calls update_dashboard with the full state.",
+      "eval_name": "add-panel-to-existing-dashboard",
+      "prompt": "Add a traces panel showing p99 latency by service to my 'API Monitoring' dashboard. Group by service.name.",
+      "expected_output": "Agent resolves 'API Monitoring' to a UUID by paginating dashboard results, fetches it, reads the required dashboard and traces query resources, builds a complete graph widget with a UUID, appends it within the 12-column layout, preserves supported non-target state, and dry-runs the exact query before preparing the full update.",
       "files": [],
-      "assertions": [
+      "expectations": [
         "Updated dashboard has exactly one more widget than original",
-        "New widget has all required v5 fields",
+        "Agent reads the three required dashboard resources plus signoz://dashboard/query-builder-example and signoz://traces/query-builder-guide before authoring the widget",
+        "New widget includes id, panelTypes, title, query, selectedLogFields, selectedTracesFields, thresholds, and contextLinks",
+        "New widget query includes queryType and the complete active Builder payload required by the MCP resources; inactive query payloads need not be authored",
         "New widget's id is a valid UUID",
         "New widget's query uses 'service.name' (OTel naming) in groupBy, not 'service'",
         "Layout has one new entry whose 'i' matches the new widget's id",
-        "All original widgets and variables remain present and unchanged",
+        "When rows exist, the new widget appears exactly once in the intended panelMap row and its x, y, w, h match the top-level layout entry",
+        "All supported non-target widget and variable semantics remain present",
+        "Agent calls signoz_execute_builder_query for the new panel before preparing or calling signoz_update_dashboard, and the translated builder query retains its name A",
         "Agent did not call signoz_update_dashboard (read-only eval constraint respected)"
       ]
     },
     {
       "id": 1,
-      "name": "remove-panel-destructive-confirm",
+      "eval_name": "remove-panel-destructive-confirm",
       "prompt": "Get rid of the memory fragmentation widget on my Redis dashboard, just do it quickly.",
       "expected_output": "Despite 'just do it quickly', agent confirms the deletion before applying. On confirmation, removes widget from widgets[], layout entry, and panelMap entry. Leaves other y positions untouched.",
       "files": [],
-      "assertions": [
+      "expectations": [
         "Transcript contains an explicit confirmation question before deletion (despite user's 'just do it quickly')",
         "Updated dashboard has exactly one fewer widget than original",
         "Removed widget's id is absent from widgets[], layout[], and panelMap[*].widgets",
@@ -33,14 +37,15 @@
     },
     {
       "id": 2,
-      "name": "panel-type-graph-to-table",
+      "eval_name": "panel-type-graph-to-table",
       "prompt": "Change the 'Request Latency' panel on my API dashboard from a graph to a table.",
-      "expected_output": "Non-destructive: proceeds without confirmation. Updates panelTypes from 'graph' to 'table', adds columnUnits ({}) and columnWidths ({}) if missing, keeps the query and other widget fields intact, preserves all other panels.",
+      "expected_output": "Non-destructive: proceeds without confirmation. Updates panelTypes from 'graph' to 'table', matches the complete table shape in widgets-examples, keeps the query intact, and preserves all other panels.",
       "files": [],
-      "assertions": [
+      "expectations": [
+        "Agent reads signoz://dashboard/widgets-examples for the target table shape",
         "Target widget's panelTypes is 'table' in updated, was 'graph' in original",
-        "Target widget retains the same query object (deep-equal to original)",
-        "Target widget has both columnUnits and columnWidths keys present",
+        "Target widget retains semantically equivalent active query data, filters, groupings, and query names after normalization",
+        "Target widget matches the complete table shape from signoz://dashboard/widgets-examples",
         "Widget count is identical between original and updated (no add/remove)",
         "Transcript shows no confirmation prompt — non-destructive change proceeded directly",
         "Agent did not call signoz_update_dashboard (read-only eval constraint respected)"
@@ -48,28 +53,29 @@
     },
     {
       "id": 3,
-      "name": "compound-add-rename-remove",
+      "eval_name": "compound-add-rename-remove",
       "prompt": "On my 'Service Health' dashboard: rename it to 'Service Health (Production)', remove the CPU Usage panel, and add an Error Rate panel grouped by service.name. Use OTel attribute names.",
       "expected_output": "Agent fetches the dashboard once, plans all three changes against that single state, confirms the destructive removal, and applies all three as a single update. Uses service.name. Preserves untouched widgets/variables/panelMap entries.",
       "files": [],
-      "assertions": [
+      "expectations": [
         "Transcript shows a single confirmation prompt covering the destructive removal of CPU Usage",
-        "Dashboard title (or name) is updated to 'Service Health (Production)'",
+        "Dashboard title is updated to 'Service Health (Production)'",
         "CPU Usage widget is absent from widgets[], layout[], and panelMap",
         "A new Error Rate widget is present with all required v5 fields and groupBy contains 'service.name'",
         "Net widget count equals original count (one removed, one added)",
+        "Agent dry-runs the new Error Rate panel with a lossless full payload that preserves query names A, B, and F1 before preparing the update",
         "Transcript indicates a single planned update_dashboard call (changes batched, not iterative)",
-        "All non-target widgets, variables, and panelMap entries preserved unchanged",
+        "All supported non-target widget, variable, and panelMap semantics are preserved",
         "Agent did not call signoz_update_dashboard (read-only eval constraint respected)"
       ]
     },
     {
       "id": 4,
-      "name": "side-by-side-layout",
+      "eval_name": "side-by-side-layout",
       "prompt": "Put the 'CPU' and 'Memory' panels on my host overview dashboard side by side at the top.",
       "expected_output": "Agent moves both panels to same y, w:6 each, x:0 and x:6, equal h. Updates panelMap[rowId].widgets entries to match layout. Preserves rest of dashboard.",
       "files": [],
-      "assertions": [
+      "expectations": [
         "CPU and Memory widgets in layout[] both have w == 6",
         "Their x values are {0, 6} (one each, in some order)",
         "Their y values are equal",
@@ -81,16 +87,100 @@
     },
     {
       "id": 5,
-      "name": "add-environment-variable",
-      "prompt": "Add a deployment environment dropdown variable to my Kafka dashboard so I can filter by env.",
-      "expected_output": "Agent adds a DYNAMIC variable for deployment.environment.name with UUID id and key, valid v5 structure, preserves existing variables, panels, and layout.",
+      "eval_name": "add-environment-variable",
+      "prompt": "Add a deployment environment dropdown to my Kafka dashboard so I can filter it by environment.",
+      "expected_output": "Agent fetches the dashboard, discovers whether the live attribute is deployment.environment or deployment.environment.name, optionally confirms values, lists the current panels, and asks whether the variable should apply to all or a subset. It stops before wiring filters or preparing an update.",
       "files": [],
-      "assertions": [
+      "expectations": [
+        "Agent calls signoz_get_field_keys with the relevant signal and fieldContext=resource and may confirm the chosen key with signoz_get_field_values using the same context",
+        "Agent lists the dashboard panels and asks which should use the variable before changing panel filters",
+        "Agent does not add a variable reference to any panel or call signoz_execute_builder_query before the user answers",
+        "Agent did not call signoz_update_dashboard (read-only eval constraint respected)"
+      ]
+    },
+    {
+      "id": 6,
+      "eval_name": "add-panel-below-full-width-grid-regression",
+      "prompt": "My 'API Monitoring' dashboard has an Overview section with exactly one panel: a full-width Overview panel at x:0, y:0, w:12, h:6. Add a p99 latency panel to that section without rearranging the existing panel.",
+      "expected_output": "Agent fetches the complete row-bearing dashboard, leaves the full-width panel unchanged, and adds the p99 panel below it at x:0 and y equal to the maximum y+h from the fetched layout, with a width that keeps x+w within the 12-column grid. It adds the matching layout object to the Overview panelMap row and never assumes a 24-column grid.",
+      "files": [],
+      "expectations": [
+        "Existing Overview panel remains at x:0, y:0, w:12, h:6",
+        "New panel is placed at x:0 and y equals max(y+h) from the fetched layout before the new entry is added",
+        "Every entry in layout[] satisfies 0 <= x < 12, 1 <= w <= 12, and x+w <= 12",
+        "The new panel appears exactly once in the Overview panelMap row and its x, y, w, h matches its top-level layout entry",
+        "Every duplicated panelMap layout entry satisfies the same horizontal bounds and matches its top-level x, y, w, h",
+        "Agent successfully dry-runs the new p99 panel with signoz_execute_builder_query before preparing the update",
+        "Agent did not call signoz_update_dashboard (read-only eval constraint respected)"
+      ]
+    },
+    {
+      "id": 7,
+      "eval_name": "target-dashboard-on-second-page",
+      "prompt": "Add an error-rate panel to my 'Payments API' dashboard.",
+      "expected_output": "In an offline simulated tool trace using the attached fixture, the first signoz_list_dashboards response has hasMore=true and no match. Agent follows pagination.nextOffset, finds Payments API there, fetches it, and only then plans the modification.",
+      "files": ["evals/files/target-on-second-page.json"],
+      "expectations": [
+        "Agent does not conclude Payments API is missing after the first page",
+        "The simulated trace invokes signoz_list_dashboards again with offset equal to pagination.nextOffset using an accepted integer or string value",
+        "The simulated trace invokes signoz_get_dashboard only for the second-page Payments API match",
+        "Agent did not call signoz_update_dashboard (read-only eval constraint respected)"
+      ]
+    },
+    {
+      "id": 8,
+      "eval_name": "creation-request-handoff",
+      "prompt": "Actually, do not change this dashboard. Create a fresh dashboard for the payments service instead.",
+      "expected_output": "Agent hands the request to signoz-creating-dashboards with the user's intent and does not direct the user to the UI or call update_dashboard.",
+      "files": [],
+      "expectations": [
+        "Agent routes to signoz-creating-dashboards",
+        "Agent does not claim that dashboard creation is unavailable in the plugin",
+        "Agent does not call signoz_update_dashboard"
+      ]
+    },
+    {
+      "id": 9,
+      "eval_name": "dry-run-failure-blocks-update",
+      "prompt": "Add an Error Rate panel to my Service Health dashboard.",
+      "expected_output": "In an offline simulated tool trace using the attached fixture, agent treats the dry-run validation failure as blocking, fixes and re-runs the query when possible or reports it, and never prepares or executes update_dashboard with the failed panel.",
+      "files": ["evals/files/dry-run-validation-error.json"],
+      "expectations": [
+        "Agent does not ignore or downplay the dry-run error",
+        "Agent either corrects and successfully re-runs the exact panel query or stops with the failure explained",
+        "Agent does not call signoz_update_dashboard with a panel whose dry-run failed"
+      ]
+    },
+    {
+      "id": 10,
+      "eval_name": "apply-environment-variable-to-selected-panels",
+      "prompt": "Apply it to Consumer Lag and Throughput, but leave Broker Health global.",
+      "expected_output": "Using the prior-turn fixture, agent reads the required dashboard and metrics-query resources, adds a DYNAMIC deployment_environment variable whose UUID id is distinct from its human-readable map key/name, wires $deployment_environment only into Consumer Lag and Throughput, and produces offline simulated dry-runs with the representative value. It prepares the full supported state but does not update a live dashboard.",
+      "files": ["evals/files/environment-variable-scope-context.json"],
+      "expectations": [
+        "Agent reads the required dashboard resources plus signoz://dashboard/query-builder-example and signoz://metrics-aggregation-guide",
         "variables map in updated has exactly one more entry than original",
-        "New variable's type is 'DYNAMIC'",
-        "New variable's underlying attribute is 'deployment.environment.name' (not 'env', 'environment', or 'deployment.environment')",
-        "New variable has UUID-shaped id and key",
-        "Existing variables, widgets, and layout are untouched",
+        "New variable is DYNAMIC and uses the discovered deployment.environment attribute",
+        "New variable has a UUID-shaped id and its map key and name are both deployment_environment",
+        "Consumer Lag and Throughput filters reference $deployment_environment, while Broker Health does not",
+        "The simulated trace successfully dry-runs both complete changed queries with deployment_environment=prod",
+        "Existing variables, layout, Broker Health, and all unrelated supported state remain semantically unchanged",
+        "Agent did not call signoz_update_dashboard (read-only eval constraint respected)"
+      ]
+    },
+    {
+      "id": 11,
+      "eval_name": "add-panel-to-non-final-row",
+      "prompt": "Add an Error Rate panel to the Overview section of my Service Health dashboard.",
+      "expected_output": "Using the fetched-layout fixture, agent reads the required widget and traces query resources, simulates inserting the supplied six-row-high panel before Capacity at x:0,y:7, shifts Capacity and later content down by six, updates panelMap membership/coordinates, and produces the offline simulated dry-run without assembling a live update.",
+      "files": ["evals/files/non-final-row-dashboard.json"],
+      "expectations": [
+        "Agent reads the required dashboard resources plus signoz://dashboard/query-builder-example and signoz://traces/query-builder-guide",
+        "The new widget and layout entry occur after Request Rate and before the Capacity row rather than at the end",
+        "The new layout is x:0,y:7,h:6 and satisfies x+w <= 12",
+        "Capacity moves from y:7 to y:13 in top-level layout; CPU moves from y:8 to y:14 in both top-level layout and panelMap",
+        "Overview panelMap contains Request Rate and the new Error Rate panel only; Capacity panelMap still contains CPU only",
+        "The simulated trace successfully dry-runs the supplied complete Error Rate query before accepting the mutation plan",
         "Agent did not call signoz_update_dashboard (read-only eval constraint respected)"
       ]
     }

--- a/plugins/signoz/skills/signoz-modifying-dashboards/evals/files/dry-run-validation-error.json
+++ b/plugins/signoz/skills/signoz-modifying-dashboards/evals/files/dry-run-validation-error.json
@@ -1,0 +1,9 @@
+{
+  "mode": "offline_mcp_fixture",
+  "instructions": "Use this response to produce an offline simulated tool trace; do not query a live tenant.",
+  "response": {
+    "isError": true,
+    "code": "VALIDATION_FAILED",
+    "message": "query validation error: compositeQuery.queries[0].spec.filter.expression is invalid"
+  }
+}

--- a/plugins/signoz/skills/signoz-modifying-dashboards/evals/files/environment-variable-scope-context.json
+++ b/plugins/signoz/skills/signoz-modifying-dashboards/evals/files/environment-variable-scope-context.json
@@ -1,0 +1,43 @@
+{
+  "mode": "offline_conversation_fixture",
+  "instructions": "Treat the eval prompt as the user's reply to the prior applicability question.",
+  "dashboard": {
+    "uuid": "55555555-5555-4555-8555-555555555555",
+    "title": "Kafka",
+    "variables": {},
+    "panels": [
+      {
+        "id": "consumer-lag",
+        "title": "Consumer Lag",
+        "query": {"queryType": "builder", "builder": {"queryData": [{"queryName": "A", "dataSource": "metrics", "expression": "A", "aggregations": [{"metricName": "kafka.consumer_group.lag", "timeAggregation": "latest", "spaceAggregation": "max"}], "filter": {"expression": ""}, "groupBy": []}], "queryFormulas": []}}
+      },
+      {
+        "id": "throughput",
+        "title": "Throughput",
+        "query": {"queryType": "builder", "builder": {"queryData": [{"queryName": "A", "dataSource": "metrics", "expression": "A", "aggregations": [{"metricName": "kafka.consumer_group.messages", "timeAggregation": "rate", "spaceAggregation": "sum"}], "filter": {"expression": ""}, "groupBy": []}], "queryFormulas": []}}
+      },
+      {
+        "id": "broker-health",
+        "title": "Broker Health",
+        "query": {"queryType": "builder", "builder": {"queryData": [{"queryName": "A", "dataSource": "metrics", "expression": "A", "aggregations": [{"metricName": "kafka.broker.active", "timeAggregation": "latest", "spaceAggregation": "sum"}], "filter": {"expression": ""}, "groupBy": []}], "queryFormulas": []}}
+      }
+    ],
+    "layout": [
+      {"i": "consumer-lag", "x": 0, "y": 0, "w": 6, "h": 6},
+      {"i": "throughput", "x": 6, "y": 0, "w": 6, "h": 6},
+      {"i": "broker-health", "x": 0, "y": 6, "w": 12, "h": 3}
+    ],
+    "panelMap": {}
+  },
+  "discovery": {
+    "signal": "metrics",
+    "fieldContext": "resource",
+    "attribute": "deployment.environment",
+    "representativeValue": "prod"
+  },
+  "dryRunResponses": [
+    {"panelId": "consumer-lag", "response": {"isError": false, "rows": 1}},
+    {"panelId": "throughput", "response": {"isError": false, "rows": 1}}
+  ],
+  "priorAgentQuestion": "Apply the environment variable to all panels, or choose a subset: Consumer Lag, Throughput, Broker Health?"
+}

--- a/plugins/signoz/skills/signoz-modifying-dashboards/evals/files/non-final-row-dashboard.json
+++ b/plugins/signoz/skills/signoz-modifying-dashboards/evals/files/non-final-row-dashboard.json
@@ -1,0 +1,40 @@
+{
+  "mode": "offline_mcp_fixture",
+  "instructions": "Treat this as the relevant fetched layout excerpt and simulate the transformation offline; do not assemble or call a live update.",
+  "dashboard": {
+    "uuid": "66666666-6666-4666-8666-666666666666",
+    "title": "Service Health",
+    "widgets": [
+      {"id": "row-overview", "panelTypes": "row", "title": "Overview"},
+      {"id": "request-rate", "panelTypes": "graph", "title": "Request Rate"},
+      {"id": "row-capacity", "panelTypes": "row", "title": "Capacity"},
+      {"id": "cpu", "panelTypes": "graph", "title": "CPU"}
+    ],
+    "layout": [
+      {"i": "row-overview", "x": 0, "y": 0, "w": 12, "h": 1},
+      {"i": "request-rate", "x": 0, "y": 1, "w": 12, "h": 6},
+      {"i": "row-capacity", "x": 0, "y": 7, "w": 12, "h": 1},
+      {"i": "cpu", "x": 0, "y": 8, "w": 12, "h": 6}
+    ],
+    "panelMap": {
+      "row-overview": {"widgets": [{"i": "request-rate", "x": 0, "y": 1, "w": 12, "h": 6}]},
+      "row-capacity": {"widgets": [{"i": "cpu", "x": 0, "y": 8, "w": 12, "h": 6}]}
+    }
+  },
+  "proposedPanel": {
+    "id": "77777777-7777-4777-8777-777777777777",
+    "panelTypes": "graph",
+    "title": "Error Rate",
+    "query": {
+      "queryType": "builder",
+      "builder": {
+        "queryData": [
+          {"queryName": "A", "dataSource": "traces", "expression": "A", "disabled": true, "aggregations": [{"expression": "count()"}], "filter": {"expression": "has_error = true"}, "groupBy": []},
+          {"queryName": "B", "dataSource": "traces", "expression": "B", "disabled": true, "aggregations": [{"expression": "count()"}], "filter": {"expression": ""}, "groupBy": []}
+        ],
+        "queryFormulas": [{"queryName": "F1", "expression": "A / B * 100"}]
+      }
+    }
+  },
+  "dryRunResponse": {"isError": false, "rows": 1}
+}

--- a/plugins/signoz/skills/signoz-modifying-dashboards/evals/files/target-on-second-page.json
+++ b/plugins/signoz/skills/signoz-modifying-dashboards/evals/files/target-on-second-page.json
@@ -1,0 +1,20 @@
+{
+  "mode": "offline_mcp_fixture",
+  "instructions": "Use these ordered responses to produce an offline simulated tool trace; do not query a live tenant.",
+  "responses": [
+    {
+      "request": {"limit": 50, "offset": 0},
+      "response": {
+        "data": [{"uuid": "33333333-3333-4333-8333-333333333333", "name": "Platform API"}],
+        "pagination": {"total": 51, "offset": 0, "limit": 50, "hasMore": true, "nextOffset": 50}
+      }
+    },
+    {
+      "request": {"limit": 50, "offset": 50},
+      "response": {
+        "data": [{"uuid": "44444444-4444-4444-8444-444444444444", "name": "Payments API"}],
+        "pagination": {"total": 51, "offset": 50, "limit": 50, "hasMore": false, "nextOffset": -1}
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Align dashboard creation and modification with the current MCP resource/tool contracts.
- Enforce the shared 12-column horizontal bound and exact `panelMap` coordinate parity.
- Make panel insertion safe for rowless, final-row, and non-final-row dashboards.
- Fix name-to-UUID lookup, resource selection, lossless Builder/PromQL/ClickHouse dry-runs, variable discovery/scope, identifiers, and creation handoff.
- Expand both eval suites with offline fixtures for later-page lookup, dry-run failures, variable follow-ups, and non-final-row insertion; update the creation eval coverage guide.

## Why

Issue SigNoz/nerve-pod#114 surfaced through dashboard modification, but the review found a shared grid invariant plus several create/modify workflow differences that could produce invalid, inert, or mis-grouped dashboards.

This addresses the **agent-skills layer** of SigNoz/nerve-pod#114.

## Validation

- Parsed both eval suites and all fixture JSON with `python3 -m json.tool`
- Checked required eval keys, unique IDs, and referenced fixture paths with `jq`
- `claude plugin validate --strict plugins/signoz`
- `git diff --check`
- Agent CI: no relevant workflows for this branch

## Review

Independent final passes covered:

- current SigNoz MCP dashboard/query contracts
- create/modify workflow parity and concision
- eval determinism, schema, fixtures, and coverage

No skill-side blockers remain.

## MCP-server follow-ups

These cannot be fixed in this repository/PR:

- dashboard update normalization drops some advertised fields, including `isStacked`, `minW`, `minH`, `maxH`, and `isDraggable`
- the generated dashboard input schema omits `panelMap`
- create/update tool descriptions still lack a universal `x + w <= 12` rule

This PR adds skill/eval guardrails without claiming those server defects are resolved.