### PR TITLE
fix(skills): correct query-construction guidance behind top MCP error classes

### DIFF
--- a/docs/signoz-creating-dashboards-evals.md
+++ b/docs/signoz-creating-dashboards-evals.md
@@ -30,7 +30,7 @@ plugins/signoz/skills/signoz-creating-dashboards/evals/evals.json
 |---|---|
 | metrics | 0, 1, 7, 9, 18, 21 |
 | traces | 8, 10, 12, 15, 16, 17, 19, 23 |
-| logs | 14, 20 |
+| logs | 14, 20, 24 |
 
 ### Panel types (from `PANEL_TYPES` enum in `frontend/src/constants/queryBuilder.ts`)
 
@@ -38,7 +38,7 @@ plugins/signoz/skills/signoz-creating-dashboards/evals/evals.json
 |---|---|
 | graph (timeseries) | 7, 9, 10, 12, 14, 17, 19, 21, 23 |
 | value | 9, 14, 16 |
-| table | 14, 16, 20, 22 |
+| table | 14, 16, 20, 22, 24 |
 | list | 15 |
 | bar | 16 |
 | pie | 16 |
@@ -56,7 +56,7 @@ plugins/signoz/skills/signoz-creating-dashboards/evals/evals.json
 | Duplicate found on a later page → present choices before any write | 18 |
 | Broad/ambiguous request → present multiple template options | 2 |
 | Vague request → emit `needs_input` / clarify scope | 5 |
-| No template match → custom build | 6, 7, 8, 9, 10, 12, 14, 15, 16, 17, 19, 20, 21, 22, 23 |
+| No template match → custom build | 6, 7, 8, 9, 10, 12, 14, 15, 16, 17, 19, 20, 21, 22, 23, 24 |
 
 ### Guardrails exercised
 
@@ -75,7 +75,7 @@ plugins/signoz/skills/signoz-creating-dashboards/evals/evals.json
 | Pie panel must have `groupBy` AND `legend` | 16 |
 | Error-rate formula `A*100/B` with `disabled:true` on base queries | 9, 16 |
 | Dashboard `groupBy` aliases stay in create payloads; dry-runs use canonical v5 fields | 10 |
-| Dashboard filters/limits/order/select fields/formulas translate to canonical execution fields | 9, 14, 15, 20, 22 |
+| Dashboard filters/limits/order/select fields/formulas translate to canonical execution fields | 9, 14, 15, 20, 22, 24 |
 | Non-empty dashboard HAVING arrays stay saved but block parity claims because frontend execution drops them | 20 |
 | Trace operators become raw-preserved sibling `builder_trace_operator` envelopes | 23 |
 | Unsupported execution-affecting fields block false-positive dry-run success | 20, 21, 22 |
@@ -115,6 +115,7 @@ plugins/signoz/skills/signoz-creating-dashboards/evals/evals.json
 | 21 | `unsupported-builder-function-blocks-lossy-validation` | Current execution schema cannot represent a requested Builder function | metrics | graph | surface unsupported field; never claim a stripped dry-run passed |
 | 22 | `formula-order-limit-schema-gate` | Formula order/limit unsupported by current execution schema | (builder) | table | preserve saved formula; block or explicitly accept unvalidated state |
 | 23 | `trace-operator-sibling-envelope-contract` | Trace-operator dashboard/editor JSON to V5 execution-envelope translation | traces | graph | base A/B plus raw-preserved sibling `builder_trace_operator` T1 in the actual dry-run call |
+| 24 | `saved-not-in-to-execution-not-in` | Logs table excluding checkout and frontend services | logs | table | discover the log-side service field; saved `NOT_IN` maps to execution `NOT IN`; canonical non-empty `groupBy`; short representative 30-60-minute dry-run window, not a display range |
 
 ## Intentionally uncovered
 

--- a/plugins/signoz/skills/signoz-creating-alerts/SKILL.md
+++ b/plugins/signoz/skills/signoz-creating-alerts/SKILL.md
@@ -300,9 +300,11 @@ Step 4 confirmed data flows. Step 6 does two things:
 Run the full primary query (or formula) over the last hour:
 - `signoz_execute_builder_query` for **all** builder, formula,
   and PromQL queries — set `compositeQuery.queries[].type` to
-  `builder_query` / `builder_formula` / `promql` as appropriate. For
-  PromQL specs use only `name` / `query` / `legend` / `disabled`; omit
-  builder-only fields such as `stepInterval`. Put the string in `spec.query`, read
+  `builder_query` / `builder_formula` / `promql` as appropriate. Alert PromQL
+  specs carry only `name` / `query` / `legend` / `disabled`; dry-run execution
+  PromQL specs may also carry `step` / `stats`. Still omit builder-only
+  `stepInterval`.
+  Put the string in `spec.query`, read
   `signoz://promql/instructions` for the UTF-8 quoted-selector form
   SigNoz requires (`{"metric.name.with.dots"}` — not the underscored
   or bare-dotted forms), and keep alert PromQL fully literal: no `$var`,

--- a/plugins/signoz/skills/signoz-creating-alerts/SKILL.md
+++ b/plugins/signoz/skills/signoz-creating-alerts/SKILL.md
@@ -14,19 +14,15 @@ argument-hint: <natural-language alert intent>
 
 # Alert Create
 
-Build a SigNoz alert from a user's natural-language intent. The skill targets
-two consumers: an autonomous AI SRE agent that runs without a human in the
-loop, and a human at a Claude Code / Codex / Cursor prompt. Both go through
-the same flow.
+Build a SigNoz alert from natural-language intent. Autonomous agents and
+interactive clients follow the same flow.
 
 ## Prerequisites
 
-This skill calls SigNoz MCP server tools (`signoz_create_alert`,
-`signoz_list_alert_rules`, `signoz_get_field_keys`, etc.). Before running the
-workflow, confirm the `signoz_*` tools are available. If they are not,
-run `signoz-mcp-setup` first to initialize or repair the MCP connection. Do not
-try to fall back to raw HTTP calls or fabricate alert configs without the MCP
-tools.
+This skill calls SigNoz MCP tools (`signoz_create_alert`,
+`signoz_list_alert_rules`, `signoz_get_field_keys`, etc.). Confirm they are
+available; otherwise run `signoz-mcp-setup`. Never fall back to raw HTTP or
+fabricate alert configs.
 
 ## When to use
 
@@ -45,9 +41,8 @@ Do NOT use when the user wants to:
 
 ## Required inputs (strict)
 
-Alert creation is a write operation against a shared system. Guessing here
-creates noisy alerts on the wrong service that someone else has to clean up.
-The skill enforces a strict input contract:
+Alert creation writes to a shared system. Enforce this strict input contract;
+guesses create noisy alerts on the wrong service:
 
 | Input | Required | Source if missing |
 |---|---|---|
@@ -57,25 +52,19 @@ The skill enforces a strict input contract:
 | Severity | inferred from intent | default `warning`; promote to `critical` only if user said "page", "wake up", "critical" |
 | Notification channel | yes | `signoz_list_notification_channels` + offer "create new" |
 
-If a required input is missing and cannot be discovered, **stop before
-calling any write tool** and ask the user. The host application decides
-how the question is surfaced (a structured clarification tool, inline
-`<assistant_question>` tags, an interactive prompt, etc.) — follow the
-host's UI rendering rules.
+If a required input is missing and undiscoverable, **stop before any write**
+and ask through the host's supported clarification UI.
 
 What to include in the question:
 
-- **What is missing** — name the input concretely (e.g. "which
-  resource-attribute filter to use").
-- **Candidate lists** populated from your discovery calls — concrete
-  values per attribute the user can pick from. Example shape:
+- **What is missing** — name it concretely (e.g. "which resource-attribute
+  filter to use").
+- **Candidate lists** from discovery — concrete values per attribute, e.g.:
   `service.name` → `frontend`, `checkout`, `payments`;
   `host.name` → `prod-api-1`, `prod-db-1`.
-- **Allow free-form input** so the user can name a value you didn't
-  surface.
+- **Free-form input** so the user can name an unsurfaced value.
 
-In autonomous mode (no human), escalate to the caller or fill the gap
-from upstream context. Either way, do not proceed to
+In autonomous mode, escalate or use upstream context; never call
 `signoz_create_alert` with a guessed value.
 
 ## Workflow
@@ -184,10 +173,8 @@ result and ask the user to confirm before save. Treat this exception
 narrowly: it applies to "alert me when bad thing happens" log queries,
 not to alerts that depend on continuous data flow.
 
-This probe is cheap (one query, ~100ms), and catching the no-data case
-early avoids the worst UX failure mode of this skill — the user reading
-through a fully-authored JSON payload and only then learning the alert
-can never fire.
+This cheap probe catches no-data before the user reviews an alert that cannot
+fire.
 
 ### Step 5: Build the alert config
 
@@ -195,6 +182,10 @@ The MCP server is the source of truth for the alert JSON schema, threshold
 codes, and validation rules. Read the `signoz://alert/instructions` and
 `signoz://alert/examples` MCP resources for the canonical, version-current
 shape.
+
+Threshold/PromQL `condition.thresholds` requires `kind` (use `"basic"`) and
+non-empty `spec[]`, except when `alertOnAbsent` is the sole trigger. Anomaly
+rules omit it.
 
 For most user intents, the config is one of a small number of patterns:
 
@@ -209,12 +200,11 @@ For most user intents, the config is one of a small number of patterns:
 | ClickHouse SQL alert — author SQL using the schema in `signoz://alert/examples` | non-trivial joins, custom aggregations the builder cannot express |
 | PromQL alert — delegate to `signoz-generating-queries` for the query, then return here | when user already has PromQL |
 
-**Threshold `op` and `matchType` values.** v2alpha1 accepts the
-human-readable strings (`"above"`, `"on_average"`); the legacy numeric
-codes (`"1"`, `"3"`) are also accepted but harder to read in the UI. Prefer
-the words. Use `op: "above"` for anomaly rules: the anomaly score is already
-an absolute deviation, so this detects both spikes and drops without an
-unsupported `"above_or_below"` operator.
+**Threshold `op` and `matchType` values.** Prefer readable words; symbols and
+legacy numeric codes are accepted but discouraged. Valid `op` words are
+`above`, `below`, `equal`, `not_equal`,
+`above_or_equal`, `below_or_equal`, and `outside_bounds`; `equals` is invalid.
+Use `above` for anomaly rules: their absolute score covers spikes and drops.
 
 | Comparison | `op` | Evaluation behavior | `matchType` |
 |---|---|---|---|
@@ -232,11 +222,8 @@ unsupported `"above_or_below"` operator.
 - `matchType: "at_least_once"` for error counts / error rates —
   catches any breach.
 
-**Severity defaults — derive from the intrinsic urgency of the alert, not
-just the user's words.** The user saying "alert me" doesn't force `warning`
-when the condition itself describes a critical event. Use this table; an
-explicit user cue overrides it ("just FYI" → demote, "page me" / "wake me
-up" → promote).
+**Severity defaults — derive intrinsic urgency, not just wording.** An explicit
+cue overrides this table ("just FYI" → demote; "page me" → promote).
 
 | Alert intent | Default severity |
 |---|---|
@@ -253,13 +240,11 @@ When the user's intent is ambiguous on severity (no urgency cue, no
 clearly-critical condition), default to `warning` and surface the choice
 in the preview so they can adjust.
 
-**OTel attribute names** — always use semantic conventions:
-`service.name`, `host.name`, `k8s.namespace.name`, `deployment.environment` or `deployment.environment.name`. Never `service`, `host`, or `env`.
+**Attribute names** — use exact keys returned by `signoz_get_field_keys`; when
+available they are usually OTel names such as `service.name`, not `service`.
 
-**Annotation templates** — the on-call engineer sees the notification, not
-the alert config. A notification that says "Pod crash detected" with no
-service name, no count, and no value is nearly useless at 3am. Always
-include the moving values:
+**Annotation templates** — include moving values; on-call sees the notification,
+not the config:
 
 - `summary` — single-line headline. Include the resource scope and the
   numeric value: `"checkoutservice error rate {{$value}}% above 3%"`.
@@ -316,10 +301,17 @@ Run the full primary query (or formula) over the last hour:
 - `signoz_execute_builder_query` for **all** builder, formula,
   and PromQL queries — set `compositeQuery.queries[].type` to
   `builder_query` / `builder_formula` / `promql` as appropriate. For
-  PromQL put the query string in `spec.query` and read
+  PromQL specs use only `name` / `query` / `legend` / `disabled`; omit
+  builder-only fields such as `stepInterval`. Put the string in `spec.query`, read
   `signoz://promql/instructions` for the UTF-8 quoted-selector form
   SigNoz requires (`{"metric.name.with.dots"}` — not the underscored
-  or bare-dotted forms).
+  or bare-dotted forms), and keep alert PromQL fully literal: no `$var`,
+  `$__rate_interval`, or other dashboard variable is evaluated.
+- Alert specs omit time bounds, but this dry-run cannot: set outer-query
+  `start` / `end` to absolute JSON integer Unix-ms (e.g. now−3600000 → now),
+  or `signoz_execute_builder_query` fails with `missing start or end timestamp`.
+- For intent grouped by a dimension, each execution `groupBy[].name` is the
+  exact Step 2 key (e.g. `k8s.pod.name`), never empty. Omit `groupBy` otherwise.
 - `signoz_aggregate_logs` / `signoz_aggregate_traces`
   when those fit better.
 - `signoz_query_metrics` when the alert query targets a single
@@ -357,12 +349,8 @@ alert that will never fire.
 
 ### Step 7: Resolve notification channels
 
-The skill **must** resolve at least one channel before save. An alert with no
-channels saves successfully and silently never notifies anyone — the second
-most common silent failure after bad queries. Channel resolution runs after
-the dry-run so any threshold-driven severity changes (warning → critical)
-are settled before the user is asked to pick routing, and so we never
-create a notification channel inline for an alert that fails validation.
+Resolve at least one channel after dry-run and final severity; otherwise the
+alert saves but never notifies.
 
 1. Call `signoz_list_notification_channels` and follow
    `pagination.nextOffset` while `pagination.hasMore` is true.
@@ -377,17 +365,23 @@ create a notification channel inline for an alert that fails validation.
 4. If neither path resolves a channel, stop and ask the user for a
    notification channel (see *Required inputs* above).
 
+Channel creation is admin-gated. On `PERMISSION_DENIED`, have an admin create it
+out of band or configure a dedicated, short-lived minimum-role credential via
+the host's environment/secret store; never request an elevated key in chat or
+tracked config.
+
 Place the resolved channel according to the rule schema:
 
 - `threshold_rule` / `promql_rule` (v2alpha1): attach direct-routing channels
   to each `condition.thresholds.spec[N].channels` array — typically warning →
-  Slack only, critical → Slack + PagerDuty.
+  Slack only, critical → Slack + PagerDuty. When `alertOnAbsent` is the sole
+  trigger and thresholds are omitted, put fallback channels in top-level
+  `preferredChannels`.
 - `anomaly_rule` (v1): thresholds are forbidden, so put channel names in the
   top-level `preferredChannels` array.
 
-Never put a chosen anomaly channel in a nonexistent thresholds block, and do
-not use top-level `preferredChannels` as a substitute for per-tier routing on a
-multi-severity threshold rule.
+Never put a chosen anomaly or absent-only channel in a nonexistent thresholds
+block, or substitute `preferredChannels` for per-tier multi-severity routing.
 
 #### Handling secret-bearing channel config
 
@@ -445,17 +439,14 @@ does).
 
 ## Guardrails
 
-- **Strict inputs over guessing** Resource attribute and channel are
-  required. If missing, stop and ask the user (see *Required inputs* above). Creating an alert on
-  a guessed service is harder to undo than asking.
+- **Strict inputs over guessing** Resource attribute and channel are required;
+  if missing, stop and ask rather than guessing a service.
 - **Always paginate `signoz_list_alert_rules`** Stopping at page 1 misses
   duplicates and produces noise.
-- **Dry-run is mandatory** Step 4 (data probe) and Step 6 (full
-  query + threshold calibration) are both required before
-  `signoz_create_alert`. A never-firing alert is *worse* than no
-  alert: it provides a false sense of safety.
-- **Threshold operators use canonical words** Prefer `op: "above"` /
-  `"below"` / `"equal"` / `"not_equal"`. Numeric codes (`"1"`–`"7"`)
+- **Dry-run is mandatory** Complete Steps 4 and 6 before
+  `signoz_create_alert`; a never-firing alert creates false confidence.
+- **Threshold operators use canonical words** Prefer valid words, never
+  `equals`. Numeric codes (`"1"`–`"7"`)
   are accepted but discouraged — same goes for `matchType`
   (`"on_average"` / `"at_least_once"`, not `"3"` / `"1"`).
 - **Signal must match alertType** `signal: "logs"` requires
@@ -464,8 +455,8 @@ does).
   is rejected.
 - **Channels must exist and use the rule's routing field.** Use exact names
   from `signoz_list_notification_channels`; put them in per-threshold
-  `channels` for threshold/PromQL rules or top-level `preferredChannels` for
-  anomaly rules.
+  `channels` for threshold/PromQL rules, or top-level `preferredChannels` for
+  anomaly and absent-only threshold/PromQL rules without thresholds.
 - **Never echo channel secrets.** Slack webhook URLs, PagerDuty integration
   keys, and similar webhook tokens are secrets. Pass them to
   `signoz_create_notification_channel` once and never repeat the

--- a/plugins/signoz/skills/signoz-creating-alerts/evals/evals.json
+++ b/plugins/signoz/skills/signoz-creating-alerts/evals/evals.json
@@ -8,6 +8,7 @@
       "expected_output": "Multi-severity METRIC_BASED_ALERT with two thresholds (warning 80, critical 90), per-severity channels (slack on warning, pagerduty on critical), service.name='cartservice' filter on a CPU metric (e.g. system.cpu.utilization or k8s.pod.cpu.utilization), targetUnit percent, op='above', matchType='on_average' (canonical word form preferred over numeric codes). Runs a concrete-metric data probe, then the mandatory full-query dry-run before emitting a plain-language summary and saving.",
       "expectations": [
         "The data probe calls signoz_query_metrics with a concrete metricName and the cartservice filter; it never sends count() or count_distinct(service.name) as a metrics aggregation expression",
+        "Every signoz_execute_builder_query dry-run carries start and end as JSON integer Unix-millisecond values in the outer query",
         "The signoz_create_alert payload puts Slack in the warning threshold channels and PagerDuty in the critical threshold channels",
         "The threshold-rule create payload does not rely on top-level preferredChannels for its per-severity routing"
       ],
@@ -57,7 +58,22 @@
       "expectations": [
         "The trace data probe calls signoz_aggregate_traces with aggregation=count, never aggregation=count()",
         "The full dry-run preserves having.expression=count() > 50 in the Query Builder spec",
+        "The actual signoz_execute_builder_query dry-run carries start and end as JSON integer Unix-millisecond values in the outer query",
         "The signoz_create_alert payload places both Slack and PagerDuty names in the critical threshold channels array"
+      ],
+      "files": []
+    },
+    {
+      "id": 5,
+      "eval_name": "absent-data-sole-trigger-omits-thresholds",
+      "prompt": "Create an alert for checkoutservice that fires only when its request metric stops arriving. Notify #staging-alerts.",
+      "expected_output": "Agent discovers and probes a concrete checkoutservice request metric, builds a threshold/PromQL-family absent-data rule whose sole trigger is alertOnAbsent, validates the full query with absolute integer Unix-ms bounds, and creates the alert without condition.thresholds. It routes #staging-alerts through top-level preferredChannels rather than inventing an empty thresholds block or numeric threshold.",
+      "expectations": [
+        "Agent discovers a concrete metric and verifies the checkoutservice filter before authoring the alert",
+        "The full signoz_execute_builder_query dry-run has start and end as JSON integer Unix-millisecond values in the outer query",
+        "The signoz_create_alert payload enables alertOnAbsent as the sole trigger",
+        "The signoz_create_alert payload omits condition.thresholds entirely rather than sending an empty or fabricated threshold spec",
+        "The signoz_create_alert payload puts #staging-alerts in top-level preferredChannels"
       ],
       "files": []
     }

--- a/plugins/signoz/skills/signoz-creating-dashboards/SKILL.md
+++ b/plugins/signoz/skills/signoz-creating-dashboards/SKILL.md
@@ -397,8 +397,10 @@ For every query-bearing panel, read the compact
 [`dashboard-to-query-builder-v5` reference](./references/dashboard-to-query-builder-v5.md).
 When the execution schema can represent the panel, call
 `signoz_execute_builder_query` with the translated payload, never widget JSON.
-Use representative variable values and keep editor aliases unchanged in
-`signoz_create_dashboard`.
+Dry-run over a short absolute Unix-ms window — usually the last 30-60 minutes,
+never the panel's display range by reflex; apply the reference's dry-run hygiene
+rules before widening or retrying after a timeout. Use representative variable
+values and keep editor aliases unchanged in `signoz_create_dashboard`.
 
 If the reference's safety gate finds an unsupported execution field, report the
 panel as unvalidated and continue only after explicit user acceptance. Server or

--- a/plugins/signoz/skills/signoz-creating-dashboards/SKILL.md
+++ b/plugins/signoz/skills/signoz-creating-dashboards/SKILL.md
@@ -346,9 +346,10 @@ table and pie accept `builder` or `clickhouse_sql`; list requires `builder`.
 `softMax` / `softMin` are numbers, `contextLinks` is `{"linksData": [...]}`, and
 saved `having` is an array of clause objects; defer full shapes to the resources.
 
-Keep widget/layout IDs bijective: every `widgets[].id` appears exactly once in
-`layout[].i` and vice versa; create/remove both entries together. During import
-or rebuild, strip the UI drag artifact id `"__dropping-elem__"` from both arrays.
+Keep non-row widget/layout IDs bijective; create/remove both entries together.
+Row widgets need no layout entry; preserve matching row layout entries when
+present. During import or rebuild, strip the UI drag artifact id
+`"__dropping-elem__"` from both arrays.
 
 **Defaults the skill applies (and surfaces in the preview):**
 

--- a/plugins/signoz/skills/signoz-creating-dashboards/SKILL.md
+++ b/plugins/signoz/skills/signoz-creating-dashboards/SKILL.md
@@ -310,6 +310,11 @@ core resources before authoring widget JSON.
 Add signal-specific resources as needed:
 
 - Metrics (PromQL): `signoz://promql/instructions`.
+  Saved PromQL may reference declared dashboard `$var` variables, but
+  `signoz_execute_builder_query` does not expand them: substitute representative
+  literals only for dry-runs, never in saved panels. Grafana-only
+  `$__rate_interval` / `$__interval` are invalid. Dotted OTel metric names use
+  Prometheus 3.x UTF-8 selectors such as `{"metric.name.with.dots"}`.
 - Metrics (ClickHouse): `signoz://dashboard/clickhouse-schema-for-metrics`
   + `signoz://dashboard/clickhouse-metrics-example`.
 - Metrics (Query Builder aggregation rules):
@@ -333,6 +338,17 @@ refresh interval. Panels follow the viewer-selected global range. If the user
 asks for a specific window, mention that range in the final handoff instead of
 inventing `timeRange`, `defaultTimeRange`, or `refresh` fields. Do not encode a
 PromQL range selector inside a Builder query.
+
+Use SigNoz enums and JSON types exactly. `panelTypes: "graph"` means time series
+(never Grafana `timeseries`); variable types are uppercase (`DYNAMIC`, `CUSTOM`).
+PromQL `queryType` is valid only for graph, value, bar, and histogram panels;
+table and pie accept `builder` or `clickhouse_sql`; list requires `builder`.
+`softMax` / `softMin` are numbers, `contextLinks` is `{"linksData": [...]}`, and
+saved `having` is an array of clause objects; defer full shapes to the resources.
+
+Keep widget/layout IDs bijective: every `widgets[].id` appears exactly once in
+`layout[].i` and vice versa; create/remove both entries together. During import
+or rebuild, strip the UI drag artifact id `"__dropping-elem__"` from both arrays.
 
 **Defaults the skill applies (and surfaces in the preview):**
 
@@ -449,7 +465,8 @@ accepted absent telemetry. Skip row panels and validate their shape against
   `signoz://dashboard/*` MCP resources. Required widget and `queryData`
   fields are listed in `signoz://dashboard/widgets-instructions` and
   `signoz://dashboard/widgets-examples`. Never wrap arrays/objects in
-  `JSON.stringify`.
+  `JSON.stringify`; enforce the widget/layout bijection, field types, and enums
+  from Step 3b-ii.4.
 - **Scope boundary** This skill creates dashboards. The moment the
   user asks to modify, edit, rearrange, or extend an existing dashboard
   — including immediately after import — hand off to

--- a/plugins/signoz/skills/signoz-creating-dashboards/evals/evals.json
+++ b/plugins/signoz/skills/signoz-creating-dashboards/evals/evals.json
@@ -349,12 +349,12 @@
       "id": 24,
       "eval_name": "saved-not-in-to-execution-not-in",
       "prompt": "Create a logs table grouped by service that excludes checkout and frontend services.",
-      "expected_output": "Agent discovers the actual log-side service field, saves the panel with the dashboard groupBy key shape and filters.items op=NOT_IN, then dry-runs the canonical execution form with filter.expression using NOT IN and a non-empty groupBy name. The dry-run outer query includes absolute integer Unix-ms bounds; the saved and execution filters remain semantically identical.",
+      "expected_output": "Agent discovers the actual log-side service field, saves the panel with the dashboard groupBy key shape and filters.items op=NOT_IN, then dry-runs the canonical execution form with filter.expression using NOT IN and a non-empty groupBy name. The dry-run outer query includes absolute integer Unix-ms bounds spanning a short representative 30-60-minute window, not a multi-hour or multi-day display range; the saved and execution filters remain semantically identical.",
       "expectations": [
         "Agent calls signoz_get_field_keys with signal=logs and uses the returned service field name rather than assuming service.name exists on logs",
         "The signoz_create_dashboard payload keeps groupBy in dashboard form and filters.items uses op=NOT_IN, never the execution spelling NOT IN",
         "The actual signoz_execute_builder_query call uses filter.expression with NOT IN and sends no filters field",
-        "The actual dry-run outer query contains start and end as JSON integer Unix-millisecond values",
+        "The actual dry-run outer query contains start and end as JSON integer Unix-millisecond values and spans a short representative window (roughly the last 30-60 minutes, not a multi-hour or multi-day display range)",
         "Every execution groupBy entry has a non-empty name equal to the discovered attribute key and contains no dashboard-only key/dataType/type aliases",
         "The saved NOT_IN values and execution NOT IN values are semantically identical"
       ],

--- a/plugins/signoz/skills/signoz-creating-dashboards/evals/evals.json
+++ b/plugins/signoz/skills/signoz-creating-dashboards/evals/evals.json
@@ -143,6 +143,7 @@
         "Payload sent to signoz_create_dashboard has layout as an array of objects (not a stringified JSON string)",
         "Payload sent to signoz_create_dashboard has widgets as an array of objects (not a stringified JSON string)",
         "Each widget in the payload includes id, panelTypes, title, query, selectedLogFields, selectedTracesFields, thresholds, and contextLinks",
+        "Each widget contextLinks is an object with a linksData array, never a bare array",
         "The widget's query object includes queryType and the complete active Builder payload; inactive PromQL and ClickHouse payloads need not be authored",
         "Agent runs signoz_execute_builder_query as a dry-run for the panel before signoz_create_dashboard"
       ],
@@ -341,6 +342,21 @@
         "The builder_trace_operator spec is passed through the current MCP raw-preservation contract and is never coerced into builder_query",
         "The execution trace-operator spec does not copy dashboard aliases queryName, dataSource, pageSize, orderBy, selectColumns, or queryTraceOperator, and does not invent signal, filter, functions, or disabled fields",
         "Agent does not call signoz_create_dashboard until the complete trace-operator execution call succeeds"
+      ],
+      "files": []
+    },
+    {
+      "id": 24,
+      "eval_name": "saved-not-in-to-execution-not-in",
+      "prompt": "Create a logs table grouped by service that excludes checkout and frontend services.",
+      "expected_output": "Agent discovers the actual log-side service field, saves the panel with the dashboard groupBy key shape and filters.items op=NOT_IN, then dry-runs the canonical execution form with filter.expression using NOT IN and a non-empty groupBy name. The dry-run outer query includes absolute integer Unix-ms bounds; the saved and execution filters remain semantically identical.",
+      "expectations": [
+        "Agent calls signoz_get_field_keys with signal=logs and uses the returned service field name rather than assuming service.name exists on logs",
+        "The signoz_create_dashboard payload keeps groupBy in dashboard form and filters.items uses op=NOT_IN, never the execution spelling NOT IN",
+        "The actual signoz_execute_builder_query call uses filter.expression with NOT IN and sends no filters field",
+        "The actual dry-run outer query contains start and end as JSON integer Unix-millisecond values",
+        "Every execution groupBy entry has a non-empty name equal to the discovered attribute key and contains no dashboard-only key/dataType/type aliases",
+        "The saved NOT_IN values and execution NOT IN values are semantically identical"
       ],
       "files": []
     }

--- a/plugins/signoz/skills/signoz-creating-dashboards/references/dashboard-to-query-builder-v5.md
+++ b/plugins/signoz/skills/signoz-creating-dashboards/references/dashboard-to-query-builder-v5.md
@@ -20,8 +20,21 @@ unsupported unless the tool schema exposes them. `legend` may remain saved-only.
 Saved panels persist no time range. Build the complete outer `query` with
 absolute `start` / `end` as JSON integer Unix-ms (for example, the last hour),
 request type, composite queries, format options, and representative variable
-values; omitted bounds fail with `missing start or end timestamp`. Dashboard
-request types are: graph/bar/histogram -> `time_series`;
+values; omitted bounds fail with `missing start or end timestamp`.
+Start every dry-run with the shortest representative window likely to contain
+data, usually the last 30-60 minutes; never use the panel's display range by reflex.
+If empty, widen according to signal cadence and report the exact windows tested
+rather than concluding telemetry is absent. A dry-run validates execution only
+for that window, not correctness across every dashboard range. A PromQL range
+selector looks backward from each evaluation timestamp: widening outer `start` /
+`end` adds evaluations rather than "covering" a long selector, and long selectors
+such as `[12h]` remain costly even with short outer bounds.
+
+On a timeout, never resend the identical payload. Shrink the window, coarsen the
+type-appropriate interval when available (PromQL `step`; Builder
+`stepInterval`; ClickHouse has no equivalent), or reduce query cost first.
+
+Dashboard request types are: graph/bar/histogram -> `time_series`;
 table/pie/value -> `scalar`; trace -> `trace`; list -> `raw`. These are the only
 execution values; never invent `aggregate`, `table`, or `timeseries`. MCP
 dashboard writes validate `panelTypes` against
@@ -70,8 +83,23 @@ Trace operator: emit a raw-preserved `builder_trace_operator` with `name` from
 (`count()` for a count panel; omit for raw). Never coerce it to `builder_query`,
 copy dashboard aliases, or invent `signal`, `filter`, `functions`, or `disabled`.
 
-PromQL and ClickHouse bypass this Builder crosswalk; build their current MCP
-envelopes from the corresponding resources without dropping fields.
+## PromQL and ClickHouse panels
+
+These bypass the Builder crosswalk, but their execution envelopes are fixed. Saved
+widgets use `query.promql[]` / `query.clickhouse_sql[]` with `queryType`; never
+copy those arrays under execution `compositeQuery`.
+Map each saved `query.promql[]` item to one `compositeQuery.queries[]` entry:
+`{"type": "promql", "spec": {"name": "A", "query": "<promql>"}}`. Optional
+spec fields are `disabled`, `step`, `stats`, and `legend`. The type is exactly
+`promql`, never `promql_query`.
+Map each saved `query.clickhouse_sql[]` item to one `compositeQuery.queries[]`
+entry: `{"type": "clickhouse_sql", "spec": {"name": "A", "query": "<sql>"}}`;
+optional spec fields are `disabled` and `legend`.
+Always set `requestType` with the Builder panel mapping above. The server's
+`time_series` default when PromQL omits it is fallback only; ClickHouse has no
+default. Substitute representative literals for `$var` in dry-runs only; saved
+panels keep `$var`. Read `signoz://promql/instructions` for selector syntax and
+the matching `signoz://dashboard/clickhouse-*` resources for ClickHouse schema.
 
 ## Saved payload invariant
 

--- a/plugins/signoz/skills/signoz-creating-dashboards/references/dashboard-to-query-builder-v5.md
+++ b/plugins/signoz/skills/signoz-creating-dashboards/references/dashboard-to-query-builder-v5.md
@@ -23,7 +23,11 @@ request type, composite queries, format options, and representative variable
 values; omitted bounds fail with `missing start or end timestamp`. Dashboard
 request types are: graph/bar/histogram -> `time_series`;
 table/pie/value -> `scalar`; trace -> `trace`; list -> `raw`. These are the only
-values; never invent `aggregate`, `table`, or `timeseries`.
+execution values; never invent `aggregate`, `table`, or `timeseries`. MCP
+dashboard writes validate `panelTypes` against
+graph/value/table/list/bar/pie/histogram only; never author a new trace panel.
+Use a list panel with raw trace rows instead; keep `trace` -> `trace` only when
+executing an existing saved panel.
 
 Put every dependency in one `compositeQuery.queries` array: `queryData[]` ->
 `builder_query`; `queryFormulas[]` -> sibling `builder_formula`;

--- a/plugins/signoz/skills/signoz-creating-dashboards/references/dashboard-to-query-builder-v5.md
+++ b/plugins/signoz/skills/signoz-creating-dashboards/references/dashboard-to-query-builder-v5.md
@@ -17,10 +17,13 @@ unsupported unless the tool schema exposes them. `legend` may remain saved-only.
 
 ## Translate one panel
 
-Build the complete outer `query` with its time range, request type, composite
-queries, format options, and representative variable values. Dashboard request
-types are: graph/time-series/bar/histogram -> `time_series`; table/pie/value ->
-`scalar`; trace -> `trace`; list -> `raw`.
+Saved panels persist no time range. Build the complete outer `query` with
+absolute `start` / `end` as JSON integer Unix-ms (for example, the last hour),
+request type, composite queries, format options, and representative variable
+values; omitted bounds fail with `missing start or end timestamp`. Dashboard
+request types are: graph/bar/histogram -> `time_series`;
+table/pie/value -> `scalar`; trace -> `trace`; list -> `raw`. These are the only
+values; never invent `aggregate`, `table`, or `timeseries`.
 
 Put every dependency in one `compositeQuery.queries` array: `queryData[]` ->
 `builder_query`; `queryFormulas[]` -> sibling `builder_formula`;
@@ -30,9 +33,13 @@ For each `builder_query`:
 
 - `queryName` -> `name`; `dataSource` -> `signal`.
 - Use `filter.expression`, or convert `filters.items[]` and `filters.op` exactly.
-  Never send `filters`.
-- `groupBy[].key/dataType/type` -> `name/fieldDataType/fieldContext`; set
-  `signal` from the field or enclosing query. Send no dashboard aliases.
+  Saved operators use underscore enums (`NOT_IN`); execution expressions use
+  SQL-ish forms (`NOT IN`). Translate, never mix representations, and keep both
+  forms semantically aligned when saved JSON contains both. Never send `filters`.
+- Saved `groupBy[].key/dataType/type` -> execution
+  `name/fieldDataType/fieldContext`; set `signal` from the field or enclosing
+  query. For "by <dimension>", `name` is the actual attribute key and never
+  empty; omit `groupBy` when ungrouped. Send no dashboard aliases.
 - `selectColumns[]` -> `selectFields[]`: `name` from `name` or `key`,
   `fieldDataType` from `fieldDataType` or `dataType`, `fieldContext` from
   `fieldContext` or `type`, plus `signal`. Send only canonical metadata.

--- a/plugins/signoz/skills/signoz-explaining-alerts/SKILL.md
+++ b/plugins/signoz/skills/signoz-explaining-alerts/SKILL.md
@@ -89,6 +89,8 @@ pass that value as `cursor`, replace `timeRange` with the note's resolved
 absolute `start` and `end`, and preserve the same state, filter, and order.
 Stop when `nextCursor` is absent / the note reports `hasMore: false`. Never use
 `offset` or infer completeness from page fullness.
+History `state` accepts only `firing` or `inactive`; when intentionally filtering
+for "resolved" / "recovered", use `state: "inactive"`, never `resolved`.
 Derive a single rule-level line from the complete set. History rows are emitted
 per label-group `fingerprint`, so never equate row count with alert-fire count.
 Count distinct rule transitions where `overallStateChanged: true` and

--- a/plugins/signoz/skills/signoz-explaining-alerts/SKILL.md
+++ b/plugins/signoz/skills/signoz-explaining-alerts/SKILL.md
@@ -89,8 +89,9 @@ pass that value as `cursor`, replace `timeRange` with the note's resolved
 absolute `start` and `end`, and preserve the same state, filter, and order.
 Stop when `nextCursor` is absent / the note reports `hasMore: false`. Never use
 `offset` or infer completeness from page fullness.
-History `state` accepts only `firing` or `inactive`; when intentionally filtering
-for "resolved" / "recovered", use `state: "inactive"`, never `resolved`.
+History `state` accepts `inactive`, `pending`, `recovering`, `firing`, `nodata`,
+or `disabled`. For "resolved" / "recovered", use `state: "inactive"`;
+`resolved` is not a value; `recovering` is a transient keep-firing state, not resolution.
 Derive a single rule-level line from the complete set. History rows are emitted
 per label-group `fingerprint`, so never equate row count with alert-fire count.
 Count distinct rule transitions where `overallStateChanged: true` and

--- a/plugins/signoz/skills/signoz-generating-queries/SKILL.md
+++ b/plugins/signoz/skills/signoz-generating-queries/SKILL.md
@@ -139,9 +139,9 @@ For `signoz_aggregate_logs` / `signoz_aggregate_traces`, `aggregation` is one
 bare token: `count`, `count_distinct`, `avg`, `sum`, `min`, `max`, `p50`, `p75`,
 `p90`, `p95`, `p99`, or `rate`. Never include parentheses or a column; put the
 column in `aggregateOn` (`count` and `rate` need none). Omit `orderBy` for the
-default aggregation-expression descending order; explicit ordering must name a
-`groupBy` key or the aggregation expression per the tool schema. Custom aliases
-or formulas require `signoz_execute_builder_query`.
+default aggregation-expression descending order; explicit ordering should use a
+`groupBy` key or the aggregation expression. Custom aliases or formulas require
+`signoz_execute_builder_query`.
 
 **`requestType` decision for aggregations:**
 - `scalar` (default): "How many?", "What is the p99?", "Which service has the most?"
@@ -166,10 +166,11 @@ not apply to PromQL or ClickHouse SQL envelopes.
   result relevance.
 - Respect the requested range; otherwise use 1h. Search/aggregate log and trace
   tools accept relative `timeRange` strings (`"1h"`, `"24h"`; default `1h`) —
-  prefer them. Valid Unix-ms `start`/`end` override `timeRange`; malformed values
-  error with `use timeRange instead`. `signoz_execute_builder_query` has no
-  relative option: its outer `query` requires absolute `start` and `end` as JSON
-  integer Unix-ms or fails with `missing start or end timestamp`.
+  prefer them. Valid Unix-ms `start`/`end` override `timeRange`; malformed explicit
+  timestamps return validation guidance pointing to `timeRange`.
+  `signoz_execute_builder_query` has no relative option: its outer `query` requires
+  absolute `start` and `end` as JSON integer Unix-ms or fails with
+  `missing start or end timestamp`.
 - Use shortcut parameters (`service`, `severity`, `operation`, `error`) when they
   match the user's filters — they are simpler and less error-prone than building
   `filter` expressions.

--- a/plugins/signoz/skills/signoz-generating-queries/SKILL.md
+++ b/plugins/signoz/skills/signoz-generating-queries/SKILL.md
@@ -58,6 +58,9 @@ Map the user's intent to the right signal:
 | Ingestion volume (bytes or count), cost, or billing usage | **metrics** with `source=meter` (Cost Meter) | `signoz.meter.*` ingestion metrics (logs/spans/datapoints by count **and** bytes) live only in the meter store; bytes are unavailable on the raw signals. Dollar **cost is not a metric** — derive it from volume × per-unit price (see Step 2). groupBy/filter work like a normal metric, but only over the limited attribute set the meter retains (not arbitrary log/trace fields). For a *count* sliced by an attribute the meter doesn't carry, aggregate logs/traces directly instead. |
 | "How many X per Y" (count/rate grouped by dimension) | **traces** or **logs** (aggregate) | Use `signoz_aggregate_traces` or `signoz_aggregate_logs` for grouped counts. |
 
+Traces have no unqualified full-text search; use `CONTAINS` against a discovered
+structured trace field. `searchText`-style body search is logs-only.
+
 If the signal is genuinely ambiguous, ask the user before proceeding. The
 host application decides how the question is surfaced (e.g. a structured
 clarification tool or an inline `<assistant_question>` tag) — follow the
@@ -73,7 +76,19 @@ Run discovery calls in parallel where possible:
 - **For metrics**: Call `signoz_list_metrics` with a `searchText` substring
   matching the user's intent (e.g., `searchText: "http"`, `searchText: "latency"`).
   The response includes metric type, temporality, and isMonotonic — pass these to
-  `signoz_query_metrics` to avoid extra lookups.
+  `signoz_query_metrics` to avoid extra lookups. Before filtering or grouping,
+  discover labels with `signoz_get_field_keys(signal: "metrics", metricName:
+  <discovered-name>)`; metric labels are not trace/log attributes (`db.system`,
+  for example, is a span attribute unless discovery also returns it for metrics).
+
+  Choose `timeAggregation` from the discovered metric metadata:
+
+  | Metric type | Valid `timeAggregation` |
+  |---|---|
+  | gauge | `latest`, `sum`, `avg`, `min`, `max`, `count`, `count_distinct` |
+  | monotonic counter/sum | `rate`, `increase` |
+  | non-monotonic sum | `avg`, `sum`, `min`, `max`, `count`, `count_distinct` — never `latest` or `rate` |
+  | histogram / exponential histogram | omit; aggregation is automatic |
 - **For Cost Meter** (ingestion volume, cost, billing): pass `source=meter` to
   `signoz_list_metrics` to discover the metrics (`signoz.meter.*`) — they're
   invisible in the default store and the set evolves, so don't hardcode it.
@@ -91,14 +106,20 @@ Run discovery calls in parallel where possible:
   following `pagination.nextOffset` while `pagination.hasMore` is true before
   declaring it missing.
   Optionally call `signoz_get_service_top_operations` for the service to find
-  operation names. Call `signoz_get_field_keys(signal: "traces")` if you need
-  to filter on a non-standard attribute.
-- **For logs**: Call `signoz_get_field_keys(signal: "logs")` if filtering on
-  attributes beyond `body`, `severity_text`, and `service.name`. Call
-  `signoz_get_field_values` to validate specific filter values.
+  operation names. Before any attribute filter or grouping, call
+  `signoz_get_field_keys(signal: "traces")`.
+- **For logs**: Before any attribute filter or grouping, call
+  `signoz_get_field_keys(signal: "logs")`; use `signoz_get_field_values` only
+  after discovery to validate values.
 
-If the user already provides exact field names, service names, or metric names
-from context (e.g., from a dashboard or @mention), skip redundant discovery.
+Field keys are signal-specific: `service.name` may be absent on logs, while
+`body` is logs-only. Never carry a key across signals. Skip key discovery only
+when live output in this conversation returned it for the same signal — never
+for user text or memory. Use returned dot notation verbatim, not camelCase
+guesses such as `traceID` or `hostname`. Never assume tenant keys (`org.id`,
+`orgId`, `organization_id`, etc.); discover the actual key per signal. Call
+`signoz_get_field_keys` before `signoz_get_field_values`; both require `signal`,
+and values also require a non-empty discovered `name`.
 
 ### Step 3: Choose the right tool
 
@@ -106,26 +127,49 @@ from context (e.g., from a dashboard or @mention), skip redundant discovery.
 
 | Question type | Tool | When to use |
 |---|---|---|
-| Metric time series or scalar | `signoz_query_metrics` | Ordinary metrics queries, plus Cost Meter trends or per-second rates. Handles aggregation defaults automatically and supports formulas via `formula` + `formulaQueries` params. |
+| Metric time series, scalar, ratio, or formula | `signoz_query_metrics` | Ordinary metrics queries, Cost Meter trends/rates, and metric ratios via `formula` + `formulaQueries`. |
 | Cost Meter total or grouped total attribution | `signoz_execute_builder_query` | Use the discovered meter metric with raw `timeAggregation: "sum"`; sum complete hourly buckets. Do not use `signoz_query_metrics` for totals. |
 | Log search (find matching entries) | `signoz_search_logs` | Finding specific log lines. Use `searchText` for body text, `filter` for field filters, `severity` for level filtering. |
 | Trace search (find matching spans) | `signoz_search_traces` | Finding specific traces/spans. Use `service`, `operation`, `error`, `minDuration`/`maxDuration` shortcuts plus `filter` for field filters. |
-| Log aggregation (count, avg, percentiles) | `signoz_aggregate_logs` | "How many errors?", "error count by service", "p99 response time from logs". Set `requestType` to `scalar` for totals or `time_series` for trends. |
-| Trace aggregation (count, avg, percentiles) | `signoz_aggregate_traces` | "p99 latency for checkout", "error count per operation", "request rate by endpoint". Set `requestType` to `scalar` for totals or `time_series` for trends. |
-| Complex multi-query or formula | `signoz_execute_builder_query` | Only when simpler tools cannot express it. Read the guide for the actual signal: traces or logs query-builder guide, metrics aggregation guide, or PromQL instructions. |
+| Log aggregation (count, avg, percentiles) | `signoz_aggregate_logs` | Plain totals, grouped counts, and top-N by one aggregation. |
+| Trace aggregation (count, avg, percentiles) | `signoz_aggregate_traces` | Plain totals, grouped counts, and top-N by one aggregation. |
+| Complex log/trace formula or shaping | `signoz_execute_builder_query` | Use when ratios, shaping, ordering, or cardinality control exceed the convenience tools; never hand-build a plain grouped count. |
+
+For `signoz_aggregate_logs` / `signoz_aggregate_traces`, `aggregation` is one
+bare token: `count`, `count_distinct`, `avg`, `sum`, `min`, `max`, `p50`, `p75`,
+`p90`, `p95`, `p99`, or `rate`. Never include parentheses or a column; put the
+column in `aggregateOn` (`count` and `rate` need none). Omit `orderBy` for the
+default aggregation-expression descending order; explicit ordering must name a
+`groupBy` key or the aggregation expression per the tool schema. Custom aliases
+or formulas require `signoz_execute_builder_query`.
 
 **`requestType` decision for aggregations:**
 - `scalar` (default): "How many?", "What is the p99?", "Which service has the most?"
 - `time_series`: "When did errors spike?", "How did latency change?", "Show trend"
 - If the question has ANY temporal component (spike, trend, change), use `time_series`
 
+Aggregate tools accept only `scalar` or `time_series`. For builder-query
+envelopes passed to `signoz_execute_builder_query`, use only:
+
+| Signal | Valid `requestType` |
+|---|---|
+| metrics | `time_series`, `scalar` |
+| traces | `raw`, `trace`, `scalar`, `time_series` |
+| logs | `raw`, `scalar`, `time_series` |
+
+Never invent `aggregate`, `table`, `timeseries`, or `series`. This matrix does
+not apply to PromQL or ClickHouse SQL envelopes.
+
 ### Step 4: Execute the query
 
 - Always include `searchContext` with the user's original question — it improves
   result relevance.
-- Default time range is last 1 hour. Respect the user's time range if specified.
-  Convert relative times ("last 6 hours", "yesterday") to `timeRange` param format
-  (e.g., `6h`, `24h`) or Unix millisecond `start`/`end`.
+- Respect the requested range; otherwise use 1h. Search/aggregate log and trace
+  tools accept relative `timeRange` strings (`"1h"`, `"24h"`; default `1h`) —
+  prefer them. Valid Unix-ms `start`/`end` override `timeRange`; malformed values
+  error with `use timeRange instead`. `signoz_execute_builder_query` has no
+  relative option: its outer `query` requires absolute `start` and `end` as JSON
+  integer Unix-ms or fails with `missing start or end timestamp`.
 - Use shortcut parameters (`service`, `severity`, `operation`, `error`) when they
   match the user's filters — they are simpler and less error-prone than building
   `filter` expressions.
@@ -172,8 +216,13 @@ from context (e.g., from a dashboard or @mention), skip redundant discovery.
 
 ## Guardrails
 
-- **Discovery first**: Never guess metric names, field names, or service names.
-  Use discovery tools or context to confirm they exist before querying.
+- **Discovery first**: Never guess metric, field, or service names. A field is
+  confirmed only by live output for the same signal in this conversation.
+- **Supply required parameters**: Never invoke tools hoping they auto-discover.
+  `signoz_aggregate_*` requires `aggregation`; `signoz_query_metrics` requires a
+  `metricName` from `signoz_list_metrics`; `signoz_get_trace_details` requires a
+  `traceId`; `signoz_get_service_top_operations` requires a `service` from
+  `signoz_list_services`. Discover first, then call.
 - **Never claim root cause**: Present data patterns and correlations. Write
   "Error rate for checkout increased from 0.2% to 4.1% at 14:05" not "The
   deployment caused the errors."
@@ -191,7 +240,7 @@ from context (e.g., from a dashboard or @mention), skip redundant discovery.
   write, build, generate, or show a query, include an `apply_filter` action
   on your final assistant message with the exact full v5 `query` object you
   passed to a successful `signoz_execute_builder_query` call in this turn. The
-  chip carries the entire query-range envelope (`schemaVersion`, `start`,
+  chip carries the entire query-range envelope (`schemaVersion: "v1"`, `start`,
   `end`, `requestType`, `compositeQuery`), not just the inner
   `compositeQuery`, and you must copy it verbatim rather than reconstructing
   it. If you answered via simplified tools (`signoz_search_logs`,
@@ -215,13 +264,15 @@ from context (e.g., from a dashboard or @mention), skip redundant discovery.
    returns `signoz_calls_total` with `metricType: "sum"`,
    `temporality: "cumulative"`, and `isMonotonic: true`.
 2. Calls `signoz_get_field_keys(signal: "metrics", metricName:
-   "signoz_calls_total", searchText: "status")`, then calls
-   `signoz_get_field_values` with `signal: "metrics"`, the returned field
-   `name` and `fieldContext`, and the same `metricName`, confirming the error
-   value `STATUS_CODE_ERROR`.
+   "signoz_calls_total")` to discover both service and error labels, then
+   `signoz_get_field_values` for each returned `name` / `fieldContext` with the
+   same metric, confirming `checkout-service` and `STATUS_CODE_ERROR`. This
+   example's returned names are `service.name` and `status_code`; use whatever
+   names live discovery returns.
 3. Calls `signoz_query_metrics` with these complete arguments. The primary
    arguments define query A; `formulaQueries` explicitly defines query B with
-   a different filter so the denominator includes every checkout request:
+   a different filter so the denominator includes every checkout request. Both
+   filters use the label names returned in Step 2 verbatim:
 
    ```json
    {
@@ -298,7 +349,8 @@ from context (e.g., from a dashboard or @mention), skip redundant discovery.
 **Agent:**
 1. Bytes by service → Cost Meter. `signoz_list_metrics(searchText: "log",
    source: "meter")` and selects the returned log-volume metric from its live name and unit.
-2. Calls `signoz_execute_builder_query` with the outer `query` wrapper, Unix-ms range,
+2. Calls `signoz_execute_builder_query` with the outer `query` wrapper,
+   `schemaVersion: "v1"`, integer Unix-ms range,
    `requestType: "time_series"`, `formatOptions`, `variables`, and a builder spec using
    `signal: "metrics"`, `source: "meter"`, the discovered metric name and temporality,
    `stepInterval: 3600`, raw `timeAggregation: "sum"`, `spaceAggregation: "sum"`, and

--- a/plugins/signoz/skills/signoz-generating-queries/evals/evals.json
+++ b/plugins/signoz/skills/signoz-generating-queries/evals/evals.json
@@ -5,15 +5,17 @@
       "id": 0,
       "eval_name": "metrics-error-rate-service",
       "prompt": "Show me the error rate for the checkout-service over the last hour.",
-      "expected_output": "Agent discovers a concrete request-count metric by a substring that can match its name, discovers the error field/value, and calls signoz_query_metrics with a complete A/B formula payload. Primary query A filters the requested service plus the discovered error value; formulaQueries defines B with the same discovered metric and metadata but only the service filter, and formula is A / B * 100. Reports the rate with the time window, or correctly handles a no-data / missing-instrumentation case.",
+      "expected_output": "Agent discovers a concrete request-count metric by a matching substring, discovers both service and error label keys/values for that exact metric, and calls signoz_query_metrics with a complete A/B formula payload. Query A uses the discovered service and error labels; B uses the same discovered service label without the error condition; formula is A / B * 100. Reports the rate with the window, or correctly handles no data / missing instrumentation.",
       "expectations": [
         "Agent calls signoz_list_metrics with a searchText that can match the selected metric name; it does not claim searchText=error discovered signoz_calls_total",
-        "Agent discovers the metric's error field and calls signoz_get_field_values with signal=metrics, the returned field name/context, and the same metricName before using the returned error value in a filter",
+        "After metric discovery and before filtering, Agent calls signoz_get_field_keys with signal=metrics and the exact metricName and discovers both service and error label keys",
+        "Agent calls signoz_get_field_values for both discovered keys with signal=metrics, each returned name/context, and the same metricName before filtering",
         "The actual signoz_query_metrics call uses the exact metricName, metricType, temporality, and isMonotonic values returned by discovery",
-        "The actual signoz_query_metrics primary filter for query A contains both service.name = 'checkout-service' and the discovered error condition",
+        "The actual signoz_query_metrics primary filter for query A contains the discovered service key = 'checkout-service' and the discovered error condition",
         "The actual signoz_query_metrics formulaQueries is an array containing a query named B with a concrete metricName and the same discovered metric metadata as A",
-        "Query B has a distinct total-request filter containing service.name = 'checkout-service' but not the error-only condition",
-        "The actual signoz_query_metrics call sets formula to A / B * 100, so every referenced query name is defined"
+        "Query B uses the same discovered service key = 'checkout-service' but omits the error-only condition",
+        "The actual signoz_query_metrics call sets formula to A / B * 100, so every referenced query name is defined",
+        "Agent uses signoz_query_metrics for the metric ratio and does not route the formula through signoz_execute_builder_query"
       ],
       "files": []
     },
@@ -59,6 +61,59 @@
         "Agent does not use signoz_query_metrics for the grouped Cost Meter total attribution",
         "Agent excludes partial=true datapoints and sums complete hourly buckets per service",
         "Agent falls back to a direct count and notes that bytes remain meter-only if service.name is unavailable in the meter"
+      ],
+      "files": []
+    },
+    {
+      "id": 6,
+      "eval_name": "traces-simple-grouped-count-prefers-aggregate",
+      "prompt": "Rank the top 10 services by error span count over the last hour.",
+      "expected_output": "Agent discovers the trace grouping key, then uses signoz_aggregate_traces with bare aggregation=count, error=true, the discovered service key in groupBy, scalar request type, and a one-hour range. It relies on default aggregation-descending order or valid tool-schema ordering and does not hand-build a Query Builder envelope for this plain grouped count.",
+      "expectations": [
+        "Agent calls signoz_get_field_keys with signal=traces before grouping and uses the returned service attribute name verbatim",
+        "Agent calls signoz_aggregate_traces with aggregation=count, requestType=scalar, timeRange=1h, and the discovered groupBy key",
+        "The aggregation token is count, never count() or count(service.name)",
+        "Agent does not call signoz_execute_builder_query for the simple grouped count"
+      ],
+      "files": []
+    },
+    {
+      "id": 7,
+      "eval_name": "traces-error-rate-ranking-needs-builder-formula",
+      "prompt": "Rank services by trace error rate, not raw error count, for the last hour.",
+      "expected_output": "Agent discovers the trace service and error fields, then uses signoz_execute_builder_query with error-count and total-count builder queries plus a sibling formula computing their ratio. The outer query uses schemaVersion v1 and absolute integer Unix-ms bounds; no aggregate convenience call is presented as sufficient for a ratio.",
+      "expectations": [
+        "Agent discovers every trace field used in filters or groupBy with signoz_get_field_keys signal=traces",
+        "The actual signoz_execute_builder_query call contains two trace builder_query siblings and a builder_formula sibling whose expression computes error count divided by total count",
+        "The actual outer query has schemaVersion=v1 and start/end as JSON integer Unix-millisecond values",
+        "Every execution groupBy entry has a non-empty discovered name and contains no dashboard-only key alias",
+        "Agent does not use signoz_aggregate_traces alone to answer the error-rate ranking"
+      ],
+      "files": []
+    },
+    {
+      "id": 8,
+      "eval_name": "logs-error-rate-ranking-needs-builder-formula",
+      "prompt": "Show the top services by percentage of ERROR logs over all their logs in the last 24 hours.",
+      "expected_output": "Agent discovers log-side service and severity keys, then uses signoz_execute_builder_query with ERROR-log and all-log counts plus a sibling percentage formula. It does not assume service.name exists on logs and does not use a single aggregate count as an error rate.",
+      "expectations": [
+        "Agent calls signoz_get_field_keys with signal=logs before using service or severity fields and uses returned dot-notation names verbatim",
+        "The actual signoz_execute_builder_query call contains two log builder_query siblings and a builder_formula sibling computing A / B * 100 or an equivalent percentage",
+        "The actual outer query has absolute start/end JSON integer Unix-ms values and every execution groupBy name is non-empty",
+        "Agent does not claim signoz_aggregate_logs alone computes the requested per-service percentage"
+      ],
+      "files": []
+    },
+    {
+      "id": 9,
+      "eval_name": "metrics-non-monotonic-sum-aggregation",
+      "prompt": "Graph the average cart value metric by service for the last 6 hours. Discovery reports metricType=sum and isMonotonic=false.",
+      "expected_output": "Agent discovers the concrete metric and its metric labels, preserves the non-monotonic sum metadata, and calls signoz_query_metrics with timeAggregation=avg. It never selects latest, rate, or increase for this non-monotonic sum.",
+      "expectations": [
+        "Agent calls signoz_list_metrics and then signoz_get_field_keys with signal=metrics and the discovered metricName before filtering or grouping",
+        "The actual signoz_query_metrics call preserves metricType=sum and isMonotonic=false from discovery",
+        "The actual signoz_query_metrics call uses timeAggregation=avg",
+        "The actual query does not use timeAggregation=latest, rate, or increase"
       ],
       "files": []
     }

--- a/plugins/signoz/skills/signoz-investigating-alerts/SKILL.md
+++ b/plugins/signoz/skills/signoz-investigating-alerts/SKILL.md
@@ -90,6 +90,8 @@ alerts.
    with the note's resolved absolute `start` and `end`, and preserve the same
    state/filter (including omission) and order. Stop when `nextCursor` is absent
    / the note reports `hasMore: false`; never use `offset` or page fullness.
+   If a later intentional state filter means "resolved" / "recovered", map it
+   to `inactive`; history accepts only `firing` or `inactive`.
    Pattern analysis needs the complete transition set. Rows are emitted per
    label-group `fingerprint`; do not interleave them. From the response:
    - **Build rule-wide incident windows** from distinct rows where

--- a/plugins/signoz/skills/signoz-investigating-alerts/SKILL.md
+++ b/plugins/signoz/skills/signoz-investigating-alerts/SKILL.md
@@ -90,8 +90,9 @@ alerts.
    with the note's resolved absolute `start` and `end`, and preserve the same
    state/filter (including omission) and order. Stop when `nextCursor` is absent
    / the note reports `hasMore: false`; never use `offset` or page fullness.
-   If a later intentional state filter means "resolved" / "recovered", map it
-   to `inactive`; history accepts only `firing` or `inactive`.
+   If a later intentional state filter means "resolved" / "recovered", use
+   `inactive`. The enum is `inactive|pending|recovering|firing|nodata|disabled`;
+   `recovering` is a transient keep-firing state, not resolution.
    Pattern analysis needs the complete transition set. Rows are emitted per
    label-group `fingerprint`; do not interleave them. From the response:
    - **Build rule-wide incident windows** from distinct rows where

--- a/plugins/signoz/skills/signoz-mcp-setup/SKILL.md
+++ b/plugins/signoz/skills/signoz-mcp-setup/SKILL.md
@@ -176,6 +176,17 @@ For native client setup, use `client-configs.md`:
 - Keep the server name `signoz` in native client configs (the bundled Claude
   Code plugin file is the only one that uses the `mcp` key — do not rename it).
 
+### Auth and role diagnosis
+
+Backend RBAC classifies MCP failures from the API key's user role: reads need at
+least viewer; alert/dashboard writes need editor or admin; notification-channel
+management and API-key creation need admin. `401` / `UNAUTHORIZED` means the
+credential is missing, invalid, or expired: check configuration/presence
+first, then reauthenticate or reissue as appropriate. `403` /
+`PERMISSION_DENIED` means credentials are valid but under-privileged. Have a
+sufficiently privileged user act or issue a dedicated minimum-role key; never
+paste elevated keys into chat or tracked config.
+
 ### Step 5: Tell the user how to finish
 
 Tell the user that the SigNoz MCP endpoint has been configured, then give the

--- a/plugins/signoz/skills/signoz-modifying-dashboards/SKILL.md
+++ b/plugins/signoz/skills/signoz-modifying-dashboards/SKILL.md
@@ -172,8 +172,11 @@ Merge the planned changes into the full dashboard JSON from Step 2.
 panel, read the compact
 [`dashboard-to-query-builder-v5` reference](./references/dashboard-to-query-builder-v5.md).
 When the execution schema can represent the panel, call
-`signoz_execute_builder_query` with the translated payload. Use representative
-variable values and keep editor aliases unchanged in saved state.
+`signoz_execute_builder_query` with the translated payload. Dry-run over a short
+absolute Unix-ms window — usually the last 30-60 minutes, never the panel's
+display range by reflex; apply the reference's dry-run hygiene rules before
+widening or retrying after a timeout. Use representative variable values and
+keep editor aliases unchanged in saved state.
 
 If the reference's safety gate finds an unsupported execution field, report the
 panel as unvalidated and continue only after explicit acceptance. Server or

--- a/plugins/signoz/skills/signoz-modifying-dashboards/SKILL.md
+++ b/plugins/signoz/skills/signoz-modifying-dashboards/SKILL.md
@@ -104,10 +104,10 @@ Merge the planned changes into the full dashboard JSON from Step 2.
   what the user requested, and compare semantics after MCP normalization. Do not
   drop unrelated widgets, variables, layout items, or panelMap entries.
 
-- **Preserve widget/layout identity.** Every `widgets[].id` appears exactly once
-  in `layout[].i` and vice versa. Reuse existing widget IDs verbatim; add/remove
-  widget and layout entries together. Strip any literal `"__dropping-elem__"`
-  widget/layout id leaked by the UI drag state.
+- **Preserve widget/layout identity.** Keep non-row widget/layout IDs bijective;
+  add/remove both entries together. Row widgets need no layout entry; preserve
+  matching row layout entries when present. Reuse widget IDs verbatim. Strip any
+  literal `"__dropping-elem__"` widget/layout id leaked by the UI drag state.
 
 - **Read schemas before every update.** Read all required and applicable
   conditional resources named by `signoz_update_dashboard`. For Query Builder,

--- a/plugins/signoz/skills/signoz-modifying-dashboards/SKILL.md
+++ b/plugins/signoz/skills/signoz-modifying-dashboards/SKILL.md
@@ -104,6 +104,11 @@ Merge the planned changes into the full dashboard JSON from Step 2.
   what the user requested, and compare semantics after MCP normalization. Do not
   drop unrelated widgets, variables, layout items, or panelMap entries.
 
+- **Preserve widget/layout identity.** Every `widgets[].id` appears exactly once
+  in `layout[].i` and vice versa. Reuse existing widget IDs verbatim; add/remove
+  widget and layout entries together. Strip any literal `"__dropping-elem__"`
+  widget/layout id leaked by the UI drag state.
+
 - **Read schemas before every update.** Read all required and applicable
   conditional resources named by `signoz_update_dashboard`. For Query Builder,
   also read `signoz://metrics-aggregation-guide`,
@@ -222,6 +227,9 @@ Briefly tell the user what was changed. Offer further modifications if relevant.
 - **Identifiers**: Use UUIDs for new widget and variable IDs. Reuse the widget ID
   as `layout.i`; keep each variable map key identical to its human-readable `name`,
   and keep query names such as `A`, `B`, and `F1` stable.
+- **Real dashboard IDs only**: Never send a sentinel such as `"unused"` as a
+  dashboard UUID. Resolve it through `signoz_list_dashboards` and
+  `signoz_get_dashboard` first.
 - **Scope boundary**: This skill modifies existing dashboards. Hand new-dashboard
   requests to `signoz-creating-dashboards`.
 

--- a/plugins/signoz/skills/signoz-modifying-dashboards/evals/evals.json
+++ b/plugins/signoz/skills/signoz-modifying-dashboards/evals/evals.json
@@ -219,12 +219,12 @@
       "id": 14,
       "eval_name": "promql-envelope-timeout-retry",
       "prompt": "Using the attached offline fixture, add a PromQL 'Up Targets' graph panel using sum(up) to my Prometheus Overview dashboard. I am viewing the dashboard over the last 12 hours.",
-      "expected_output": "Agent preserves the dashboard's PromQL widget style, dry-runs the new panel with the PromQL execution envelope over a short absolute Unix-ms window, and responds to the fixture's timeout by retrying with a strictly shorter window before preparing the saved widget shape.",
+      "expected_output": "Agent preserves the dashboard's PromQL widget style, dry-runs the new panel with the PromQL execution envelope over a short absolute Unix-ms window, and responds to the fixture's timeout by retrying with a materially cheaper query before preparing the saved widget shape.",
       "files": ["evals/files/promql-timeout-retry.json"],
       "expectations": [
-        "The first and second signoz_execute_builder_query calls each use one compositeQuery.queries entry with type='promql' and spec containing name and query; neither call uses widget query.promql arrays under compositeQuery or type='promql_query'",
+        "The first and second signoz_execute_builder_query calls each use one compositeQuery.queries entry with type='promql' and a spec whose query is the requested panel's sum(up) PromQL; neither call uses widget query.promql arrays under compositeQuery or type='promql_query'",
         "Both dry-runs use absolute JSON integer Unix-ms start and end values and minutes-scale windows rather than the dashboard's 12-hour display range",
-        "After the first dry-run times out, the second call's end - start duration is strictly smaller than the first call's end - start duration; byte inequality or JSON key reordering alone does not satisfy this expectation",
+        "After the first dry-run times out, the second call is materially cheaper in an objectively comparable way: a strictly smaller end - start duration, or the same window where both calls set an explicit PromQL step and the second step is strictly larger; byte inequality or JSON key reordering alone does not satisfy this expectation",
         "The prepared saved widget keeps queryType='promql' and the dashboard/editor query.promql[] shape rather than the execution envelope",
         "Agent does not call signoz_update_dashboard (read-only eval constraint respected)"
       ]

--- a/plugins/signoz/skills/signoz-modifying-dashboards/evals/evals.json
+++ b/plugins/signoz/skills/signoz-modifying-dashboards/evals/evals.json
@@ -18,6 +18,8 @@
         "When rows exist, the new widget appears exactly once in the intended panelMap row and its x, y, w, h match the top-level layout entry",
         "All supported non-target widget and variable semantics remain present",
         "The actual signoz_execute_builder_query call maps queryName='A' to name='A' and dataSource='traces' to signal='traces', and maps groupBy to name='service.name', fieldDataType='string', fieldContext='resource', signal='traces'",
+        "The actual dry-run outer query contains start and end as JSON integer Unix-millisecond values",
+        "Every groupBy entry passed to signoz_execute_builder_query has a non-empty name",
         "No groupBy entry passed to signoz_execute_builder_query contains the dashboard-only key, dataType, or type fields",
         "Agent did not call signoz_update_dashboard (read-only eval constraint respected)"
       ]
@@ -209,6 +211,7 @@
         "The dry-run builder_query.spec contains none of filters, pageSize, orderBy, selectColumns, queryName, or dataSource, and no groupBy/selectFields entry contains dashboard-only key/dataType/type; canonical order[].key is allowed",
         "The actual signoz_update_dashboard call has top-level id='66666666-6666-4666-8666-666666666666' and a nested dashboard object; title, widgets, layout, and variables are not flattened beside id",
         "The nested dashboard is the complete fetched state and retains dashboard/editor filters, pageSize=25, orderBy=[{columnName:'timestamp',order:'asc'}], and selectColumns",
+        "The fetched and updated widget contextLinks is an object with linksData=[] and is never converted to a bare array",
         "The update is called only after the canonical dry-run succeeds"
       ]
     }

--- a/plugins/signoz/skills/signoz-modifying-dashboards/evals/evals.json
+++ b/plugins/signoz/skills/signoz-modifying-dashboards/evals/evals.json
@@ -214,6 +214,20 @@
         "The fetched and updated widget contextLinks is an object with linksData=[] and is never converted to a bare array",
         "The update is called only after the canonical dry-run succeeds"
       ]
+    },
+    {
+      "id": 14,
+      "eval_name": "promql-envelope-timeout-retry",
+      "prompt": "Using the attached offline fixture, add a PromQL 'Up Targets' graph panel using sum(up) to my Prometheus Overview dashboard. I am viewing the dashboard over the last 12 hours.",
+      "expected_output": "Agent preserves the dashboard's PromQL widget style, dry-runs the new panel with the PromQL execution envelope over a short absolute Unix-ms window, and responds to the fixture's timeout by retrying with a strictly shorter window before preparing the saved widget shape.",
+      "files": ["evals/files/promql-timeout-retry.json"],
+      "expectations": [
+        "The first and second signoz_execute_builder_query calls each use one compositeQuery.queries entry with type='promql' and spec containing name and query; neither call uses widget query.promql arrays under compositeQuery or type='promql_query'",
+        "Both dry-runs use absolute JSON integer Unix-ms start and end values and minutes-scale windows rather than the dashboard's 12-hour display range",
+        "After the first dry-run times out, the second call's end - start duration is strictly smaller than the first call's end - start duration; byte inequality or JSON key reordering alone does not satisfy this expectation",
+        "The prepared saved widget keeps queryType='promql' and the dashboard/editor query.promql[] shape rather than the execution envelope",
+        "Agent does not call signoz_update_dashboard (read-only eval constraint respected)"
+      ]
     }
   ]
 }

--- a/plugins/signoz/skills/signoz-modifying-dashboards/evals/files/promql-timeout-retry.json
+++ b/plugins/signoz/skills/signoz-modifying-dashboards/evals/files/promql-timeout-retry.json
@@ -1,0 +1,57 @@
+{
+  "mode": "offline_mcp_fixture",
+  "instructions": "Use the ordered reads and stubbed dry-runs to produce an offline simulated tool trace. Do not query a live tenant or call signoz_update_dashboard.",
+  "responses": [
+    {
+      "tool": "signoz_list_dashboards",
+      "request": {"limit": 50, "offset": 0},
+      "response": {
+        "data": [{"uuid": "88888888-8888-4888-8888-888888888888", "name": "Prometheus Overview"}],
+        "pagination": {"total": 1, "offset": 0, "limit": 50, "hasMore": false, "nextOffset": -1}
+      }
+    },
+    {
+      "tool": "signoz_get_dashboard",
+      "request": {"id": "88888888-8888-4888-8888-888888888888"},
+      "response": {
+        "status": "success",
+        "data": {
+          "uuid": "88888888-8888-4888-8888-888888888888",
+          "title": "Prometheus Overview",
+          "description": "Prometheus scrape health",
+          "tags": ["prometheus"],
+          "variables": {},
+          "widgets": [
+            {
+              "id": "99999999-9999-4999-8999-999999999999",
+              "panelTypes": "graph",
+              "title": "Scrape Rate",
+              "query": {
+                "queryType": "promql",
+                "promql": [
+                  {"name": "A", "query": "sum(rate(prometheus_tsdb_head_samples_appended_total[5m]))", "disabled": false, "legend": "Samples"}
+                ]
+              },
+              "selectedLogFields": [],
+              "selectedTracesFields": [],
+              "thresholds": [],
+              "contextLinks": {"linksData": []}
+            }
+          ],
+          "layout": [{"i": "99999999-9999-4999-8999-999999999999", "x": 0, "y": 0, "w": 12, "h": 6}],
+          "panelMap": {}
+        }
+      }
+    }
+  ],
+  "stubbed_tools": [
+    {
+      "tool": "signoz_execute_builder_query",
+      "response": {"isError": true, "code": "UPSTREAM_ERROR", "message": "context deadline exceeded"}
+    },
+    {
+      "tool": "signoz_execute_builder_query",
+      "response": {"status": "success", "data": {"result": [{"value": 12}]}}
+    }
+  ]
+}

--- a/plugins/signoz/skills/signoz-modifying-dashboards/evals/files/update-payload-contract.json
+++ b/plugins/signoz/skills/signoz-modifying-dashboards/evals/files/update-payload-contract.json
@@ -60,7 +60,7 @@
               "selectedLogFields": [],
               "selectedTracesFields": [],
               "thresholds": [],
-              "contextLinks": []
+              "contextLinks": {"linksData": []}
             }
           ],
           "layout": [{"i": "77777777-7777-4777-8777-777777777777", "x": 0, "y": 0, "w": 12, "h": 6}],

--- a/plugins/signoz/skills/signoz-modifying-dashboards/references/dashboard-to-query-builder-v5.md
+++ b/plugins/signoz/skills/signoz-modifying-dashboards/references/dashboard-to-query-builder-v5.md
@@ -20,8 +20,21 @@ unsupported unless the tool schema exposes them. `legend` may remain saved-only.
 Saved panels persist no time range. Build the complete outer `query` with
 absolute `start` / `end` as JSON integer Unix-ms (for example, the last hour),
 request type, composite queries, format options, and representative variable
-values; omitted bounds fail with `missing start or end timestamp`. Dashboard
-request types are: graph/bar/histogram -> `time_series`;
+values; omitted bounds fail with `missing start or end timestamp`.
+Start every dry-run with the shortest representative window likely to contain
+data, usually the last 30-60 minutes; never use the panel's display range by reflex.
+If empty, widen according to signal cadence and report the exact windows tested
+rather than concluding telemetry is absent. A dry-run validates execution only
+for that window, not correctness across every dashboard range. A PromQL range
+selector looks backward from each evaluation timestamp: widening outer `start` /
+`end` adds evaluations rather than "covering" a long selector, and long selectors
+such as `[12h]` remain costly even with short outer bounds.
+
+On a timeout, never resend the identical payload. Shrink the window, coarsen the
+type-appropriate interval when available (PromQL `step`; Builder
+`stepInterval`; ClickHouse has no equivalent), or reduce query cost first.
+
+Dashboard request types are: graph/bar/histogram -> `time_series`;
 table/pie/value -> `scalar`; trace -> `trace`; list -> `raw`. These are the only
 execution values; never invent `aggregate`, `table`, or `timeseries`. MCP
 dashboard writes validate `panelTypes` against
@@ -70,8 +83,23 @@ Trace operator: emit a raw-preserved `builder_trace_operator` with `name` from
 (`count()` for a count panel; omit for raw). Never coerce it to `builder_query`,
 copy dashboard aliases, or invent `signal`, `filter`, `functions`, or `disabled`.
 
-PromQL and ClickHouse bypass this Builder crosswalk; build their current MCP
-envelopes from the corresponding resources without dropping fields.
+## PromQL and ClickHouse panels
+
+These bypass the Builder crosswalk, but their execution envelopes are fixed. Saved
+widgets use `query.promql[]` / `query.clickhouse_sql[]` with `queryType`; never
+copy those arrays under execution `compositeQuery`.
+Map each saved `query.promql[]` item to one `compositeQuery.queries[]` entry:
+`{"type": "promql", "spec": {"name": "A", "query": "<promql>"}}`. Optional
+spec fields are `disabled`, `step`, `stats`, and `legend`. The type is exactly
+`promql`, never `promql_query`.
+Map each saved `query.clickhouse_sql[]` item to one `compositeQuery.queries[]`
+entry: `{"type": "clickhouse_sql", "spec": {"name": "A", "query": "<sql>"}}`;
+optional spec fields are `disabled` and `legend`.
+Always set `requestType` with the Builder panel mapping above. The server's
+`time_series` default when PromQL omits it is fallback only; ClickHouse has no
+default. Substitute representative literals for `$var` in dry-runs only; saved
+panels keep `$var`. Read `signoz://promql/instructions` for selector syntax and
+the matching `signoz://dashboard/clickhouse-*` resources for ClickHouse schema.
 
 ## Saved payload invariant
 

--- a/plugins/signoz/skills/signoz-modifying-dashboards/references/dashboard-to-query-builder-v5.md
+++ b/plugins/signoz/skills/signoz-modifying-dashboards/references/dashboard-to-query-builder-v5.md
@@ -23,7 +23,11 @@ request type, composite queries, format options, and representative variable
 values; omitted bounds fail with `missing start or end timestamp`. Dashboard
 request types are: graph/bar/histogram -> `time_series`;
 table/pie/value -> `scalar`; trace -> `trace`; list -> `raw`. These are the only
-values; never invent `aggregate`, `table`, or `timeseries`.
+execution values; never invent `aggregate`, `table`, or `timeseries`. MCP
+dashboard writes validate `panelTypes` against
+graph/value/table/list/bar/pie/histogram only; never author a new trace panel.
+Use a list panel with raw trace rows instead; keep `trace` -> `trace` only when
+executing an existing saved panel.
 
 Put every dependency in one `compositeQuery.queries` array: `queryData[]` ->
 `builder_query`; `queryFormulas[]` -> sibling `builder_formula`;

--- a/plugins/signoz/skills/signoz-modifying-dashboards/references/dashboard-to-query-builder-v5.md
+++ b/plugins/signoz/skills/signoz-modifying-dashboards/references/dashboard-to-query-builder-v5.md
@@ -17,10 +17,13 @@ unsupported unless the tool schema exposes them. `legend` may remain saved-only.
 
 ## Translate one panel
 
-Build the complete outer `query` with its time range, request type, composite
-queries, format options, and representative variable values. Dashboard request
-types are: graph/time-series/bar/histogram -> `time_series`; table/pie/value ->
-`scalar`; trace -> `trace`; list -> `raw`.
+Saved panels persist no time range. Build the complete outer `query` with
+absolute `start` / `end` as JSON integer Unix-ms (for example, the last hour),
+request type, composite queries, format options, and representative variable
+values; omitted bounds fail with `missing start or end timestamp`. Dashboard
+request types are: graph/bar/histogram -> `time_series`;
+table/pie/value -> `scalar`; trace -> `trace`; list -> `raw`. These are the only
+values; never invent `aggregate`, `table`, or `timeseries`.
 
 Put every dependency in one `compositeQuery.queries` array: `queryData[]` ->
 `builder_query`; `queryFormulas[]` -> sibling `builder_formula`;
@@ -30,9 +33,13 @@ For each `builder_query`:
 
 - `queryName` -> `name`; `dataSource` -> `signal`.
 - Use `filter.expression`, or convert `filters.items[]` and `filters.op` exactly.
-  Never send `filters`.
-- `groupBy[].key/dataType/type` -> `name/fieldDataType/fieldContext`; set
-  `signal` from the field or enclosing query. Send no dashboard aliases.
+  Saved operators use underscore enums (`NOT_IN`); execution expressions use
+  SQL-ish forms (`NOT IN`). Translate, never mix representations, and keep both
+  forms semantically aligned when saved JSON contains both. Never send `filters`.
+- Saved `groupBy[].key/dataType/type` -> execution
+  `name/fieldDataType/fieldContext`; set `signal` from the field or enclosing
+  query. For "by <dimension>", `name` is the actual attribute key and never
+  empty; omit `groupBy` when ungrouped. Send no dashboard aliases.
 - `selectColumns[]` -> `selectFields[]`: `name` from `name` or `key`,
   `fieldDataType` from `fieldDataType` or `dataType`, `fieldContext` from
   `fieldContext` or `type`, plus `signal`. Send only canonical metadata.

--- a/plugins/signoz/skills/signoz-searching-docs/SKILL.md
+++ b/plugins/signoz/skills/signoz-searching-docs/SKILL.md
@@ -23,6 +23,12 @@ Prefer the SigNoz MCP server tools when available; fall back to direct HTTP fetc
 - `signoz_search_docs` — BM25 search over the indexed docs corpus. Pass the user's natural-language query as `searchText`. Narrow with `section_slug` when the question maps cleanly to a single docs section (the tool's own schema lists valid slugs — defer to it rather than memorizing). Trust the ranking — the index handles relevance.
 - `signoz_fetch_doc` — markdown for one indexed page. Pass the canonical URL or `/docs/...` path; optionally narrow to a section with `heading`. Inspect `truncation_reason` and `available_headings` in every response rather than assuming the returned `content` is complete.
 
+`signoz_search_docs` requires non-empty `searchText`; always pass the user's
+phrase. Never call it, or `signoz_fetch_doc` without a URL, hoping it guesses.
+`signoz://...` URIs are MCP resources: read them through the MCP resource API,
+never `signoz_fetch_doc`, which accepts only `https://signoz.io/docs/...` URLs
+or `/docs/...` paths and rejects other scopes.
+
 Never construct `/docs/...` URLs from memory. Only pass URLs returned by
 `signoz_search_docs` to `signoz_fetch_doc`; if you think you already know the
 page path, search first and fetch the canonical URL from the result.

--- a/plugins/signoz/skills/signoz-searching-docs/SKILL.md
+++ b/plugins/signoz/skills/signoz-searching-docs/SKILL.md
@@ -23,9 +23,8 @@ Prefer the SigNoz MCP server tools when available; fall back to direct HTTP fetc
 - `signoz_search_docs` — BM25 search over the indexed docs corpus. Pass the user's natural-language query as `searchText`. Narrow with `section_slug` when the question maps cleanly to a single docs section (the tool's own schema lists valid slugs — defer to it rather than memorizing). Trust the ranking — the index handles relevance.
 - `signoz_fetch_doc` — markdown for one indexed page. Pass the canonical URL or `/docs/...` path; optionally narrow to a section with `heading`. Inspect `truncation_reason` and `available_headings` in every response rather than assuming the returned `content` is complete.
 
-`signoz_search_docs` also accepts legacy `query`, but always pass the user's
-phrase as non-empty canonical `searchText`. Never call it, or `signoz_fetch_doc`
-without a URL, hoping it guesses.
+Always pass the user's phrase as non-empty `searchText`. Never call
+`signoz_search_docs`, or `signoz_fetch_doc` without a URL, hoping it guesses.
 `signoz://...` URIs are MCP resources: read them through the MCP resource API,
 never `signoz_fetch_doc`, which accepts only `https://signoz.io/docs/...` URLs
 or `/docs/...` paths and rejects other scopes.

--- a/plugins/signoz/skills/signoz-searching-docs/SKILL.md
+++ b/plugins/signoz/skills/signoz-searching-docs/SKILL.md
@@ -23,8 +23,9 @@ Prefer the SigNoz MCP server tools when available; fall back to direct HTTP fetc
 - `signoz_search_docs` — BM25 search over the indexed docs corpus. Pass the user's natural-language query as `searchText`. Narrow with `section_slug` when the question maps cleanly to a single docs section (the tool's own schema lists valid slugs — defer to it rather than memorizing). Trust the ranking — the index handles relevance.
 - `signoz_fetch_doc` — markdown for one indexed page. Pass the canonical URL or `/docs/...` path; optionally narrow to a section with `heading`. Inspect `truncation_reason` and `available_headings` in every response rather than assuming the returned `content` is complete.
 
-`signoz_search_docs` requires non-empty `searchText`; always pass the user's
-phrase. Never call it, or `signoz_fetch_doc` without a URL, hoping it guesses.
+`signoz_search_docs` also accepts legacy `query`, but always pass the user's
+phrase as non-empty canonical `searchText`. Never call it, or `signoz_fetch_doc`
+without a URL, hoping it guesses.
 `signoz://...` URIs are MCP resources: read them through the MCP resource API,
 never `signoz_fetch_doc`, which accepts only `https://signoz.io/docs/...` URLs
 or `/docs/...` paths and rejects other scopes.

--- a/plugins/signoz/skills/signoz-searching-docs/SKILL.md
+++ b/plugins/signoz/skills/signoz-searching-docs/SKILL.md
@@ -23,8 +23,8 @@ Prefer the SigNoz MCP server tools when available; fall back to direct HTTP fetc
 - `signoz_search_docs` — BM25 search over the indexed docs corpus. Pass the user's natural-language query as `searchText`. Narrow with `section_slug` when the question maps cleanly to a single docs section (the tool's own schema lists valid slugs — defer to it rather than memorizing). Trust the ranking — the index handles relevance.
 - `signoz_fetch_doc` — markdown for one indexed page. Pass the canonical URL or `/docs/...` path; optionally narrow to a section with `heading`. Inspect `truncation_reason` and `available_headings` in every response rather than assuming the returned `content` is complete.
 
-Always pass the user's phrase as non-empty `searchText`. Never call
-`signoz_search_docs`, or `signoz_fetch_doc` without a URL, hoping it guesses.
+Never call `signoz_search_docs` with empty `searchText` — always pass the user's phrase.
+Never call `signoz_fetch_doc` without a URL; neither tool guesses missing input.
 `signoz://...` URIs are MCP resources: read them through the MCP resource API,
 never `signoz_fetch_doc`, which accepts only `https://signoz.io/docs/...` URLs
 or `/docs/...` paths and rejects other scopes.

--- a/plugins/signoz/skills/signoz-writing-clickhouse-queries/SKILL.md
+++ b/plugins/signoz/skills/signoz-writing-clickhouse-queries/SKILL.md
@@ -78,10 +78,17 @@ syntax, dashboard templates, query examples, and a validation checklist.
 ## Top Anti-Patterns
 
 - Missing `ts_bucket_start BETWEEN $start_timestamp - 1800 AND $end_timestamp`.
-- Using plain `IN` instead of `GLOBAL IN` on the resource fingerprint subquery.
+- Plain `IN` / `JOIN` whose subquery reads a distributed table: with
+  `distributed_product_mode='deny'` it fails. Prefer the time-bounded fingerprint
+  `GLOBAL IN` pattern or a local subquery table. Use `GLOBAL JOIN` only for a
+  demonstrably small, bounded RHS; it broadcasts that dataset to every shard.
 - Adding a resource CTE when there is no resource attribute filter.
+- Omitting a non-aggregated projection from `GROUP BY`, including computed
+  projections such as `JSONExtractString(body, ...)`.
 - Logs query with `$start_datetime` or `$end_datetime`.
 - Traces query with `$start_timestamp_nano` or `$end_timestamp_nano`.
+- Logs query against `signoz_logs.logs`, bare `logs`, or `distributed_logs`;
+  always use `signoz_logs.distributed_logs_v2`.
 - Traces query with `resources_string['service.name']` instead of
   `resource_string_service$$name`.
 

--- a/plugins/signoz/skills/signoz-writing-clickhouse-queries/references/clickhouse-logs-reference.md
+++ b/plugins/signoz/skills/signoz-writing-clickhouse-queries/references/clickhouse-logs-reference.md
@@ -8,6 +8,7 @@
   - Timestamp Bucketing
   - Use Indexed (Selected) Columns Over Map Access
   - Use GLOBAL IN for Resource Fingerprint Subquery
+  - Complete GROUP BY Projections
   - Body Text Search — Engaging Skip Indexes (predicate engagement,
     anti-patterns, OR-of-LIKE, hyphens/punctuation, EXPLAIN, type traps)
 - Attribute Access Syntax (resource attributes, span/log attributes,
@@ -120,7 +121,18 @@ Always use `GLOBAL IN`, not plain `IN`:
 WHERE resource_fingerprint GLOBAL IN __resource_filter
 ```
 
-### 5. Body Text Search — Engaging Skip Indexes
+Plain `IN` or `JOIN` with a distributed table in its subquery fails when
+`distributed_product_mode='deny'`. Prefer the time-bounded fingerprint
+`GLOBAL IN` pattern above, then a local table in the subquery. Do not default to
+`GLOBAL JOIN`: it broadcasts the RHS to every shard and is safe only when that
+dataset is demonstrably small and bounded.
+
+### 5. Complete GROUP BY Projections
+
+Every non-aggregated `SELECT` expression must appear in `GROUP BY`, including
+computed expressions: `SELECT JSONExtractString(body, 'kind') AS kind, count() ... GROUP BY kind`.
+
+### 6. Body Text Search — Engaging Skip Indexes
 
 The `body` column has two skip indexes, **both on `lower(body)`**:
 
@@ -370,10 +382,11 @@ Before finalizing any query, verify:
 - [ ] **`ts_bucket_start`** filter is included: `BETWEEN $start_timestamp - 1800 AND $end_timestamp`
 - [ ] **Nanosecond variables** used for the `timestamp` column: `$start_timestamp_nano` / `$end_timestamp_nano`
 - [ ] **`fromUnixTimestamp64Nano(timestamp)`** used in SELECT when displaying timestamps
-- [ ] **`GLOBAL IN`** is used (not plain `IN`) for the any subquery
+- [ ] **`GLOBAL IN`** is used (not plain `IN`) for the resource fingerprint subquery
+- [ ] Every non-aggregated projection, including computed expressions, appears in `GROUP BY`
 - [ ] **Indexed columns** used over map access where the attribute is a selected field
 - [ ] **Body searches** use `lower(body)` (not raw `body`) and `LIKE` (not `position` / `positionCaseInsensitive`); for OR'd patterns, a shared `hasToken` or `LIKE` is ANDed before the OR block
 - [ ] **`seen_at_ts_bucket_start`** filter is included in the resource CTE
 - [ ] For timeseries: results are ordered by `ts ASC`
-- [ ] **Table Name**: Always use the `distributed_` prefix (`distributed_logs_v2`, not `logs_v2`)
+- [ ] **Table Name**: use `signoz_logs.distributed_logs_v2`, never `signoz_logs.logs`, bare `logs`, or `distributed_logs`
 - [ ] If multiple tables are joined, ensure all tables have timestamp and bucket filter applied if applicable.


### PR DESCRIPTION
Implements the skill half of SigNoz/nerve-pod#15 (companion server issue: SigNoz/nerve-pod#14) **and the skill half of SigNoz/nerve-pod#75** (PromQL dry-run envelope + validation-window hygiene — see its section below). Every guidance line added here was verified against the `signoz-mcp-server` source rather than trusted from the issue text — several issue claims were corrected in the process (see below).

## What changed

**signoz-generating-queries** (highest-leverage; field/key discovery = 31% of all user-client errors)
- Discovery-first is now unconditional and signal-scoped: no cross-signal key reuse (`service.name` is often absent on logs; `body` is logs-only), no tenant-key assumptions (`org.id`), no camelCase guesses; `get_field_keys` before `get_field_values`, both with `signal`, values with non-empty `name`. Removed the old `service.name` exemption and the "skip discovery on exact-looking names" allowance that contradicted this.
- Per-tool time contract: search/aggregate tools take relative `timeRange` ("1h"); `signoz_execute_builder_query` requires absolute JSON-integer Unix-ms `start`/`end` (no relative option).
- Per-signal `requestType` matrix for builder-query envelopes; never invent `aggregate`/`table`/`timeseries`.
- Aggregate-tool simplified DSL (bare-token `aggregation`, `aggregateOn`, default ordering) and routing: aggregate tools for grouped counts/top-N, `signoz_query_metrics` formulas for metric ratios, builder queries only when shaping exceeds the convenience tools.
- `timeAggregation` × metric-type matrix (gauge / monotonic / non-monotonic sum / histogram) tied to `signoz_list_metrics` metadata.
- `schemaVersion: "v1"` in envelope guidance and examples.

**signoz-creating-alerts** (tightened 490 → 481 lines while adding)
- Dry-run must set absolute Unix-ms `start`/`end` (alert specs legitimately omit them) and carry real `groupBy[].name` keys, never empty placeholders.
- `condition.thresholds` requires `kind` + `spec[]` — except `alertOnAbsent`-only rules (omit thresholds, route via top-level `preferredChannels`) and anomaly rules.
- Valid `op` words listed; `equals` called out as invalid. PromQL specs: only `name`/`query`/`legend`/`disabled`, fully literal (no `$var`).
- Channel creation is admin-gated; guidance avoids elevated-key-in-chat patterns.

**signoz-explaining/investigating-alerts** — history `state` filter enum per the v2 rule-history API (signoz-mcp-server#235): `inactive|pending|recovering|firing|nodata|disabled`; user "resolved" maps to `inactive` only when a state filter is intentional (`recovering` is a transient keep-firing state, not resolution; incident reconstruction keeps omitting `state`).

**Dashboard skills + shared v5 reference** (both copies byte-identical)
- Dry-run translation: saved panels persist no time range → absolute Unix-ms bounds required; saved `groupBy[].key` vs execution `groupBy[].name` distinguished; saved `NOT_IN` ↔ execution `NOT IN` representation mapping.
- Widget/layout id bijection (ids reused verbatim on edit; `"__dropping-elem__"` stripped); sentinel dashboard-id ban; panel field JSON types (`softMax` number, `contextLinks` object, `having` clause array); enum corrections (`graph` not `timeseries`, uppercase variable types, PromQL only on graph/value/bar/histogram, list panels builder-only).
- Fixed the `contextLinks` eval fixture that asserted the wrong (bare-array) shape.

**signoz-writing-clickhouse-queries** — named the `distributed_product_mode='deny'` pitfall (GLOBAL IN / local-table remedies; `GLOBAL JOIN` only for small bounded RHS), explicit GROUP-BY-projection rule incl. `JSONExtractString(body,…)`, canonical `signoz_logs.distributed_logs_v2` table name.

**signoz-searching-docs** — `searchText` required non-empty; `signoz://…` URIs are MCP resources, never `signoz_fetch_doc` inputs.

**signoz-mcp-setup** — API-key role matrix (viewer reads / editor-admin writes / admin channels & keys) and 401-vs-403 diagnosis.

**Evals** — targeted assertions for the contracts most likely to regress: dry-run Unix-ms bounds, absent-only alerts without thresholds, discovered-key filters, non-monotonic-sum aggregation, NOT_IN↔NOT IN, `contextLinks` shape, aggregate-vs-builder routing.

## SigNoz/nerve-pod#75 — PromQL/ClickHouse dry-run envelopes (commit 8876083)

Telemetry (RCA SigNoz/nerve-pod#76) showed a dashboard-modify execution wasting 4 tool calls: the PromQL execution envelope was undocumented, so the model sent saved widget JSON, then guessed `promql_query`; a 12h validation window then timed out and was retried byte-identically. Per the issue's follow-up comment, PromQL panels on PromQL dashboards are *correct* — so this documents the envelope rather than steering toward Builder.

- **Shared v5 reference (both byte-identical copies)** — new "PromQL and ClickHouse panels" section: map each saved `query.promql[]` / `query.clickhouse_sql[]` item to one `compositeQuery.queries[]` entry (`{"type": "promql"|"clickhouse_sql", "spec": {"name", "query", ...}}` with exact optional spec fields); never copy widget arrays under execution `compositeQuery`; type token exactly `promql`, never `promql_query`; panel-aware `requestType` (server `time_series` default is fallback only; ClickHouse has no default); `$var` literals in dry-runs only.
- **Dry-run hygiene (all query types)** — start with the shortest representative window (~30–60 min), never the panel's display range by reflex; widen per signal cadence and report windows tested; PromQL range selectors look backward from evaluation timestamps (widening outer bounds only adds evaluations); on timeout, never resend an identical payload — shrink the window, coarsen `step`/`stepInterval`, or reduce query cost.
- **Eval** — `promql-envelope-timeout-retry` (id 14, modifying-dashboards) with offline fixture `files/promql-timeout-retry.json`: asserts the promql envelope shape, minutes-scale Unix-ms windows, and a strictly smaller `end − start` on the post-timeout retry.

Server-side follow-ups recorded on the issue (not this repo): named rejection of unknown `queries[].type` (current server already forwards unknown types raw, `pkg/types/querybuilder.go:105-115`); stale `compositeQuery.queryType="promql"` tool description (`internal/handler/tools/query_builder.go:29`).

## Issue claims corrected against server source

- `requestType` valid set is per-signal for builder envelopes (metrics `time_series|scalar`; traces `raw|trace|scalar|time_series`; logs `raw|scalar|time_series`) — `raw_stream`/`distribution` are rejected by the MCP layer.
- Threshold operators: words like `equal` are valid; only `equals` is not (the issue's "must be a symbol" was wrong).
- Convenience tools do accept valid Unix-ms `start`/`end` (overriding `timeRange`); only malformed values error.
- Canonical `schemaVersion` is `v1`.
- Kept the current `labels`/resource-table ClickHouse pattern (the issue's `resources_string` suggestion targets a deprecated map).

## Live eval verification (sonnet-5 against staging, 2026-07-16)

Ran the PR's new eval prompts live through the SigNoz AI assistant (claude-sonnet-5, skills at this PR's head) and an A/B baseline with pre-PR skills:

- **PromQL envelope (eval 14 scenario)** — baseline skills reproduced the incident exactly (3 attempts: `promQueries` map → "missing or empty compositeQuery.queries"; `promql_query` → 400 `unknown query type`; then `promql`). With this PR's skills the correct `{"type": "promql", "spec": {...}}` envelope was sent on the **first** call. Staging's named 400 for unknown types also means server follow-up 1 below is already partially served by the backend.
- **NOT_IN dashboard, absent-data widening, aggregate-vs-builder routing** — behaved per guidance (field discovery, execution `filter.expression NOT IN`, widen-and-report-windows on missing telemetry).
- **Fixed in commit f9955e4** — both live dashboard runs ignored the window rule (12h / 48h dry-runs): the modifying-dashboards agent never read the reference on the PromQL path, so the rule now also sits distilled in both SKILL.md dry-run paragraphs; eval 24 encodes the 30-60-minute window, eval 14's timeout-retry expectation now matches the reference's rule (objectively comparable cheaper retry, dry-runs pinned to the panel's query), and eval 24 was added to the creating-dashboards coverage doc.
- **Found: absent-alert contract mismatch (server-side follow-up)** — following this PR's guidance (and the MCP schema claim at `pkg/types/alertrule.go:88`, thresholds "Required unless alertOnAbsent is true"), the agent sent `alertOnAbsent` as sole trigger with `condition.thresholds` omitted and `#staging-alerts` in top-level `preferredChannels`; the staging API rejected it with 400 "alert rule is not valid". It succeeded only after adding a `thresholds` block (basic, target 0, channels inside `spec[].channels`). Either the backend requires thresholds even for absent-only rules (making the MCP schema claim stale) or staging validation is buggy — needs confirmation in `signoz-mcp-server`/backend — tracked in SigNoz/nerve-pod#140. Until resolved, creating-alerts eval 5 expectations 3–5 cannot pass against the live backend.

## Verification

- `claude plugin validate --strict plugins/signoz` ✅
- All 13 SKILL.md under 500 lines (creating-alerts 490 → 481) ✅
- Both `dashboard-to-query-builder-v5.md` copies byte-identical (`cmp`) ✅
- All edited `evals.json` + fixture parse (`jq`), eval IDs unique ✅
- `git diff --check` clean ✅
- Plan approved by external review (3 rounds); implementation adversarially reviewed and all 5 findings fixed
- No manual version bumps (CI auto-bumps CalVer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


