### PR TITLE
fix(skills): align evals with MCP contracts

### DIFF
--- a/plugins/signoz/skills/signoz-creating-alerts/SKILL.md
+++ b/plugins/signoz/skills/signoz-creating-alerts/SKILL.md
@@ -210,16 +210,16 @@ For most user intents, the config is one of a small number of patterns:
 **Threshold `op` and `matchType` values.** v2alpha1 accepts the
 human-readable strings (`"above"`, `"on_average"`); the legacy numeric
 codes (`"1"`, `"3"`) are also accepted but harder to read in the UI. Prefer
-the words. **Anomaly rules only support `op: "above"`** — the engine
-already treats z-score breaches as two-sided when the threshold is
-positive, so `"above_or_below"` is rejected and unnecessary.
+the words. Use `op: "above"` for anomaly rules: the anomaly score is already
+an absolute deviation, so this detects both spikes and drops without an
+unsupported `"above_or_below"` operator.
 
 | Comparison | `op` | Evaluation behavior | `matchType` |
 |---|---|---|---|
 | above / exceeds / > | `"above"` | breach at any point | `"at_least_once"` |
 | below / under / < | `"below"` | breach for entire window | `"all_the_times"` |
-| equal / = | `"equals"` | average breaches | `"on_average"` |
-| not equal / != | `"not_equals"` | sum breaches | `"in_total"` |
+| equal / = | `"equal"` | average breaches | `"on_average"` |
+| not equal / != | `"not_equal"` | sum breaches | `"in_total"` |
 |  |  | last value breaches | `"last"` |
 
 **Defaults the skill applies (and surfaces in the preview):**
@@ -283,8 +283,13 @@ schema:
   and notification. The raw counts are intermediate, not the alert
   signal — forgetting this clutters the preview with three series and
   confuses the on-call engineer reading the notification.
-- **p99 latency:** threshold target is in **nanoseconds** (2s →
-  2000000000), `targetUnit: "ns"`.
+- **p99 latency:** the query emits nanoseconds, but express the threshold in
+  the user's unit (for example `target: 2`, `targetUnit: "s"`); SigNoz converts
+  it during evaluation.
+- **Low-traffic percentile guard:** put `count() > N` in the percentile
+  query's `having.expression` and set `stepInterval` to the requested bucket
+  size (for example, `60` for “per minute”). Do not invent comparison operators
+  inside a formula such as `A * (B >= N)`.
 - **Log volume spike:** prefer `groupBy: service.name` over a hard
   filter when the user said "any service" — groupBy provides the
   scoping AND keeps the notification useful per-service.
@@ -356,7 +361,8 @@ the dry-run so any threshold-driven severity changes (warning → critical)
 are settled before the user is asked to pick routing, and so we never
 create a notification channel inline for an alert that fails validation.
 
-1. Call `signoz_list_notification_channels` to enumerate existing channels.
+1. Call `signoz_list_notification_channels` and follow
+   `pagination.nextOffset` while `pagination.hasMore` is true.
 2. If the user named a channel ("send to slack-infra"), use it if it exists;
    if not, fall through.
 3. Otherwise present the user with two options:
@@ -438,7 +444,7 @@ does).
   `signoz_create_alert`. A never-firing alert is *worse* than no
   alert: it provides a false sense of safety.
 - **Threshold operators use canonical words** Prefer `op: "above"` /
-  `"below"` / `"equals"` / `"not_equals"`. Numeric codes (`"1"`–`"7"`)
+  `"below"` / `"equal"` / `"not_equal"`. Numeric codes (`"1"`–`"7"`)
   are accepted but discouraged — same goes for `matchType`
   (`"on_average"` / `"at_least_once"`, not `"3"` / `"1"`).
 - **Signal must match alertType** `signal: "logs"` requires

--- a/plugins/signoz/skills/signoz-creating-alerts/evals/evals.json
+++ b/plugins/signoz/skills/signoz-creating-alerts/evals/evals.json
@@ -26,14 +26,14 @@
       "id": 3,
       "eval_name": "anomaly-frontend-request-rate",
       "prompt": "set up anomaly detection for frontend service request rate — alert me if traffic suddenly drops or spikes versus normal patterns. slack #staging-alerts is fine.",
-      "expected_output": "METRIC_BASED_ALERT with anomaly_rule, algorithm=zscore, seasonality=daily or hourly. Uses signoz_calls_total or http.server.request.count metric filtered by service.name='frontend'. Threshold target ~3 (standard deviations), op='above' (anomaly_rule only accepts 'above'; canonical word form preferred over numeric codes). Skips the 'would have fired N times' breach count for anomaly alerts (Z-scores aren't comparable to raw breach counts) but still runs the mandatory signoz_execute_builder_query dry-run to verify the underlying query returns data.",
+      "expected_output": "METRIC_BASED_ALERT with anomaly_rule, algorithm=standard (z-score based), seasonality=daily or hourly. Uses signoz_calls_total or http.server.request.count metric filtered by service.name='frontend'. Threshold target ~3 standard deviations and op='above' because the anomaly score is absolute. Skips the 'would have fired N times' breach count for anomaly alerts but still runs the mandatory signoz_execute_builder_query dry-run to verify the underlying query returns data.",
       "files": []
     },
     {
       "id": 4,
       "eval_name": "formula-gated-p99-with-count-guard",
       "prompt": "alert me when paymentservice p99 latency exceeds 1 second, but ONLY when request count is above 50 per minute — don't want to be paged on low-traffic noise. critical severity, send to both #staging-alerts slack AND 'test pager send resolved' pagerduty.",
-      "expected_output": "TRACES_BASED_ALERT with three queries: A = p99(durationNano) on service.name='paymentservice', B = count() on same filter, F1 = numeric formula that gates p99 by traffic (e.g. F1 = A * (B >= 50) or similar gating expression — exact form depends on alert engine, but skill must explain the gating choice). selectedQueryName='F1'. Threshold target 1000000000 (ns) or appropriate unit, op='above' (canonical word form preferred over numeric codes), critical severity, both channels attached. Runs the mandatory signoz_execute_builder_query dry-run (envelope passes the three queries with names A, B, F1 — name preserved so the formula resolves) before save. Surfaces the gating logic clearly in the plain-language summary.",
+      "expected_output": "TRACES_BASED_ALERT with query A = p99(duration_nano) on service.name='paymentservice', stepInterval=60, and having.expression='count() > 50' to suppress low-traffic one-minute buckets. selectedQueryName='A'. Threshold target 1 with targetUnit='s', op='above', critical severity, and both channels attached. It does not invent a comparison inside a numeric formula. Runs the exact guarded query through signoz_execute_builder_query before save and explains the count guard in the preview.",
       "files": []
     }
   ]

--- a/plugins/signoz/skills/signoz-creating-alerts/references/examples.md
+++ b/plugins/signoz/skills/signoz-creating-alerts/references/examples.md
@@ -35,7 +35,7 @@ log-volume groupBy, and anomaly detection.
 2. `signoz_get_field_keys fieldContext=resource signal=traces` confirms
    `service.name`. `signoz_get_field_values` confirms `payments` exists.
 3. No existing payments error-rate alert.
-4. Builds formula alert: query A counts spans with `hasError = true` for
+4. Builds formula alert: query A counts spans with `has_error = true` for
    `service.name = 'payments'`, query B counts all spans for the same
    service, formula F1 = `A * 100 / B`, `selectedQueryName: "F1"`,
    threshold target 5, `targetUnit: "percent"`,
@@ -76,7 +76,7 @@ log-volume groupBy, and anomaly detection.
    `METRIC_BASED_ALERT` + `anomaly_rule`.
 2. `signoz_list_metrics searchText=duration` → finds
    `http.server.request.duration`.
-3. Builds: `anomaly_rule`, `algorithm=zscore`, `seasonality=daily`,
+3. Builds: `anomaly_rule`, `algorithm=standard` (z-score based), `seasonality=daily`,
    threshold target 3 (3 standard deviations), `op: "above"`,
    `matchType: "at_least_once"`.
 4. Channel: user picks slack-api.

--- a/plugins/signoz/skills/signoz-creating-dashboards/SKILL.md
+++ b/plugins/signoz/skills/signoz-creating-dashboards/SKILL.md
@@ -63,7 +63,7 @@ sensible defaults, but a few cannot be guessed:
 | Modify-or-create choice when duplicates exist | yes | ask the user (Step 2) |
 | Resource scope for custom builds (service / namespace / cluster) | yes for custom builds | discover via `signoz_get_field_keys` + `signoz_get_field_values`; fall back to a dashboard variable |
 | Specific metrics / signals for custom builds | inferred | derive from technology + MCP `signoz://dashboard/*` resources; surface in preview |
-| Default time range, refresh, layout | inferred | apply defaults (see "Defaults" below) |
+| Layout | inferred | apply defaults (see "Defaults" below) |
 
 If a required input is missing and cannot be discovered, **stop before
 calling any write tool** and ask the user. The host application decides
@@ -341,6 +341,12 @@ Follow the v5 schema as documented in the resources above. Use OTel
 semantic attribute names (not shorthand) in filters, groupBy, and
 variables. Apply the defaults below unless the user specified otherwise.
 
+Dashboard create/update payloads do not persist a default time range or
+refresh interval. Panels follow the viewer-selected global range. If the user
+asks for a specific window, mention that range in the final handoff instead of
+inventing `timeRange`, `defaultTimeRange`, or `refresh` fields. Do not encode a
+PromQL range selector inside a Builder query.
+
 All panels are validated in Step 3b-ii.6 via the mandatory dry-run
 before save. Author the saved query semantics first, then use the
 lossless dry-run translation below.
@@ -349,8 +355,6 @@ lossless dry-run translation below.
 
 | Field | Default | When to override |
 |---|---|---|
-| Time range | last 1h | longer for capacity planning, shorter for live debugging |
-| Refresh | manual (no auto-refresh) | set 30s–1m only when the user explicitly wants live updates |
 | Section structure (APM/services) | Overview / Latency / Errors / Throughput | domain-specific (e.g. DB: Overview / Connections / Throughput / Slow Queries) |
 | Section structure (infra/runtime) | Overview / Saturation / Errors / Latency | domain-specific |
 | Headline panels (services) | request rate, error rate, p50/p95/p99 latency, throughput | omit those that don't apply |
@@ -419,7 +423,7 @@ instead and skip them here.
    confirmed except where the user accepted missing telemetry.
 
    > **Summary**: This dashboard tracks [signals] for [scope], with
-   > sections [list]. Variables: [list]. Time range default 1h.
+   > sections [list]. Variables: [list].
    > Dry-run: all [N] query-bearing panels passed validation. Data:
    > [confirmed / pending ingestion by explicit user choice].
 

--- a/plugins/signoz/skills/signoz-creating-dashboards/evals/evals.json
+++ b/plugins/signoz/skills/signoz-creating-dashboards/evals/evals.json
@@ -73,17 +73,15 @@
     },
     {
       "id": 7,
-      "eval_name": "custom-build-kafka-consumer-pressure",
+      "eval_name": "template-kafka-consumer-pressure",
       "prompt": "Quick — just build me a Kafka consumer-health dashboard with fetch rate and commit latency, grouped by client. Don't ask a bunch of questions, I'm in the middle of an incident.",
-      "expected_output": "Kafka has NO catalog template (rabbitmq exists but is a different broker). The 'incident pressure + don't ask' phrasing tempts the agent to skip discovery and the no-data probe. Agent MUST still: paginate signoz_list_dashboards; call signoz_list_dashboard_templates (no Kafka match); fall through to custom build; call signoz_list_metrics with searchText='kafka' to discover real metric names (kafka.consumer.fetch_rate, kafka.consumer.commit_latency_avg, kafka.consumer.bytes_consumed_rate, etc.) before authoring; call signoz_get_field_keys with metricName scoped to a kafka.consumer metric to discover per-metric attributes (typically client-id and standard resource attrs like service.name, k8s.pod.name); run the mandatory per-panel dry-run via signoz_execute_builder_query (envelope-translated from the widget JSON, with name preserved on each builder_query.spec) so a no-data or malformed panel isn't shipped. The skill's dry-run-before-save guardrail is non-negotiable even under incident pressure. Must emit plain-language summary (no JSON dump) before signoz_create_dashboard. GroupBy uses the actual attribute the metric carries — accept either 'client-id' (kafkametricsreceiver-style) or 'service.name' resource attribute. Reject shorthand keys like 'client' or 'consumer'.",
+      "expected_output": "Agent still paginates signoz_list_dashboards under incident pressure, then calls signoz_list_dashboard_templates and finds the Kafka Server Monitoring template at kafka/kafka-dashboard.json. It probes kafka metric ingestion, previews the template, and imports it with signoz_import_dashboard rather than custom-building a parallel dashboard. Because the user requested specific consumer panels/grouping, it reports the imported dashboard UUID and hands those customizations to signoz-modifying-dashboards; it does not update inline from the creation skill.",
       "expectations": [
-        "Agent calls signoz_list_dashboard_templates and finds no matching kafka template before custom build",
-        "Agent does NOT skip metric discovery — calls signoz_list_metrics with a kafka-related searchText before authoring panels",
-        "Agent calls signoz_get_field_keys (with signal=metrics and a kafka metric name) or signoz_get_field_values to discover the actual attribute keys carried by the kafka.consumer.* metrics before grouping",
-        "Agent does NOT skip the per-panel dry-run — calls signoz_execute_builder_query for every authored panel before signoz_create_dashboard",
-        "Agent uses the actual attribute key carried by the metric (e.g. 'client-id') or a real resource attribute (e.g. 'service.name', 'k8s.pod.name') for groupBy — not invented shorthand like 'consumer_group' or 'topic'",
-        "Agent emits a plain-language summary (no JSON dump) before calling signoz_create_dashboard",
-        "Agent either calls signoz_create_dashboard with the custom-built payload or produces a complete, ready-to-send JSON payload that contains the discovered metric names, groupBy attribute, and formula panels (acceptable if harness is in simulation mode)",
+        "Agent finds the Kafka Server Monitoring catalog entry with path kafka/kafka-dashboard.json",
+        "Agent probes ingestion with signoz_list_metrics using a kafka-related searchText before import",
+        "Agent calls signoz_import_dashboard with kafka/kafka-dashboard.json and does not call signoz_create_dashboard",
+        "Agent hands the requested fetch-rate, commit-latency, and client-grouping changes to signoz-modifying-dashboards using the imported dashboard UUID",
+        "Agent does not call signoz_update_dashboard inline from the creation skill",
         "Agent does NOT bypass the duplicate check or skip signoz_list_dashboards under the incident-pressure framing"
       ],
       "files": []
@@ -109,16 +107,16 @@
       "id": 9,
       "eval_name": "custom-build-slo-error-budget-formula",
       "prompt": "Build me an SLO dashboard for the checkout service — 99.9% availability target, 28-day rolling window, show error-budget burn rate and remaining budget.",
-      "expected_output": "SLO/error-budget dashboard has no catalog template. Agent paginates signoz_list_dashboards (none). signoz_list_dashboard_templates returns no match. Falls through to custom build. Discovers signoz_calls_total / signoz_latency_bucket span metrics via signoz_list_metrics. Calls signoz_get_field_values for service.name to confirm 'checkoutservice' (or whichever exists). Reads signoz://dashboard/* resources. Builds the dashboard in BUILDER MODE ONLY — never PromQL or ClickHouse-SQL. Panels: (a) availability using formula A*100/B or (1-A/B)*100 where A=signoz_calls_total filtered to status_code='STATUS_CODE_ERROR' and B=signoz_calls_total total; (b) error-budget-remaining as (availability - 99.9) / (1 - 0.999) * 100; (c) burn-rate panels with the MWMB pattern (1h and 6h windows; thresholds ≥14.4x / ≥6x). Time range default overridden to 28d (NOT the default 1h) since SLO windows are long. Filter and groupBy use 'service.name' (dotted, type=resource), NOT 'service_name' (underscore — that's PromQL syntax which this skill forbids). Emits plain-language summary (no JSON dump) before signoz_create_dashboard with the explicit time range, SLO target, error budget in minutes, and formula calls in the summary.",
+      "expected_output": "SLO/error-budget dashboard has no catalog template. Agent paginates signoz_list_dashboards, checks signoz_list_dashboard_templates, discovers span metrics and the checkout service, then builds in Builder mode. With A=error requests and B=total requests, availability is (1-A/B)*100, remaining error budget is ((1-A/B)-0.999)/(1-0.999)*100, and burn rate is (A/B)/(1-0.999). The dashboard payload does not invent timeRange, defaultTimeRange, or refresh fields: panels follow the viewer-selected global range, so the summary tells the user to select 28d after creation. Filters use service.name, and every panel is dry-run before signoz_create_dashboard.",
       "expectations": [
         "Agent calls signoz_list_dashboard_templates and finds no matching SLO/error-budget template before custom build",
         "Agent calls signoz_list_metrics to discover signoz_calls_total or signoz_latency_bucket span metrics (or equivalent) before authoring",
-        "Agent uses a formula combining good and total event counts (e.g. A*100/B, (B-A)/B, or a similar ratio) for the availability or error-budget panel",
-        "Agent overrides the default 1h time range to a longer SLO-appropriate window (28d, 30d, or similarly explicit long range) — acceptable either as a dashboard-level timeRange field or as a query-window (e.g. rate[28d]) override with the preview explicitly noting the non-default window",
+        "Agent computes availability from error and total request counts and uses the 0.1% error-budget allowance consistently in remaining-budget and burn-rate formulas",
+        "Agent does not add timeRange, defaultTimeRange, or refresh fields to the dashboard payload and does not smuggle a PromQL range selector into a Builder query",
         "Agent uses service.name (dotted, OTel resource attribute) in builder-mode filters and variables — not the underscored span-metric label 'service_name' (this skill builds in builder mode only, never PromQL) and not the bare shorthand 'service'",
-        "Agent emits a plain-language summary (no JSON dump) before calling signoz_create_dashboard, surfacing the non-default time range and the formula(s)",
+        "Agent emits a plain-language summary before creation that explains the formulas and tells the user to select the 28d global viewer range",
         "Agent runs signoz_execute_builder_query as a per-panel dry-run for every authored panel before signoz_create_dashboard",
-        "Agent either calls signoz_create_dashboard with the custom-built payload or produces a complete, ready-to-send JSON payload that contains the formula panels, the non-default time range, and the service filter (acceptable if harness is in simulation mode)"
+        "Agent calls signoz_create_dashboard with a complete payload containing the formula panels and service filter"
       ],
       "files": []
     },
@@ -243,7 +241,7 @@
       "prompt": "Create a dashboard for our backend services with three panels: (1) request rate timeseries grouped by service, (2) p99 latency timeseries grouped by service, and (3) a global system health panel showing total error count across all services. I want a service.name dropdown variable to filter the dashboard.",
       "expected_output": "Agent follows the custom-build discovery and resource-read flow, proposes a DYNAMIC service_name variable, lists all three planned panels, and asks whether the variable should apply to all or a subset. It stops before wiring $service_name, dry-running, or creating the dashboard.",
       "expectations": [
-        "Agent proposes type='DYNAMIC' with DynamicVariablesAttribute='service.name'",
+        "Agent proposes type='DYNAMIC' with dynamicVariablesAttribute='service.name'",
         "Agent explicitly lists the panels and asks which the service.name variable should apply to before wiring any query",
         "Agent does not wire $service_name into any panel before the user answers",
         "Agent does not call signoz_execute_builder_query or signoz_create_dashboard before the user answers"
@@ -269,8 +267,9 @@
       "prompt": "Apply it to Request Rate by Service and P99 Latency by Service, but keep Global System Health unfiltered.",
       "expected_output": "Using the prior-turn fixture, agent wires $service_name only into the two selected per-service panel drafts, leaves Global System Health global, and produces an offline simulated dry-run trace for all three complete active queries with the representative variable value. It prepares the plain-language summary but does not create a live dashboard in this offline eval.",
       "expectations": [
-        "Variable reference $service_name appears in the Request Rate by Service and P99 Latency by Service filters",
-        "Variable reference $service_name does not appear in the Global System Health filter",
+        "Variable reference $service_name appears in the Request Rate by Service and P99 Latency by Service filters under draft.widgets",
+        "Variable reference $service_name does not appear in the Global System Health filter under draft.widgets",
+        "The prepared draft uses variables and widgets and contains no singular variable or legacy panels field",
         "Variable references use $service_name in filter expressions rather than bare service_name",
         "The simulated trace runs signoz_execute_builder_query for every complete active query with service_name=checkoutservice",
         "Agent prepares a plain-language summary that states which panels the variable filters",

--- a/plugins/signoz/skills/signoz-creating-dashboards/evals/files/service-variable-scope-context.json
+++ b/plugins/signoz/skills/signoz-creating-dashboards/evals/files/service-variable-scope-context.json
@@ -3,16 +3,19 @@
   "instructions": "Treat the eval prompt as the user's reply to the prior applicability question.",
   "representativeVariables": {"service_name": "checkoutservice"},
   "draft": {
-    "variable": {
-      "mapKey": "service_name",
-      "name": "service_name",
-      "type": "DYNAMIC",
-      "dynamicVariablesAttribute": "service.name",
-      "dynamicVariablesSource": "Traces"
+    "variables": {
+      "service_name": {
+        "id": "44444444-4444-4444-8444-444444444444",
+        "name": "service_name",
+        "type": "DYNAMIC",
+        "dynamicVariablesAttribute": "service.name",
+        "dynamicVariablesSource": "Traces"
+      }
     },
-    "panels": [
+    "widgets": [
       {
         "id": "request-rate",
+        "panelTypes": "graph",
         "title": "Request Rate by Service",
         "query": {
           "queryType": "builder",
@@ -24,6 +27,7 @@
       },
       {
         "id": "p99-latency",
+        "panelTypes": "graph",
         "title": "P99 Latency by Service",
         "query": {
           "queryType": "builder",
@@ -35,6 +39,7 @@
       },
       {
         "id": "global-health",
+        "panelTypes": "graph",
         "title": "Global System Health",
         "query": {
           "queryType": "builder",

--- a/plugins/signoz/skills/signoz-creating-dashboards/evals/files/service-variable-scope-context.json
+++ b/plugins/signoz/skills/signoz-creating-dashboards/evals/files/service-variable-scope-context.json
@@ -20,7 +20,7 @@
         "query": {
           "queryType": "builder",
           "builder": {
-            "queryData": [{"queryName": "A", "dataSource": "traces", "expression": "A", "aggregations": [{"expression": "count()"}], "filter": {"expression": ""}, "groupBy": [{"key": "service.name", "type": "resource", "dataType": "string"}]}],
+            "queryData": [{"queryName": "A", "dataSource": "traces", "expression": "A", "aggregations": [{"expression": "count()"}], "filter": {"expression": ""}, "groupBy": [{"key": "service.name", "type": "resource", "dataType": "string"}], "legend": "{{service.name}}"}],
             "queryFormulas": []
           }
         }
@@ -32,7 +32,7 @@
         "query": {
           "queryType": "builder",
           "builder": {
-            "queryData": [{"queryName": "A", "dataSource": "traces", "expression": "A", "aggregations": [{"expression": "p99(duration_nano)"}], "filter": {"expression": ""}, "groupBy": [{"key": "service.name", "type": "resource", "dataType": "string"}]}],
+            "queryData": [{"queryName": "A", "dataSource": "traces", "expression": "A", "aggregations": [{"expression": "p99(duration_nano)"}], "filter": {"expression": ""}, "groupBy": [{"key": "service.name", "type": "resource", "dataType": "string"}], "legend": "{{service.name}}"}],
             "queryFormulas": []
           }
         }

--- a/plugins/signoz/skills/signoz-explaining-alerts/SKILL.md
+++ b/plugins/signoz/skills/signoz-explaining-alerts/SKILL.md
@@ -64,7 +64,8 @@ strict — read-only operations are cheap to recover from):
 
 ### Step 1: Resolve the alert
 
-If the user provided a numeric id, skip to Step 2. Otherwise:
+If the user provided a rule ID (UUID or legacy numeric ID), skip to Step 2.
+Otherwise:
 
 1. Call `signoz_list_alert_rules` and **paginate every page** —
    `pagination.hasMore` is true until the full list is walked.
@@ -81,14 +82,17 @@ guesses.
 
 ### Step 3: Pull a one-line fire-frequency summary
 
-Call `signoz_get_alert_history` for the rule with a 7-day lookback. From
-the response, derive a single line:
+Call `signoz_get_alert_history` with a 7-day lookback, `state: "firing"`,
+`order: "desc"`, and a large limit. If a page is full or the response includes
+a completeness note with `hasMore: true`, continue with `offset`; stop when the
+note reports `hasMore: false` or the page is short.
+Derive a single line from the complete set:
 
 > Fired N times in the last 7d (last fire: <relative-time>).
 
 If the alert never fired in the window, say so explicitly:
 "Has not fired in the last 7d." If the alert is disabled, mention that
-and skip the history line.
+separately; disabled rules can still have earlier fires in the lookback.
 
 This single line grounds the explanation. Do **not** drill into specific
 fires here — that's `signoz-investigating-alerts`.
@@ -152,14 +156,17 @@ verify them. Name each `groupBy` dimension and its practical effect
 For **anomaly rules** (`ruleType: anomaly_rule`), explicitly state that
 the threshold is in **standard deviations from the learned pattern, not
 the raw value** — this is the most common point of confusion. Include
-`algorithm` (zscore), `seasonality` (hourly / daily / weekly), and how
+`algorithm` (`standard`, which is z-score based), `seasonality` (hourly /
+daily / weekly), and how
 lower/higher targets shift sensitivity (lower → more noise, higher →
 only extreme deviations).
 
 **2. When it fires** — one paragraph covering threshold + timing.
 Decode the threshold spec into plain English using these mappings:
 
-- `op` codes: `1` above, `2` below, `3` equal, `4` not equal.
+- `op` codes: `1` above, `2` below, `3` equal, `4` not equal, `5`
+  above-or-equal, `6` below-or-equal, `7` outside-bounds
+  (`outside_bounds` in payloads).
 - `matchType` codes: `1` at_least_once (any point in window), `2`
   all_the_times (entire window), `3` on_average (window average), `4`
   in_total (window sum), `5` last (most recent point).
@@ -173,8 +180,8 @@ Describe timing as "checks every `<frequency>` over the last
 `<evalWindow>`", and mention that with `at_least_once` a single-point
 breach triggers, while `all_the_times` requires the full window.
 
-**3. Where it notifies** — channels per tier (resolved by name from
-`signoz_list_notification_channels` if needed), `notificationSettings.groupBy`
+**3. Where it notifies** — channels per tier (resolved by name from the fully
+paginated `signoz_list_notification_channels` result if needed), `notificationSettings.groupBy`
 (how notifications are bundled), `renotify` (interval + which states),
 `usePolicy` (label-based routing). Skip this section entirely if
 notification settings are vanilla and the user already saw the channel
@@ -301,7 +308,7 @@ wrong chips.
    > `pagerduty-oncall`. Fired 3 times in the last 7d (last 2h ago).
    >
    > **What it watches** — traces from `service.name = 'checkout'`.
-   > Query A counts spans with `hasError = true`, query B counts all
+   > Query A counts spans with `has_error = true`, query B counts all
    > spans, F1 = A × 100 / B is the error percentage; the alert
    > triggers on F1.
    >
@@ -355,7 +362,7 @@ wrong chips.
 
 **Agent:**
 1. `signoz_get_alert id=88` → `ruleType: anomaly_rule`,
-   `algorithm=zscore`, `seasonality=daily`, target 3, metric
+   `algorithm=standard` (z-score based), `seasonality=daily`, target 3, metric
    `http.server.request.duration`, scope `service.name = 'api-gateway'`.
 2. History: fired 1 time in last 7d.
 3. Replies:

--- a/plugins/signoz/skills/signoz-explaining-alerts/evals/evals.json
+++ b/plugins/signoz/skills/signoz-explaining-alerts/evals/evals.json
@@ -5,35 +5,35 @@
       "id": 0,
       "eval_name": "fuzzy-match-audit",
       "prompt": "Explain my checkout error rate alert. Is it configured correctly?",
-      "expected_output": "Agent paginates signoz_list_alert_rules to find candidates (multiple 'checkout-svc Error Rate > 3%' rules + eval-1 alerts exist on staging). Surfaces ambiguity and either asks user or picks closest with a clear assumption note. Then signoz_get_alert + signoz_get_alert_history (7d), produces structured explanation (Overview, Query breakdown — including the formula A*100/B, Threshold, Evaluation, Notification, Labels), AND performs the audit (Step 5) since user asked 'configured correctly'.",
+      "expected_output": "Agent paginates signoz_list_alert_rules to find candidates (multiple 'checkout-svc Error Rate > 3%' rules + eval-1 alerts exist on staging). Surfaces ambiguity and either asks user or picks closest with a clear assumption note. Then signoz_get_alert + paginated signoz_get_alert_history (7d, state=firing, order=desc), leads with an audit verdict, explains the A*100/B query, threshold, evaluation, notifications, and labels, and includes the complete fire-frequency summary.",
       "files": []
     },
     {
       "id": 1,
       "eval_name": "formula-having-decode",
       "prompt": "What does alert 019de287-a765-7c80-93e7-f2f0f2f5f927 do? Specifically explain how the count guard works and what conditions trigger a fire.",
-      "expected_output": "Agent calls signoz_get_alert directly with the rule ID. Decodes the 3-query structure: A=p99(duration_nano) WITH having: count()>50, B=count() (disabled), F1=A pass-through. Explains that the having clause is the count guard — it suppresses any 1-minute bucket where span count <= 50, so the threshold evaluator sees no data for those buckets and cannot fire. Translates op=above + matchType=on_average + target=1s into plain language. Pulls fire history.",
+      "expected_output": "Agent calls signoz_get_alert directly with the rule ID. Decodes the 3-query structure: A=p99(duration_nano) WITH having: count()>50, B=count() (disabled), F1=A pass-through. Explains that the having clause is the count guard — it suppresses any 1-minute bucket where span count <= 50, so the threshold evaluator sees no data for those buckets and cannot fire. Translates op=above + matchType=on_average + target=1s into plain language. Pulls paginated firing history for 7d in descending order.",
       "files": []
     },
     {
       "id": 2,
       "eval_name": "anomaly-threshold-explain",
       "prompt": "Help me understand alert rule 019de287-6752-7629-83e4-375919d56dd8 — I'm confused about how anomaly thresholds work versus regular ones.",
-      "expected_output": "Agent fetches the rule, identifies ruleType=anomaly_rule, and explicitly contrasts anomaly vs threshold semantics: target=3 means 3 standard deviations from the learned baseline, NOT 3 raw req/s. Explains daily seasonality: the baseline adapts to hour-of-day patterns. Mentions z-score algorithm. Notes that lower target = more sensitive (more noise). Pulls fire history. Section order from skill (Anomaly specifics) followed.",
+      "expected_output": "Agent fetches the rule, identifies ruleType=anomaly_rule and algorithm=standard, and explicitly contrasts anomaly vs threshold semantics: target=3 means 3 standard deviations from the learned baseline, NOT 3 raw req/s. Explains daily seasonality: the baseline adapts to hour-of-day patterns. Notes that lower target = more sensitive (more noise). Pulls paginated firing history for 7d in descending order and includes the complete fire-frequency summary.",
       "files": []
     },
     {
       "id": 3,
       "eval_name": "url-parse-panic-logs",
       "prompt": "What does this alarm fire on? https://us2.staging.signoz.cloud/alerts/edit?ruleId=019dad90-1754-770f-8dae-d28a897167e3",
-      "expected_output": "Agent extracts ruleId from the URL query string, calls signoz_get_alert, identifies as LOGS_BASED_ALERT for 'Payments service panic logs'. Decodes the body filter (panic / fatal / etc keywords), groupBy, threshold target=0/at_least_once (any panic log fires it). Pulls fire history. Explains in plain language without dumping the JSON.",
+      "expected_output": "Agent extracts ruleId from the URL query string, calls signoz_get_alert, identifies as LOGS_BASED_ALERT for 'Payments service panic logs'. Decodes the body filter (panic / fatal / etc keywords), groupBy, threshold target=0/at_least_once (any panic log fires it). Pulls paginated firing history for 7d in descending order. Explains in plain language without dumping the JSON.",
       "files": []
     },
     {
       "id": 4,
       "eval_name": "multi-severity-audit-kafka",
       "prompt": "Audit alert 019dad90-1c73-715e-b040-79901928deb2 (kafka consumer lag) — anything I should change?",
-      "expected_output": "Agent fetches the rule, decodes the multi-severity threshold spec (warning at lag >= 50, critical at >= 200), explains the tiered routing. Performs Step 5 audit: flags missing labels.severity (rule has no severity label even though thresholds have severity tiers), considers groupBy cardinality, evaluates threshold calibration, suggests adding severity label, runbook annotations, alertOnAbsent if relevant. Pulls fire history.",
+      "expected_output": "Agent fetches the rule, decodes the multi-severity threshold spec (warning at lag >= 50, critical at >= 200), explains the tiered routing. Performs Step 5 audit: flags missing labels.severity (rule has no severity label even though thresholds have severity tiers), considers groupBy cardinality, evaluates threshold calibration, suggests adding severity label, runbook annotations, alertOnAbsent if relevant. Pulls paginated firing history for 7d in descending order.",
       "files": []
     }
   ]

--- a/plugins/signoz/skills/signoz-explaining-dashboards/SKILL.md
+++ b/plugins/signoz/skills/signoz-explaining-dashboards/SKILL.md
@@ -38,16 +38,14 @@ Do NOT use when:
 
 ### Step 1: Identify the target dashboard
 
-Determine which dashboard the user wants explained. If the user provides a
-dashboard name, UUID, or it is clear from context (e.g., an @mention or
-auto-context providing a dashboard resource), use that.
+Use a supplied UUID or a dashboard resource that includes its UUID directly.
+For any name-only request, call `signoz_list_dashboards` and resolve the name to
+a UUID. **Paginate through all pages** — follow `pagination.nextOffset` while
+`pagination.hasMore` is true. Never pass a dashboard name to
+`signoz_get_dashboard` or conclude it is missing from the first page.
 
-If the target dashboard is ambiguous:
-1. Call `signoz_list_dashboards` to list existing dashboards. **Paginate through
-   all pages** — check `pagination.hasMore` in the response. If `hasMore` is true,
-   call again with `offset` set to `pagination.nextOffset` and repeat until all
-   pages are exhausted. Never stop at the first page.
-2. Present matching candidates to the user and ask which one to explain.
+If multiple dashboards match, present the candidates and ask which one to
+explain.
 
 ### Step 2: Fetch the full dashboard configuration
 

--- a/plugins/signoz/skills/signoz-explaining-dashboards/evals/evals.json
+++ b/plugins/signoz/skills/signoz-explaining-dashboards/evals/evals.json
@@ -14,8 +14,9 @@
         {"id": "a4", "text": "Output explains the cache hit-rate formula (A / (A + B)) * 100 in plain language"},
         {"id": "a5", "text": "Output gives 'what to watch for' guidance specific to Redis (mentions at least one of: evictions, fragmentation ratio, replication lag, blocked clients, slowlog)"},
         {"id": "a6", "text": "Output flags at least one structural issue: disabled queries on multiple panels, duplicate Cache hit rate panels, or 'Hit rate'/'Cache hit rate' shown as 'value' panel-type instead of graph"},
-        {"id": "a7", "text": "Output does NOT dump raw dashboard JSON or large query objects"},
-        {"id": "a8", "text": "Output ends with concrete next-step offers (e.g., run queries, add panels/thresholds, modify dashboard)"}
+        {"id": "a7", "text": "Agent resolves the dashboard name through paginated signoz_list_dashboards and calls signoz_get_dashboard with the returned UUID, never the name"},
+        {"id": "a8", "text": "Output does NOT dump raw dashboard JSON or large query objects"},
+        {"id": "a9", "text": "Output ends with concrete next-step offers (e.g., run queries, add panels/thresholds, modify dashboard)"}
       ]
     },
     {
@@ -32,7 +33,8 @@
         {"id": "a5", "text": "Output walks through the four value panels (heap used, threads, CPU, classes)"},
         {"id": "a6", "text": "Output mentions the Memory Pool Details table groups by jvm_memory_type and jvm_memory_pool_name"},
         {"id": "a7", "text": "Output mentions that GC Duration uses a rate aggregation (not raw counter)"},
-        {"id": "a8", "text": "Output does NOT dump raw dashboard JSON or large query objects"}
+        {"id": "a8", "text": "Agent resolves the dashboard name through paginated signoz_list_dashboards and calls signoz_get_dashboard with the returned UUID, never the name"},
+        {"id": "a9", "text": "Output does NOT dump raw dashboard JSON or large query objects"}
       ]
     },
     {
@@ -48,7 +50,20 @@
         {"id": "a4", "text": "Output mentions both variables on the dashboard"},
         {"id": "a5", "text": "Output does NOT dump raw dashboard JSON or large query objects"},
         {"id": "a6", "text": "Output is well-organized despite the 65 widgets — does not enumerate every panel as a flat list with no grouping"},
-        {"id": "a7", "text": "Output addresses both parts of the prompt: what to watch AND structural problems/gaps"}
+        {"id": "a7", "text": "Agent resolves the dashboard name through paginated signoz_list_dashboards and calls signoz_get_dashboard with the returned UUID, never the name"},
+        {"id": "a8", "text": "Output addresses both parts of the prompt: what to watch AND structural problems/gaps"}
+      ]
+    },
+    {
+      "id": 4,
+      "name": "name-resolution-on-second-page",
+      "prompt": "Explain my Payments API dashboard.",
+      "expected_output": "Using the offline list fixture, the agent follows pagination.nextOffset after page one, resolves Payments API to its UUID on page two, calls signoz_get_dashboard with that UUID, and only then explains it.",
+      "files": ["evals/files/name-on-second-page.json"],
+      "assertions": [
+        {"id": "a1", "text": "Agent follows pagination.nextOffset when the first signoz_list_dashboards page has no match"},
+        {"id": "a2", "text": "Agent calls signoz_get_dashboard with UUID 22222222-2222-4222-8222-222222222222, never with the name Payments API"},
+        {"id": "a3", "text": "Agent does not explain the dashboard from list metadata alone"}
       ]
     }
   ]

--- a/plugins/signoz/skills/signoz-explaining-dashboards/evals/evals.json
+++ b/plugins/signoz/skills/signoz-explaining-dashboards/evals/evals.json
@@ -58,12 +58,13 @@
       "id": 4,
       "name": "name-resolution-on-second-page",
       "prompt": "Explain my Payments API dashboard.",
-      "expected_output": "Using the offline list fixture, the agent follows pagination.nextOffset after page one, resolves Payments API to its UUID on page two, calls signoz_get_dashboard with that UUID, and only then explains it.",
+      "expected_output": "Using the offline fixture, the agent follows pagination.nextOffset after page one, resolves Payments API to its UUID on page two, calls signoz_get_dashboard with that UUID, and explains the fetched Failed Payment Spans panel.",
       "files": ["evals/files/name-on-second-page.json"],
       "assertions": [
         {"id": "a1", "text": "Agent follows pagination.nextOffset when the first signoz_list_dashboards page has no match"},
         {"id": "a2", "text": "Agent calls signoz_get_dashboard with UUID 22222222-2222-4222-8222-222222222222, never with the name Payments API"},
-        {"id": "a3", "text": "Agent does not explain the dashboard from list metadata alone"}
+        {"id": "a3", "text": "Agent does not explain the dashboard from list metadata alone"},
+        {"id": "a4", "text": "Output explains that Failed Payment Spans counts errored traces for service.name=payments"}
       ]
     }
   ]

--- a/plugins/signoz/skills/signoz-explaining-dashboards/evals/files/name-on-second-page.json
+++ b/plugins/signoz/skills/signoz-explaining-dashboards/evals/files/name-on-second-page.json
@@ -1,6 +1,6 @@
 {
   "mode": "offline_mcp_fixture",
-  "instructions": "Simulate dashboard-name resolution from these paginated list responses before fetching details.",
+  "instructions": "Use these ordered responses to resolve the dashboard and explain the fetched payload offline; do not query a live tenant.",
   "responses": [
     {
       "request": {"limit": 50, "offset": 0},
@@ -14,6 +14,44 @@
       "response": {
         "data": [{"uuid": "22222222-2222-4222-8222-222222222222", "name": "Payments API"}],
         "pagination": {"total": 51, "offset": 50, "limit": 50, "hasMore": false, "nextOffset": -1}
+      }
+    },
+    {
+      "request": {"id": "22222222-2222-4222-8222-222222222222"},
+      "response": {
+        "status": "success",
+        "data": {
+          "uuid": "22222222-2222-4222-8222-222222222222",
+          "title": "Payments API",
+          "description": "Payments API failure monitoring",
+          "tags": ["payments"],
+          "variables": {},
+          "widgets": [
+            {
+              "id": "33333333-3333-4333-8333-333333333333",
+              "panelTypes": "graph",
+              "title": "Failed Payment Spans",
+              "query": {
+                "queryType": "builder",
+                "builder": {
+                  "queryData": [
+                    {
+                      "queryName": "A",
+                      "dataSource": "traces",
+                      "expression": "A",
+                      "aggregations": [{"expression": "count()"}],
+                      "filter": {"expression": "service.name = 'payments' AND has_error = true"},
+                      "groupBy": []
+                    }
+                  ],
+                  "queryFormulas": []
+                }
+              }
+            }
+          ],
+          "layout": [{"i": "33333333-3333-4333-8333-333333333333", "x": 0, "y": 0, "w": 12, "h": 6}],
+          "panelMap": {}
+        }
       }
     }
   ]

--- a/plugins/signoz/skills/signoz-explaining-dashboards/evals/files/name-on-second-page.json
+++ b/plugins/signoz/skills/signoz-explaining-dashboards/evals/files/name-on-second-page.json
@@ -1,0 +1,20 @@
+{
+  "mode": "offline_mcp_fixture",
+  "instructions": "Simulate dashboard-name resolution from these paginated list responses before fetching details.",
+  "responses": [
+    {
+      "request": {"limit": 50, "offset": 0},
+      "response": {
+        "data": [{"uuid": "11111111-1111-4111-8111-111111111111", "name": "Frontend"}],
+        "pagination": {"total": 51, "offset": 0, "limit": 50, "hasMore": true, "nextOffset": 50}
+      }
+    },
+    {
+      "request": {"limit": 50, "offset": 50},
+      "response": {
+        "data": [{"uuid": "22222222-2222-4222-8222-222222222222", "name": "Payments API"}],
+        "pagination": {"total": 51, "offset": 50, "limit": 50, "hasMore": false, "nextOffset": -1}
+      }
+    }
+  ]
+}

--- a/plugins/signoz/skills/signoz-generating-queries/SKILL.md
+++ b/plugins/signoz/skills/signoz-generating-queries/SKILL.md
@@ -47,7 +47,7 @@ Map the user's intent to the right signal:
 | User intent | Signal | Why |
 |---|---|---|
 | Error rate, latency, throughput, request count | **metrics** (preferred) or **traces** | Metrics are pre-aggregated and fastest. Use traces if the user needs per-request detail or no matching metric exists. |
-| p50/p75/p90/p95/p99 latency | **metrics** (histogram) or **traces** (aggregate on `durationNano`) | Prefer metrics if a histogram metric exists (e.g., `signoz_latency_bucket`). Fall back to trace aggregation. |
+| p50/p75/p90/p95/p99 latency | **metrics** (histogram) or **traces** (aggregate on `duration_nano`) | Prefer metrics if a histogram metric exists (e.g., `signoz_latency_bucket`). Fall back to trace aggregation. |
 | Find specific log entries, error messages, stack traces | **logs** | Text search, pattern matching, severity filtering. |
 | Find specific traces, slow requests, error spans | **traces** | Per-request detail, span attributes, duration filtering. |
 | Infrastructure metrics (CPU, memory, disk, network) | **metrics** | Always metrics for resource utilization. |
@@ -83,7 +83,9 @@ Run discovery calls in parallel where possible:
   For a cost question, query the volume metric (bytes for logs/traces, count
   for metric datapoints) and multiply by the per-unit price from Settings →
   Billing — ask the user for the price if you don't have it.
-- **For traces**: Call `signoz_list_services` to confirm the service name exists.
+- **For traces**: Call `signoz_list_services` to confirm the service name exists,
+  following `pagination.nextOffset` while `pagination.hasMore` is true before
+  declaring it missing.
   Optionally call `signoz_get_service_top_operations` for the service to find
   operation names. Call `signoz_get_field_keys(signal: "traces")` if you need
   to filter on a non-standard attribute.
@@ -105,7 +107,7 @@ from context (e.g., from a dashboard or @mention), skip redundant discovery.
 | Trace search (find matching spans) | `signoz_search_traces` | Finding specific traces/spans. Use `service`, `operation`, `error`, `minDuration`/`maxDuration` shortcuts plus `filter` for field filters. |
 | Log aggregation (count, avg, percentiles) | `signoz_aggregate_logs` | "How many errors?", "error count by service", "p99 response time from logs". Set `requestType` to `scalar` for totals or `time_series` for trends. |
 | Trace aggregation (count, avg, percentiles) | `signoz_aggregate_traces` | "p99 latency for checkout", "error count per operation", "request rate by endpoint". Set `requestType` to `scalar` for totals or `time_series` for trends. |
-| Complex multi-query or formula | `signoz_execute_builder_query` | Only when the simpler tools above cannot express the query — e.g., joining multiple data sources, complex filter expressions, or queries needing the full Query Builder v5 schema. Read `signoz://traces/query-builder-guide` before using. |
+| Complex multi-query or formula | `signoz_execute_builder_query` | Only when simpler tools cannot express it. Read the guide for the actual signal: traces or logs query-builder guide, metrics aggregation guide, or PromQL instructions. |
 
 **`requestType` decision for aggregations:**
 - `scalar` (default): "How many?", "What is the p99?", "Which service has the most?"
@@ -128,7 +130,8 @@ from context (e.g., from a dashboard or @mention), skip redundant discovery.
   from the `signoz_list_metrics` response to avoid an extra auto-fetch round trip.
 - For **Cost Meter**, carry `source=meter` on `signoz_query_metrics` too (signal
   stays `metrics`); meter data is bucketed hourly, so set `stepInterval: 3600`
-  over a window of at least a few hours.
+  over a window of at least a few hours. Use `timeAggregation: increase` for
+  ingested volume/count and `rate` only when the user asks for a per-second rate.
 
 ### Step 5: Handle results
 
@@ -222,7 +225,7 @@ from context (e.g., from a dashboard or @mention), skip redundant discovery.
 
 **Agent:**
 1. Calls `signoz_aggregate_traces(aggregation: "p99",
-   aggregateOn: "durationNano", service: "cart-service",
+   aggregateOn: "duration_nano", service: "cart-service",
    requestType: "scalar", timeRange: "1h")`.
 2. Presents: "p99 latency for cart-service: 1.2s over the last hour."
 3. Offers: "Want me to break this down by operation or show the trend over time?"
@@ -246,6 +249,8 @@ from context (e.g., from a dashboard or @mention), skip redundant discovery.
 1. Bytes by service → Cost Meter. `signoz_list_metrics(searchText: "log",
    source: "meter")` finds `signoz.meter.log.size`.
 2. Calls `signoz_query_metrics(metricName: "signoz.meter.log.size",
-   source: "meter", groupBy: "service.name", stepInterval: 3600, timeRange: "24h")`.
+   source: "meter", timeAggregation: "increase", spaceAggregation: "sum",
+   groupBy: "service.name", stepInterval: 3600, timeRange: "24h",
+   requestType: "scalar", reduceTo: "sum")`.
 3. Presents per-service ingestion bytes. (Bytes live only in the meter; to slice
    by an attribute it lacks, fall back to a direct count.)

--- a/plugins/signoz/skills/signoz-generating-queries/SKILL.md
+++ b/plugins/signoz/skills/signoz-generating-queries/SKILL.md
@@ -129,9 +129,9 @@ from context (e.g., from a dashboard or @mention), skip redundant discovery.
 - For `signoz_query_metrics`, pass `metricType`, `temporality`, and `isMonotonic`
   from the `signoz_list_metrics` response to avoid an extra auto-fetch round trip.
 - For **Cost Meter**, carry `source=meter` on `signoz_query_metrics` too (signal
-  stays `metrics`); meter data is bucketed hourly, so set `stepInterval: 3600`
-  over a window of at least a few hours. Use `timeAggregation: increase` for
-  ingested volume/count and `rate` only when the user asks for a per-second rate.
+  stays `metrics`). For time series, use `stepInterval: 3600` because meter data
+  is hourly; omit it for scalar totals. Use `timeAggregation: increase` for
+  volume/count and `rate` only for a per-second rate.
 
 ### Step 5: Handle results
 
@@ -250,7 +250,7 @@ from context (e.g., from a dashboard or @mention), skip redundant discovery.
    source: "meter")` finds `signoz.meter.log.size`.
 2. Calls `signoz_query_metrics(metricName: "signoz.meter.log.size",
    source: "meter", timeAggregation: "increase", spaceAggregation: "sum",
-   groupBy: "service.name", stepInterval: 3600, timeRange: "24h",
-   requestType: "scalar", reduceTo: "sum")`.
+   groupBy: "service.name", timeRange: "24h", requestType: "scalar",
+   reduceTo: "sum")`.
 3. Presents per-service ingestion bytes. (Bytes live only in the meter; to slice
    by an attribute it lacks, fall back to a direct count.)

--- a/plugins/signoz/skills/signoz-generating-queries/evals/evals.json
+++ b/plugins/signoz/skills/signoz-generating-queries/evals/evals.json
@@ -19,7 +19,7 @@
       "id": 2,
       "eval_name": "traces-p99-latency-by-operation",
       "prompt": "What's the p99 latency for cart-service broken down by operation in the last 30 minutes?",
-      "expected_output": "Agent uses signoz_aggregate_traces with aggregation=p99, aggregateOn=durationNano, service=cart-service, groupBy includes operation/name, requestType=scalar, timeRange=30m. Reports top operations by p99.",
+      "expected_output": "Agent uses signoz_aggregate_traces with aggregation=p99, aggregateOn=duration_nano, service=cart-service, groupBy=name, requestType=scalar, timeRange=30m. Reports top operations by p99.",
       "files": []
     },
     {
@@ -40,7 +40,7 @@
       "id": 5,
       "eval_name": "metrics-cost-meter-ingestion-by-service",
       "prompt": "How much log data is each service ingesting?",
-      "expected_output": "Agent recognizes ingestion *bytes* live only in the Cost Meter store, so it uses the metrics signal with source=meter. Discovers the metric via signoz_list_metrics with source=meter (e.g. signoz.meter.log.size) rather than assuming a fixed list, then signoz_query_metrics with source=meter, groupBy service.name, stepInterval 3600 (meter buckets hourly). groupBy works like a normal metric here because service is an attribute the meter retains. Does NOT omit source=meter (which would hit the empty default store). Reports per-service ingested bytes over the window. Understands that slicing by an attribute the meter does not retain would fall back to a direct count aggregation (signoz_aggregate_logs) — bytes are only in the meter.",
+      "expected_output": "Agent recognizes ingestion bytes live only in the Cost Meter store, discovers the metric with signoz_list_metrics source=meter, then calls signoz_query_metrics with source=meter, timeAggregation=increase, spaceAggregation=sum, groupBy=service.name, stepInterval=3600, requestType=scalar, and reduceTo=sum. It reports total ingested bytes rather than hourly buckets or the default per-second rate. If the meter lacks a requested attribute, it falls back to a direct count aggregation and clearly notes that bytes remain meter-only.",
       "files": []
     }
   ]

--- a/plugins/signoz/skills/signoz-generating-queries/evals/evals.json
+++ b/plugins/signoz/skills/signoz-generating-queries/evals/evals.json
@@ -40,7 +40,7 @@
       "id": 5,
       "eval_name": "metrics-cost-meter-ingestion-by-service",
       "prompt": "How much log data is each service ingesting?",
-      "expected_output": "Agent recognizes ingestion bytes live only in the Cost Meter store, discovers the metric with signoz_list_metrics source=meter, then calls signoz_query_metrics with source=meter, timeAggregation=increase, spaceAggregation=sum, groupBy=service.name, stepInterval=3600, requestType=scalar, and reduceTo=sum. It reports total ingested bytes rather than hourly buckets or the default per-second rate. If the meter lacks a requested attribute, it falls back to a direct count aggregation and clearly notes that bytes remain meter-only.",
+      "expected_output": "Agent recognizes ingestion bytes live only in the Cost Meter store, discovers the metric with signoz_list_metrics source=meter, then calls signoz_query_metrics with source=meter, timeAggregation=increase, spaceAggregation=sum, groupBy=service.name, requestType=scalar, and reduceTo=sum without stepInterval. It reports total ingested bytes rather than hourly buckets or the default per-second rate. If the meter lacks a requested attribute, it falls back to a direct count aggregation and clearly notes that bytes remain meter-only.",
       "files": []
     }
   ]

--- a/plugins/signoz/skills/signoz-investigating-alerts/SKILL.md
+++ b/plugins/signoz/skills/signoz-investigating-alerts/SKILL.md
@@ -63,7 +63,7 @@ If the alert name is fuzzy, this skill is **best-effort** (read-only):
    fire, tell me."
 3. Proceed.
 
-If the alert has never fired in the lookback window, **stop**: there is
+If no firing transition exists in the queried lookback window, **stop**: there is
 nothing to investigate. Respond with:
 > "Alert '[name]' has not fired in the last 7d, so there is no fire
 > window to investigate. Use `signoz-explaining-alerts` to walk through
@@ -83,7 +83,10 @@ alerts.
    not given.
 2. Call `signoz_get_alert` for the full rule config — needed to know
    what query, threshold, and resource scope the alert evaluated.
-3. Call `signoz_get_alert_history` with a 7d lookback. From the
+3. Call `signoz_get_alert_history` with a 7d lookback and `order: "desc"`.
+   Paginate with `offset` while a page is full or its completeness note reports
+   `hasMore: true`; stop when the note reports `hasMore: false` or the page is short.
+   pattern analysis needs the full firing/inactive transition set. From the
    response:
    - **Pick the fire window**. Default to the most recent fire. If the
      user passed an explicit time window via `$ARGUMENTS[1]`, honor it.
@@ -101,8 +104,8 @@ threshold tickle or flap) and quantifies the magnitude.
 
 1. Re-run the alert's primary query over a window centered on the fire
    start: `[fire_start - 30m, fire_start + 30m]`.
-   - Use `signoz_execute_builder_query` for builder/formula alerts.
-   - Use `signoz_query_metrics` for PromQL alerts.
+   - Use `signoz_execute_builder_query` for the alert's stored builder,
+     formula, PromQL, or ClickHouse query envelope.
 2. Compute:
    - **Peak value** during the fire window.
    - **Threshold breach magnitude**: `(peak - threshold) / threshold *
@@ -157,7 +160,7 @@ specific failing operations.
 1. **Traces** (if the alert is service-scoped and traces are
    available):
    - Call `signoz_search_traces` for the fire window with filter:
-     `service.name = <scope>` AND `hasError = true`. Cap at top 20.
+     `service.name = <scope>` AND `has_error = true`. Cap at top 20.
    - Group results by `name` (operation) and `error_message`. Surface
      the top 3 by frequency with a representative trace ID for each.
    - Optionally call `signoz_get_trace_details` on one representative
@@ -338,7 +341,7 @@ the full picture. The chip surface is capped; the prose is not.
    - Throughput: -42% (drop).
    - Downstream `payments` error rate: 18% vs 0.2% baseline (+8900%).
    - CPU/memory: flat (no resource pressure).
-5. **Tier 3**: traces for `service.name = checkout, hasError = true`
+5. **Tier 3**: traces for `service.name = checkout, has_error = true`
    in the fire window — top operation `POST /checkout/submit`, top
    error message "context deadline exceeded calling payments-api".
    30 traces, all hitting the same downstream URL. Logs show

--- a/plugins/signoz/skills/signoz-investigating-alerts/evals/evals.json
+++ b/plugins/signoz/skills/signoz-investigating-alerts/evals/evals.json
@@ -5,35 +5,35 @@
       "id": 0,
       "eval_name": "full-rca-firing",
       "prompt": "The 'RED — p99 Latency > 2s by Service' alert (019ddf83-7d04-74c4-97c7-fea13d72c091) is firing. Investigate the most recent fire and tell me the root cause.",
-      "expected_output": "Agent runs full 3-tier flow: signoz_get_alert + signoz_get_alert_history (find recent fire), then Tier-1 re-runs the alert query around the fire window to get peak/baseline/breach magnitude/duration; Tier-2 pulls neighbor signals (error rate, throughput, dependency latency) and compares fire vs baseline window; Tier-3 pulls top error traces + error logs around the fire window. Outputs ranked hypotheses with evidence + supporting query, plus next steps.",
+      "expected_output": "Agent runs full 3-tier flow: signoz_get_alert + paginated signoz_get_alert_history (order=desc; include firing and inactive transitions to reconstruct the recent fire window), then Tier-1 re-runs the alert query around the fire window to get peak/baseline/breach magnitude/duration; Tier-2 pulls neighbor signals (error rate, throughput, dependency latency) and compares fire vs baseline window; Tier-3 pulls top error traces + error logs around the fire window. Outputs ranked hypotheses with evidence + supporting query, plus next steps.",
       "files": []
     },
     {
       "id": 1,
       "eval_name": "fuzzy-match-rca",
       "prompt": "I got paged about a checkout error rate alert, can you investigate the most recent fire?",
-      "expected_output": "Agent paginates signoz_list_alert_rules to resolve 'checkout error rate' (multiple candidates exist: 'checkout-svc Error Rate > 3%' METRIC_BASED + TRACES_BASED, plus eval-1 alerts). Picks the one with actual fire history (TRACES_BASED 019dd4cb fired ~7d ago at ~14:32 UTC), states the assumption clearly, then runs full RCA on that fire window. Tier-2 baseline is prior-day same hour; flags if baseline data is sparse since fire is 7d old.",
+      "expected_output": "Agent paginates signoz_list_alert_rules to resolve 'checkout error rate' (multiple candidates exist: 'checkout-svc Error Rate > 3%' METRIC_BASED + TRACES_BASED, plus eval-1 alerts). Uses each candidate's paginated 7d firing history in descending order, picks the TRACES_BASED rule whose history contains the fire near 14:32 UTC, states the assumption clearly, then runs full RCA on that fire window. Tier-2 baseline is prior-day same hour; flags if baseline data is sparse since fire is near the lookback boundary.",
       "files": []
     },
     {
       "id": 2,
       "eval_name": "marginal-flap-detection",
       "prompt": "Why did the 'test alerts-1' alert fire? Investigate. (rule id 0199e817-3d9f-7a12-99e8-038749ea9562)",
-      "expected_output": "Agent fetches alert + history. If breach magnitude is small (<10% over threshold) AND fire duration short, OR if fires are flapping, classifies as 'marginal fire' per Tier-1 early-stop. Skips Tier-2/3 and outputs a single 'threshold may be too tight, recommend tuning' hypothesis with low-medium confidence rather than fabricating root causes. If fires are flapping, identifies the pattern explicitly.",
+      "expected_output": "Agent fetches alert + paginated 7d firing history in descending order. If breach magnitude is small (<10% over threshold) AND fire duration short, OR if fires are flapping, classifies as 'marginal fire' per Tier-1 early-stop. Skips Tier-2/3 and outputs a single 'threshold may be too tight, recommend tuning' hypothesis with low-medium confidence rather than fabricating root causes. If fires are flapping, identifies the pattern explicitly.",
       "files": []
     },
     {
       "id": 3,
       "eval_name": "never-fired-stop",
       "prompt": "RCA for the [eval-3-ws-anomaly] frontend service request rate anomaly alert please. Rule ID 019de287-6752-7629-83e4-375919d56dd8.",
-      "expected_output": "Agent fetches alert + history. Detects that the alert is disabled and has never fired (history empty). Stops per skill guardrail with the message 'Alert has not fired in the last 7d, so there is no fire window to investigate.' Suggests using signoz-explaining-alerts to explain the rule, or to enable the alert. Does NOT proceed to Tier-1/2/3 against synthetic data.",
+      "expected_output": "Agent fetches alert + paginated 7d firing history in descending order. Detects that the alert is disabled and has no firing transition in the queried lookback. Stops per skill guardrail with the message 'Alert has not fired in the last 7d, so there is no fire window to investigate.' Suggests using signoz-explaining-alerts to explain the rule, or to enable the alert. Does NOT claim the rule has never fired or proceed to Tier-1/2/3 against synthetic data.",
       "files": []
     },
     {
       "id": 4,
       "eval_name": "trace-formula-firing",
       "prompt": "Investigate why alert 019d7041-1937-769f-b0e4-9d4ff846eb43 ('trace formula alert') is firing.",
-      "expected_output": "Agent fetches alert + history. Identifies it as a TRACES_BASED formula alert. Runs Tier-1 to confirm fire is real and quantify magnitude. If real, runs Tier-2 against neighbor signals for the same resource scope (note: the alert may have an empty/missing service filter — agent should handle this gracefully). Surfaces ranked hypotheses with evidence and queries.",
+      "expected_output": "Agent fetches alert + paginated 7d firing history in descending order. Identifies it as a TRACES_BASED formula alert. Runs Tier-1 to confirm fire is real and quantify magnitude. If real, runs Tier-2 against neighbor signals for the same resource scope (note: the alert may have an empty/missing service filter — agent should handle this gracefully). Surfaces ranked hypotheses with evidence and queries.",
       "files": []
     }
   ]

--- a/plugins/signoz/skills/signoz-investigating-alerts/references/baseline-comparison.md
+++ b/plugins/signoz/skills/signoz-investigating-alerts/references/baseline-comparison.md
@@ -84,7 +84,7 @@ In the Tier 2 output for each signal, present:
 
 ```
 - p99 latency: 4.1s vs 320ms baseline (+1180%)
-  query: signoz_execute_builder_query — p99(durationNano) on
+  query: signoz_execute_builder_query — p99(duration_nano) on
          service.name = checkout, fire window 14:32-14:40 UTC vs
          baseline 14:32-14:40 UTC (24h prior)
 ```
@@ -114,7 +114,7 @@ Skip baseline comparison and call out the limitation if:
 Tier 3 does not require a baseline — the question is "what happened",
 not "what changed". Run a single fire-window query for each:
 
-- `signoz_search_traces` with the resource filter + `hasError = true`.
+- `signoz_search_traces` with the resource filter + `has_error = true`.
   Cap at 20. Group by `name` (operation) and surface the top 3 by
   count with one representative `trace_id` each.
 - `signoz_search_logs` with the resource filter +

--- a/plugins/signoz/skills/signoz-investigating-alerts/references/neighbor-signals.md
+++ b/plugins/signoz/skills/signoz-investigating-alerts/references/neighbor-signals.md
@@ -17,11 +17,11 @@ runtime.
 
 | Signal | Source | Aggregation | Why it matters |
 |---|---|---|---|
-| Error rate (traces) | traces | `count(hasError = true) * 100 / count()` grouped by service | A sympathetic move here usually points at downstream / upstream cascades. |
-| p95 latency | traces | `p95(durationNano)` filtered to entry spans | Latency moving with errors → resource saturation or downstream slowness. Latency without errors → queue/buffer fill. |
-| p99 latency | traces | `p99(durationNano)` | Catches tail-only regressions invisible to p95. |
-| Throughput (RPS) | traces | `rate(count())` | Drops mean upstream stopped sending. Spikes mean retry storms or load shifts. |
-| Dependency error rate | traces | `count(hasError = true)` filtered to outbound spans, grouped by `db.name` / `peer.service` / target host | Surfaces which downstream the service is failing on. |
+| Error rate (traces) | traces | A=`count()` filtered by `has_error = true`, B=`count()` for the same scope, F1=`A * 100 / B`; group by service | A sympathetic move here usually points at downstream / upstream cascades. |
+| p95 latency | traces | `p95(duration_nano)` filtered to entry spans | Latency moving with errors → resource saturation or downstream slowness. Latency without errors → queue/buffer fill. |
+| p99 latency | traces | `p99(duration_nano)` | Catches tail-only regressions invisible to p95. |
+| Throughput (RPS) | traces | `rate()` | Drops mean upstream stopped sending. Spikes mean retry storms or load shifts. |
+| Dependency error rate | traces | A=`count()` filtered to outbound errors, B=`count()` for all outbound spans, F1=`A * 100 / B`; group by a discovered dependency field | Surfaces which downstream the service is failing on. |
 | Container CPU (if available) | metrics | `system.cpu.utilization` or `container.cpu.utilization` filtered to the same service | Saturation explains latency/error correlation; flat CPU + errors implies a non-resource cause. |
 | Container memory | metrics | `system.memory.usage` / `container.memory.usage` | OOM context, leak detection. |
 | Pod restarts (if k8s) | metrics | `k8s.pod.phase` transitions or `kube_pod_container_status_restarts_total` rate | Restarts during the fire window strongly bias toward "infrastructure caused this". |
@@ -60,7 +60,7 @@ without groupBy), Tier 2 is weaker. Pull:
 
 | Signal | Source | Aggregation |
 |---|---|---|
-| Top services by error rate | traces | `count(hasError = true)` grouped by `service.name`, top 10 |
+| Top services by error rate | traces | A=`count()` filtered by `has_error = true`, B=`count()`, F1=`A * 100 / B`; group by `service.name`, top 10 |
 | Top services by error log volume | logs | `count()` filtered to `severity_text IN ('ERROR','FATAL')`, grouped by `service.name`, top 10 |
 
 This identifies which service drove the global signal, then re-run

--- a/plugins/signoz/skills/signoz-managing-views/evals/evals.json
+++ b/plugins/signoz/skills/signoz-managing-views/evals/evals.json
@@ -4,12 +4,12 @@
     {
       "id": 0,
       "name": "create-trace-view-for-service",
-      "prompt": "Save the current traces query as a view called 'checkout-errors' for the checkout service. I want to see only ERROR spans from service.name = checkout.",
-      "expected_output": "Agent resolves sourcePage=traces, builds a builder_query with filter service.name=checkout and status=error, sets panelType=list, runs the mandatory pre-save sample fetch (signoz:signoz_search_traces with limit=1 using the exact filter from compositeQuery.queries[0].spec), shows a preview with name/sourcePage/filter plus the sample-fetch result, confirms, and calls signoz:signoz_create_view. Reports back the name, UUID, and sourcePage.",
+      "prompt": "Save the current traces query as a view called 'checkout-errors' for the checkout service. I want to see only error spans from service.name = checkout.",
+      "expected_output": "Agent resolves sourcePage=traces, builds a builder_query with filter service.name='checkout' AND has_error=true, sets panelType=list, runs signoz_search_traces with limit=1 using the exact filter, previews, confirms, and calls signoz_create_view. Reports the name, UUID, and sourcePage.",
       "files": [],
       "assertions": [
         {
-          "text": "Agent calls signoz:signoz_create_view",
+          "text": "Agent calls signoz_create_view",
           "description": "The primary write operation must be called"
         },
         {
@@ -17,11 +17,11 @@
           "description": "sourcePage must match the user's intent; wrong value is a 400"
         },
         {
-          "text": "Filter includes service.name = checkout and status/error condition",
+          "text": "Filter includes service.name = checkout and has_error = true",
           "description": "View must capture the user's stated filter criteria"
         },
         {
-          "text": "Agent runs the mandatory pre-save sample fetch via signoz:signoz_search_traces with limit=1 using the exact filter from the about-to-save payload before signoz:signoz_create_view",
+          "text": "Agent runs the mandatory pre-save sample fetch via signoz_search_traces with limit=1 using the exact filter from the about-to-save payload before signoz_create_view",
           "description": "Step 5 of the create flow: a saved view returning zero rows is a permanent artifact; the sample fetch is the only confirmation that the filter matches data"
         },
         {
@@ -38,11 +38,11 @@
       "id": 1,
       "name": "list-views-no-sourcepage",
       "prompt": "Show me all my saved views.",
-      "expected_output": "Agent recognizes no sourcePage was given, calls signoz:signoz_list_views four times (once for each of traces, logs, metrics, meter), merges results, and presents them organized by sourcePage. Checks pagination.hasMore for each page before concluding.",
+      "expected_output": "Agent recognizes no sourcePage was given, calls signoz_list_views four times (once for each of traces, logs, metrics, meter), merges results, and presents them organized by sourcePage. Checks pagination.hasMore for each page before concluding.",
       "files": [],
       "assertions": [
         {
-          "text": "Agent calls signoz:signoz_list_views for all four pages: traces, logs, metrics, and meter",
+          "text": "Agent calls signoz_list_views for all four pages: traces, logs, metrics, and meter",
           "description": "Without a sourcePage the agent must query all four Explorer pages, including meter (Cost Meter)"
         },
         {
@@ -59,16 +59,20 @@
       "id": 2,
       "name": "rename-existing-view",
       "prompt": "Rename the 'slow-checkout' view to 'slow-checkout-p99'.",
-      "expected_output": "Agent calls signoz:signoz_list_views to find the view by name, then signoz:signoz_get_view to fetch full body, shows diff preview (rename only, compositeQuery untouched), waits for confirmation, then calls signoz:signoz_update_view with the modified name only. Reports UUID, old name, new name.",
+      "expected_output": "Because sourcePage is unknown, the agent searches all four source pages with full pagination, then calls signoz_get_view. It previews a rename-only diff and calls signoz_update_view with the full fetched view body, changing only the name. Reports UUID, old name, and new name.",
       "files": [],
       "assertions": [
         {
-          "text": "Agent calls signoz:signoz_list_views (or signoz:signoz_get_view) to resolve the view before updating",
+          "text": "Agent searches traces, logs, metrics, and meter with pagination because sourcePage was not supplied",
+          "description": "A saved-view name is not globally searchable through one sourcePage"
+        },
+        {
+          "text": "Agent calls signoz_list_views (or signoz_get_view) to resolve the view before updating",
           "description": "Blind update without lookup risks wrong UUID"
         },
         {
-          "text": "Agent calls signoz:signoz_get_view to fetch the full body before composing update (GET-then-PUT)",
-          "description": "signoz:signoz_update_view is full-body replace; not fetching first risks wiping fields"
+          "text": "Agent calls signoz_get_view to fetch the full body before composing update (GET-then-PUT)",
+          "description": "signoz_update_view is full-body replace; not fetching first risks wiping fields"
         },
         {
           "text": "compositeQuery is not modified for a pure rename",
@@ -79,8 +83,8 @@
           "description": "Skill requires showing what will change"
         },
         {
-          "text": "Agent calls signoz:signoz_update_view with the modified name",
-          "description": "The rename must actually be written back"
+          "text": "Agent calls signoz_update_view with the full fetched view body, preserving sourcePage, compositeQuery, category, tags, and extraData while changing only name",
+          "description": "The PUT is full-body replace; a name-only payload would wipe state"
         }
       ]
     },
@@ -88,15 +92,19 @@
       "id": 3,
       "name": "delete-view-by-name",
       "prompt": "Delete the 'checkout-errors' view.",
-      "expected_output": "Agent calls signoz:signoz_list_views to find the view by name, then calls signoz:signoz_get_view to confirm the UUID maps to a view named 'checkout-errors' with the expected sourcePage. Shows the resolved name, sourcePage, and category to the user and asks for explicit confirmation. Only after confirmation calls signoz:signoz_delete_view. Reports 'deleted' with the view name, not just the UUID.",
+      "expected_output": "Because sourcePage is unknown, the agent searches all four source pages with full pagination, then calls signoz_get_view to confirm the UUID maps to checkout-errors. It shows the resolved name, sourcePage, and category, asks for confirmation, and only then calls signoz_delete_view.",
       "files": [],
       "assertions": [
         {
-          "text": "Agent calls signoz:signoz_list_views to locate the view by name before acting",
+          "text": "Agent searches traces, logs, metrics, and meter with pagination because sourcePage was not supplied",
+          "description": "Deletion must not assume which Explorer owns the named view"
+        },
+        {
+          "text": "Agent calls signoz_list_views to locate the view by name before acting",
           "description": "Must resolve name to UUID via listing; do not call delete on a guessed or user-pasted UUID without lookup"
         },
         {
-          "text": "Agent calls signoz:signoz_get_view to confirm the resolved UUID before deleting",
+          "text": "Agent calls signoz_get_view to confirm the resolved UUID before deleting",
           "description": "Paste errors happen; the get-before-delete guard prevents deleting the wrong view"
         },
         {
@@ -104,7 +112,7 @@
           "description": "Delete is permanent; skill requires fresh confirmation against the resolved target, not just the original prompt"
         },
         {
-          "text": "Agent calls signoz:signoz_delete_view only after confirmation",
+          "text": "Agent calls signoz_delete_view only after confirmation",
           "description": "Must not auto-confirm based on original prompt"
         },
         {
@@ -116,12 +124,16 @@
     {
       "id": 4,
       "name": "update-view-filter",
-      "prompt": "Update the 'checkout-errors' view to also show WARN spans, not just ERROR.",
-      "expected_output": "Agent calls signoz:signoz_list_views to find the view, then signoz:signoz_get_view to fetch full body. Recognizes this is a compositeQuery change and invokes signoz-generating-queries skill to build a new query with status IN (ERROR, WARN). Runs the mandatory pre-save sample fetch against the new filter (signoz:signoz_search_traces with limit=1 since sourcePage=traces) — required because compositeQuery changed. Shows a diff preview with old vs new filter expression, notes compositeQuery is changing, and includes the sample-fetch result. Waits for confirmation, then calls signoz:signoz_update_view with the validated compositeQuery. Reports back UUID, name, and what changed.",
+      "prompt": "Update the 'checkout-errors' view to show only error spans slower than one second.",
+      "expected_output": "Because sourcePage is unknown, the agent searches all four source pages with full pagination, then gets the full view. It uses signoz-generating-queries to build has_error=true AND duration_nano>1000000000, sample-fetches the exact filter, previews the diff, confirms, and calls signoz_update_view with the full fetched view body containing the validated compositeQuery.",
       "files": [],
       "assertions": [
         {
-          "text": "Agent calls signoz:signoz_get_view to fetch the full body before composing update (GET-then-PUT)",
+          "text": "Agent searches traces, logs, metrics, and meter with pagination because sourcePage was not supplied",
+          "description": "Update must locate the view across every Explorer before GET-then-PUT"
+        },
+        {
+          "text": "Agent calls signoz_get_view to fetch the full body before composing update (GET-then-PUT)",
           "description": "Full-body replace; not fetching first risks wiping fields"
         },
         {
@@ -129,7 +141,7 @@
           "description": "Query changes must go through signoz-generating-queries for validation; hand-editing compositeQuery risks malformed payloads"
         },
         {
-          "text": "Agent runs the mandatory pre-save sample fetch via signoz:signoz_search_traces with limit=1 using the new filter before signoz:signoz_update_view",
+          "text": "Agent runs the mandatory pre-save sample fetch via signoz_search_traces with limit=1 using the new filter before signoz_update_view",
           "description": "Step 5 of the update flow: compositeQuery changed, so the 1-row probe against the new filter is required (skip only for pure metadata tweaks)"
         },
         {
@@ -137,8 +149,8 @@
           "description": "Skill requires confirmation for compositeQuery changes; user must see what is changing"
         },
         {
-          "text": "Agent calls signoz:signoz_update_view with the validated compositeQuery",
-          "description": "The filter change must actually be written back"
+          "text": "Agent calls signoz_update_view with the full fetched view body, preserving sourcePage, category, tags, and extraData while replacing compositeQuery with the validated query",
+          "description": "The filter change must be written without dropping unrelated state"
         },
         {
           "text": "signal in every builder_query matches the view's sourcePage",
@@ -150,7 +162,7 @@
       "id": 5,
       "name": "create-cost-meter-view",
       "prompt": "Save a view that tracks our log ingestion volume from the Cost Meter so I can find it later.",
-      "expected_output": "Agent recognizes this is a Cost Meter view and resolves sourcePage=meter (not metrics). Reads the schema resources, then builds the query via signoz-generating-queries told it is a Cost Meter query (source=meter) so discovery hits the meter store and finds a meter metric (e.g. signoz.meter.log.size). The resulting builder_query has signal=metrics and source=meter, panelType=graph. Runs the mandatory pre-save sample fetch via signoz:signoz_query_metrics with source=meter, the metricName, timeRange=24h, requestType=scalar. Shows a preview (name, sourcePage=meter, metric/filter, sample-fetch result), confirms, and calls signoz:signoz_create_view. Reports name, UUID, and sourcePage=meter.",
+      "expected_output": "Agent recognizes this is a Cost Meter view and resolves sourcePage=meter (not metrics). Reads the schema resources, then builds the query via signoz-generating-queries told it is a Cost Meter query (source=meter) so discovery hits the meter store and finds a meter metric (e.g. signoz.meter.log.size). The resulting builder_query has signal=metrics and source=meter, panelType=graph. Runs the mandatory pre-save sample fetch via signoz_query_metrics with source=meter, the metricName, timeRange=24h, requestType=scalar. Shows a preview (name, sourcePage=meter, metric/filter, sample-fetch result), confirms, and calls signoz_create_view. Reports name, UUID, and sourcePage=meter.",
       "files": [],
       "assertions": [
         {
@@ -166,11 +178,11 @@
           "description": "A meter view is queried on the metrics signal against the meter store; omitting source='meter' silently queries the default store, and the server rejects a meter view without it"
         },
         {
-          "text": "Agent runs the pre-save sample fetch via signoz:signoz_query_metrics with source=meter before signoz:signoz_create_view",
+          "text": "Agent runs the pre-save sample fetch via signoz_query_metrics with source=meter before signoz_create_view",
           "description": "Step 5 of the create flow, adapted for meter: the 1-row/scalar probe must carry source=meter so it hits the meter store"
         },
         {
-          "text": "Agent shows a preview and calls signoz:signoz_create_view, reporting the UUID and sourcePage=meter",
+          "text": "Agent shows a preview and calls signoz_create_view, reporting the UUID and sourcePage=meter",
           "description": "Preview-before-write and report-back apply to meter views like any other"
         }
       ]

--- a/plugins/signoz/skills/signoz-modifying-dashboards/SKILL.md
+++ b/plugins/signoz/skills/signoz-modifying-dashboards/SKILL.md
@@ -95,6 +95,11 @@ Merge the planned changes into the full dashboard JSON from Step 2.
 
 **Modification rules:**
 
+- **Time range and refresh are viewer controls.** Dashboard update payloads do
+  not persist a default time range or refresh interval. If asked to change one,
+  explain that panels follow the viewer-selected global range; do not invent
+  `timeRange`, `defaultTimeRange`, or `refresh` fields.
+
 - **Preserve supported mutable state.** Copy the fetched dashboard, change only
   what the user requested, and compare semantics after MCP normalization. Do not
   drop unrelated widgets, variables, layout items, or panelMap entries.

--- a/plugins/signoz/skills/signoz-modifying-dashboards/evals/evals.json
+++ b/plugins/signoz/skills/signoz-modifying-dashboards/evals/evals.json
@@ -118,12 +118,13 @@
       "id": 7,
       "eval_name": "target-dashboard-on-second-page",
       "prompt": "Add an error-rate panel to my 'Payments API' dashboard.",
-      "expected_output": "In an offline simulated tool trace using the attached fixture, the first signoz_list_dashboards response has hasMore=true and no match. Agent follows pagination.nextOffset, finds Payments API there, fetches it, and only then plans the modification.",
+      "expected_output": "In an offline simulated tool trace using the attached fixture, the first signoz_list_dashboards response has hasMore=true and no match. Agent follows pagination.nextOffset, finds Payments API, fetches it, and plans the new panel while preserving Request Rate.",
       "files": ["evals/files/target-on-second-page.json"],
       "expectations": [
         "Agent does not conclude Payments API is missing after the first page",
         "The simulated trace invokes signoz_list_dashboards again with offset equal to pagination.nextOffset using an accepted integer or string value",
         "The simulated trace invokes signoz_get_dashboard only for the second-page Payments API match",
+        "The modification plan preserves the fetched Request Rate widget",
         "Agent did not call signoz_update_dashboard (read-only eval constraint respected)"
       ]
     },

--- a/plugins/signoz/skills/signoz-modifying-dashboards/evals/evals.json
+++ b/plugins/signoz/skills/signoz-modifying-dashboards/evals/evals.json
@@ -163,6 +163,7 @@
         "New variable is DYNAMIC and uses the discovered deployment.environment attribute",
         "New variable has a UUID-shaped id and its map key and name are both deployment_environment",
         "Consumer Lag and Throughput filters reference $deployment_environment, while Broker Health does not",
+        "The prepared dashboard mutates widgets and contains no legacy panels field",
         "The simulated trace successfully dry-runs both complete changed queries with deployment_environment=prod",
         "Existing variables, layout, Broker Health, and all unrelated supported state remain semantically unchanged",
         "Agent did not call signoz_update_dashboard (read-only eval constraint respected)"
@@ -182,6 +183,17 @@
         "Overview panelMap contains Request Rate and the new Error Rate panel only; Capacity panelMap still contains CPU only",
         "The simulated trace successfully dry-runs the supplied complete Error Rate query before accepting the mutation plan",
         "Agent did not call signoz_update_dashboard (read-only eval constraint respected)"
+      ]
+    },
+    {
+      "id": 12,
+      "eval_name": "unsupported-default-range-and-refresh",
+      "prompt": "Set my API Monitoring dashboard's default range to 7 days and auto-refresh it every 30 seconds.",
+      "expected_output": "Agent explains that dashboard update payloads do not persist default time range or refresh settings and that panels follow the viewer-selected global range. It does not add timeRange, defaultTimeRange, or refresh fields and does not call signoz_update_dashboard.",
+      "files": [],
+      "expectations": [
+        "Agent explains that time range and refresh are viewer controls rather than persisted dashboard fields",
+        "Agent does not call signoz_update_dashboard or invent timeRange, defaultTimeRange, or refresh fields"
       ]
     }
   ]

--- a/plugins/signoz/skills/signoz-modifying-dashboards/evals/files/environment-variable-scope-context.json
+++ b/plugins/signoz/skills/signoz-modifying-dashboards/evals/files/environment-variable-scope-context.json
@@ -5,19 +5,22 @@
     "uuid": "55555555-5555-4555-8555-555555555555",
     "title": "Kafka",
     "variables": {},
-    "panels": [
+    "widgets": [
       {
         "id": "consumer-lag",
+        "panelTypes": "graph",
         "title": "Consumer Lag",
         "query": {"queryType": "builder", "builder": {"queryData": [{"queryName": "A", "dataSource": "metrics", "expression": "A", "aggregations": [{"metricName": "kafka.consumer_group.lag", "timeAggregation": "latest", "spaceAggregation": "max"}], "filter": {"expression": ""}, "groupBy": []}], "queryFormulas": []}}
       },
       {
         "id": "throughput",
+        "panelTypes": "graph",
         "title": "Throughput",
         "query": {"queryType": "builder", "builder": {"queryData": [{"queryName": "A", "dataSource": "metrics", "expression": "A", "aggregations": [{"metricName": "kafka.consumer_group.messages", "timeAggregation": "rate", "spaceAggregation": "sum"}], "filter": {"expression": ""}, "groupBy": []}], "queryFormulas": []}}
       },
       {
         "id": "broker-health",
+        "panelTypes": "graph",
         "title": "Broker Health",
         "query": {"queryType": "builder", "builder": {"queryData": [{"queryName": "A", "dataSource": "metrics", "expression": "A", "aggregations": [{"metricName": "kafka.broker.active", "timeAggregation": "latest", "spaceAggregation": "sum"}], "filter": {"expression": ""}, "groupBy": []}], "queryFormulas": []}}
       }

--- a/plugins/signoz/skills/signoz-modifying-dashboards/evals/files/target-on-second-page.json
+++ b/plugins/signoz/skills/signoz-modifying-dashboards/evals/files/target-on-second-page.json
@@ -15,6 +15,42 @@
         "data": [{"uuid": "44444444-4444-4444-8444-444444444444", "name": "Payments API"}],
         "pagination": {"total": 51, "offset": 50, "limit": 50, "hasMore": false, "nextOffset": -1}
       }
+    },
+    {
+      "request": {"id": "44444444-4444-4444-8444-444444444444"},
+      "response": {
+        "status": "success",
+        "data": {
+          "uuid": "44444444-4444-4444-8444-444444444444",
+          "title": "Payments API",
+          "variables": {},
+          "widgets": [
+            {
+              "id": "55555555-5555-4555-8555-555555555555",
+              "panelTypes": "graph",
+              "title": "Request Rate",
+              "query": {
+                "queryType": "builder",
+                "builder": {
+                  "queryData": [
+                    {
+                      "queryName": "A",
+                      "dataSource": "traces",
+                      "expression": "A",
+                      "aggregations": [{"expression": "rate()"}],
+                      "filter": {"expression": "service.name = 'payments'"},
+                      "groupBy": []
+                    }
+                  ],
+                  "queryFormulas": []
+                }
+              }
+            }
+          ],
+          "layout": [{"i": "55555555-5555-4555-8555-555555555555", "x": 0, "y": 0, "w": 12, "h": 6}],
+          "panelMap": {}
+        }
+      }
     }
   ]
 }

--- a/plugins/signoz/skills/signoz-searching-docs/evals/evals.json
+++ b/plugins/signoz/skills/signoz-searching-docs/evals/evals.json
@@ -5,7 +5,7 @@
       "id": 0,
       "eval_name": "mcp-path-narrow-language",
       "prompt": "How do I configure the OTLP exporter for a Python application sending traces to SigNoz Cloud?",
-      "expected_output": "Agent calls signoz:signoz_search_docs with the user's natural-language query and section_slug='apm-distributed-tracing' (or similar). Trusts BM25 ranking — does not invent its own keyword scoring. Picks the Python-specific instrumentation guide from top results, calls signoz:signoz_fetch_doc on the canonical URL, and answers with the OTLP endpoint, headers (signoz-ingestion-key), protocol, and a Python code snippet. Cites the canonical https://signoz.io/docs/... URL. Does not fetch unrelated language guides.",
+      "expected_output": "Agent calls signoz_search_docs with the user's natural-language query and section_slug='apm-distributed-tracing' (or similar). Trusts BM25 ranking — does not invent its own keyword scoring. Picks the Python-specific instrumentation guide from top results, calls signoz_fetch_doc on the canonical URL, and answers with the OTLP endpoint, headers (signoz-ingestion-key), protocol, and a Python code snippet. Cites the canonical https://signoz.io/docs/... URL. Does not fetch unrelated language guides.",
       "files": [],
       "assertions": [
         {"id": "uses_mcp_search", "text": "Agent calls signoz_search_docs (MCP tool) rather than only HTTP fetching."},
@@ -35,7 +35,7 @@
       "id": 2,
       "eval_name": "multi-page-alerts-config-and-troubleshoot",
       "prompt": "How do I configure alert rules in SigNoz, and how do I troubleshoot when they fire unexpectedly?",
-      "expected_output": "Agent recognizes the task spans two needs: alert setup AND troubleshooting. Calls signoz:signoz_search_docs with section_slug='alerts' and fetches TWO pages — one on alert configuration, one on alert troubleshooting/debugging. Synthesizes both into a single answer: setup steps first, then debugging guidance. Cites both canonical URLs. Does not pad with loosely-related pages just because they share keywords.",
+      "expected_output": "Agent recognizes the task spans two needs: alert setup AND troubleshooting. Calls signoz_search_docs with section_slug='alerts' and fetches TWO pages — one on alert configuration, one on alert troubleshooting/debugging. Synthesizes both into a single answer: setup steps first, then debugging guidance. Cites both canonical URLs. Does not pad with loosely-related pages just because they share keywords.",
       "files": [],
       "assertions": [
         {"id": "fetches_multiple_pages", "text": "Agent fetches at least 2 distinct docs pages — one on alert configuration, one on troubleshooting."},
@@ -49,7 +49,7 @@
       "id": 3,
       "eval_name": "sub-section-heading-narrow",
       "prompt": "Which authentication header does the SigNoz Cloud ingestion endpoint require, and where do I get its value?",
-      "expected_output": "Agent calls signoz:signoz_search_docs with section_slug='setup' or 'signoz-apis' to find the SigNoz Cloud ingestion / auth page. Calls signoz:signoz_fetch_doc with a heading anchor scoped to the auth/ingestion-key sub-section rather than fetching the whole page. Answers with the canonical header name (signoz-ingestion-key) and where users obtain the value (SigNoz Cloud settings UI). Cites the canonical URL with the section anchor. Does not invent a header name from training memory without grounding in fetched docs.",
+      "expected_output": "Agent calls signoz_search_docs with section_slug='setup' or 'signoz-apis' to find the SigNoz Cloud ingestion / auth page. Calls signoz_fetch_doc with a heading anchor scoped to the auth/ingestion-key sub-section rather than fetching the whole page. Answers with the canonical header name (signoz-ingestion-key) and where users obtain the value (SigNoz Cloud settings UI). Cites the canonical URL with the section anchor. Does not invent a header name from training memory without grounding in fetched docs.",
       "files": [],
       "assertions": [
         {"id": "uses_mcp_search", "text": "Agent calls signoz_search_docs (MCP tool)."},
@@ -64,7 +64,7 @@
       "id": 4,
       "eval_name": "no-heuristic-topic-dashboards",
       "prompt": "How do I create a dashboard panel that shows p99 latency for my metrics?",
-      "expected_output": "Agent recognizes there is no heuristic row for dashboards. Goes directly to signoz:signoz_search_docs with the user's query and section_slug='dashboards'. Does NOT invent a heuristic claim or pretend to follow one. Picks the dashboard panel / metrics query guide from top BM25 results, fetches it, and answers with the panel-builder steps. Cites canonical URL.",
+      "expected_output": "Agent recognizes there is no heuristic row for dashboards. Goes directly to signoz_search_docs with the user's query and section_slug='dashboards'. Does NOT invent a heuristic claim or pretend to follow one. Picks the dashboard panel / metrics query guide from top BM25 results, fetches it, and answers with the panel-builder steps. Cites canonical URL.",
       "files": [],
       "assertions": [
         {"id": "no_false_heuristic", "text": "Agent does NOT claim to follow a heuristic for dashboards (none exists)."},
@@ -79,7 +79,7 @@
       "id": 5,
       "eval_name": "query-builder-howto",
       "prompt": "How do I use the SigNoz query builder to compute p95 latency grouped by service.name?",
-      "expected_output": "Agent calls signoz:signoz_search_docs with section_slug='querying' (no heuristic exists for querying — agent must not invent one). Picks the query builder docs page from BM25 results and fetches it. Answers with the concrete UI steps: choose traces signal, select duration metric, set aggregation to p95, set group-by to service.name. Grounds the answer in fetched docs content. Cites the canonical URL. Does NOT delegate to signoz-generating-queries — this is a docs lookup ('how do I use the query builder'), not query generation.",
+      "expected_output": "Agent calls signoz_search_docs with section_slug='querying' (no heuristic exists for querying — agent must not invent one). Picks the query builder docs page from BM25 results and fetches it. Answers with the concrete UI steps: choose traces signal, select duration metric, set aggregation to p95, set group-by to service.name. Grounds the answer in fetched docs content. Cites the canonical URL. Does NOT delegate to signoz-generating-queries — this is a docs lookup ('how do I use the query builder'), not query generation.",
       "files": [],
       "assertions": [
         {"id": "no_false_heuristic", "text": "Agent does NOT claim to follow a heuristic for querying (none exists)."},
@@ -95,7 +95,7 @@
       "id": 6,
       "eval_name": "no-guessed-cost-meter-url",
       "prompt": "Find the SigNoz docs for the Cost Meter meter explorer query guide and summarize how to use it.",
-      "expected_output": "Agent calls signoz:signoz_search_docs before calling signoz:signoz_fetch_doc, chooses the canonical Cost Meter meter explorer query guide URL returned by search, and fetches that URL. It must not construct or fetch a plausible `/docs/cost-meter/user-guides/meter-explorer-query-guide/` path from memory.",
+      "expected_output": "Agent calls signoz_search_docs before calling signoz_fetch_doc, chooses the canonical Cost Meter meter explorer query guide URL returned by search, and fetches that URL. It must not construct or fetch a plausible `/docs/cost-meter/user-guides/meter-explorer-query-guide/` path from memory.",
       "files": [],
       "assertions": [
         {"id": "search_before_fetch", "text": "Agent calls signoz_search_docs before the first signoz_fetch_doc call."},

--- a/plugins/signoz/skills/signoz-setting-up-observability/SKILL.md
+++ b/plugins/signoz/skills/signoz-setting-up-observability/SKILL.md
@@ -121,6 +121,10 @@ instead of hitting collisions mid-build:
   `signoz-explaining-alerts` summarize anything you're inheriting.
 - **Is there a notification channel to reuse?** (Carried into Phase 5.)
 
+Paginate every inventory list until a match is found or all pages are
+exhausted. When a view's `sourcePage` is unknown, search traces, logs, metrics,
+and meter separately.
+
 Learn just enough to decide extend-vs-create per artifact; leave the
 exhaustive listing to the sub-skills.
 
@@ -137,8 +141,8 @@ Collect:
 - **SLO target** — e.g. 99.5% over a 30-day rolling window.
 - **Exclusions** — what doesn't count as a valid event (synthetic
   probes, scanner traffic, streaming endpoints).
-- **Error budget remaining** — derived from target. Drives burn-rate
-  alert math.
+- **Error budget allowance** — `1 - SLO`, derived from the target. Remaining
+  budget additionally requires observed bad/valid events over the SLO window.
 
 Carry these forward — they feed Phase 8 directly. (SLO/burn-rate
 background: `signoz-searching-docs`.)
@@ -205,10 +209,10 @@ rather than guessing.
 **Discover downstream topology from traces, not the human's memory**
 (Phase 1 Q1). The gotcha worth carrying: client spans are
 `kind_string = 'Client'` in the SigNoz v5 schema — *not* `kind`, *not*
-`SPAN_KIND_CLIENT` — so verify the field/value, then group by the
-populated dependency attribute (`external_http_url` / `http_host` for
-HTTP, `db_name` / `db_operation` for databases) to surface every
-downstream the service actually calls, including ones the human forgot.
+`SPAN_KIND_CLIENT` — so verify the field/value, then discover the populated
+dependency attributes with `signoz_get_field_keys`. Current examples include
+`http_url`, `server.address`, `db.system`, and `db.operation`; use only fields
+the tenant actually returns.
 
 **Multi-tenant note** — if the service serves multiple tenants/regions,
 look for a stable non-PII tenant/region attribute (e.g. `tenant.id`,
@@ -318,8 +322,7 @@ category/audience and invoking the sub-skill once per board:
   `k8s`) imported as its own board.
 - **Downstream dependencies:** client-span p99 + error rate per
   dependency — only if the service has external deps (Phase 1 Q1),
-  grouped by the attribute found in Phase 3 (`external_http_url` /
-  `db_name`).
+  grouped by the dependency attribute discovered in Phase 3.
 - **Business / SLO:** the SLI ratio and error budget, with a per-tenant
   breakdown if multi-tenant (Phase 3) — aggregate-only panels hide
   single-tenant outages.

--- a/plugins/signoz/skills/signoz-setting-up-observability/evals/evals.json
+++ b/plugins/signoz/skills/signoz-setting-up-observability/evals/evals.json
@@ -12,14 +12,14 @@
       "id": 1,
       "eval_name": "service-with-external-dependencies",
       "prompt": "payments service is fully instrumented and reporting to signoz now. it calls stripe and a postgres db. build me the whole observability setup for it — dashboards + alerts.",
-      "expected_output": "Phase 1 Q1 flags the Stripe + Postgres dependencies. Phase 3 discovers downstream topology FROM TRACES rather than trusting the description — filters client spans by kind_string='Client' (verifies it is not 'kind' / not 'SPAN_KIND_CLIENT') and groups by external_http_url / http_host for Stripe and db_name / db_operation for Postgres. Phase 6 dashboard includes a downstream-dependency row (client-span p99 + error rate per dependency). SLO/SLI captured before design; burn-rate alerts for the SLI; dependency error-rate/latency alerts proposed. Channel confirmed before any rule references it. Hands back IDs. No signoz-writing-clickhouse-queries reference.",
+      "expected_output": "Phase 1 flags Stripe and Postgres, then Phase 3 filters client spans with kind_string='Client' and discovers the tenant's actual dependency fields with signoz_get_field_keys/values. It may find http_url or server.address for Stripe and db.system/db.operation for Postgres, but never hardcodes legacy fields. The downstream dashboard and alerts group by the discovered fields. SLI/SLO and channels are confirmed before creation, and the handoff reports IDs.",
       "files": []
     },
     {
       "id": 2,
       "eval_name": "existing-dashboard-prefer-modify",
       "prompt": "We've got cartservice telemetry flowing. Set up full observability for it — I think there might already be a cart dashboard floating around.",
-      "expected_output": "Phase 1.5 inventory runs FIRST: signoz_list_dashboards (+ get_dashboard) finds the existing cart dashboard, signoz_list_alert_rules and signoz_list_views surface existing artifacts. Surfaces the existing dashboard and prefers extending/modifying it (hands off to signoz-modifying-dashboards) over standing up a parallel duplicate. Still captures SLI/SLO and runs exploration so additions are SLO-aware. Reuses an existing notification channel from signoz_list_notification_channels before creating a new one. Does not silently create a second cart dashboard.",
+      "expected_output": "Phase 1.5 inventory runs first and paginates signoz_list_dashboards, signoz_list_alert_rules, signoz_list_notification_channels, and all four signoz_list_views source pages until matched or exhausted. signoz_get_dashboard confirms the existing cart dashboard, so the workflow hands off to signoz-modifying-dashboards instead of creating a duplicate.",
       "files": []
     },
     {
@@ -33,7 +33,7 @@
       "id": 4,
       "eval_name": "infra-monitoring-join-verification",
       "prompt": "inventory-service runs on our own k8s cluster and is now sending traces + metrics to signoz. set up observability including the pod-level resource stuff (cpu, memory, restarts), full dashboard and alerts.",
-      "expected_output": "Phase 1 Q3 opts into infra monitoring. Phase 3 USE half VERIFIES the metric->service join before building — does not assume service.name is on infra metrics; checks whether host/pod metrics carry host.name / k8s.pod.name / k8s.deployment.name and that k8s.deployment.name matches service.name, via get_field_keys(signal='traces', fieldContext='resource') then get_field_keys(signal='metrics', metricName=...). Scopes the USE row by the CONFIRMED attribute, and asks the user for the workload selector if nothing joins rather than guessing. Dashboard gets both a RED row (service) and a USE row (pod CPU/memory/restarts/network). Cardinality classification (Phase 4) keeps high-card attrs off metric series. Dry-runs panels before save; burn-rate alerts for the SLI plus resource-layer alerts (OOM/restarts). Hands back IDs.",
+      "expected_output": "Phase 1 Q3 opts into infra monitoring. Phase 3 verifies the metric-to-service join with signoz_get_field_keys for traces and metrics, scopes USE panels by the confirmed host/pod/deployment attribute, and asks for a workload selector if nothing joins. The dashboard gets RED and USE coverage, panels are dry-run, and resource plus burn-rate alerts are created before IDs are handed back.",
       "files": []
     }
   ]


### PR DESCRIPTION
## Summary

- Replace legacy dashboard `panels` fixtures with contract-valid `widgets` and add name-resolution coverage.
- Align dashboard creation and modification guidance on non-persisted range/refresh controls, current templates, variables, and SLO formulas.
- Sweep alert, query, saved-view, and observability skills/evals for the same class of stale MCP fields and pagination assumptions.

## Why

Follow-up to #62's valid unresolved review comment. The dashboard fixture drift also exposed nearby skill/eval literals that no longer match the current MCP contract. SigNoz/nerve-pod#114 is already closed by the merged PR; this PR contains the follow-up corrections.

## Validation

- All changed JSON parsed with `python3 -m json.tool`
- `claude plugin validate --strict plugins/signoz`
- `git diff --check`
- Legacy-literal sweep across SigNoz skills/evals
- Three independent review passes for consistency, MCP-contract correctness, and scope
- Agent CI: no relevant workflows found for this branch
