### PR TITLE
fix(skills): document PromQL/ClickHouse dry-run envelopes and dry-run window hygiene

### DIFF
--- a/plugins/signoz/skills/signoz-creating-dashboards/references/dashboard-to-query-builder-v5.md
+++ b/plugins/signoz/skills/signoz-creating-dashboards/references/dashboard-to-query-builder-v5.md
@@ -20,8 +20,21 @@ unsupported unless the tool schema exposes them. `legend` may remain saved-only.
 Saved panels persist no time range. Build the complete outer `query` with
 absolute `start` / `end` as JSON integer Unix-ms (for example, the last hour),
 request type, composite queries, format options, and representative variable
-values; omitted bounds fail with `missing start or end timestamp`. Dashboard
-request types are: graph/bar/histogram -> `time_series`;
+values; omitted bounds fail with `missing start or end timestamp`.
+Start every dry-run with the shortest representative window likely to contain
+data, usually the last 30-60 minutes; never use the panel's display range by reflex.
+If empty, widen according to signal cadence and report the exact windows tested
+rather than concluding telemetry is absent. A dry-run validates execution only
+for that window, not correctness across every dashboard range. A PromQL range
+selector looks backward from each evaluation timestamp: widening outer `start` /
+`end` adds evaluations rather than "covering" a long selector, and long selectors
+such as `[12h]` remain costly even with short outer bounds.
+
+On a timeout, never resend the identical payload. Shrink the window, coarsen the
+type-appropriate interval when available (PromQL `step`; Builder
+`stepInterval`; ClickHouse has no equivalent), or reduce query cost first.
+
+Dashboard request types are: graph/bar/histogram -> `time_series`;
 table/pie/value -> `scalar`; trace -> `trace`; list -> `raw`. These are the only
 execution values; never invent `aggregate`, `table`, or `timeseries`. MCP
 dashboard writes validate `panelTypes` against
@@ -70,8 +83,23 @@ Trace operator: emit a raw-preserved `builder_trace_operator` with `name` from
 (`count()` for a count panel; omit for raw). Never coerce it to `builder_query`,
 copy dashboard aliases, or invent `signal`, `filter`, `functions`, or `disabled`.
 
-PromQL and ClickHouse bypass this Builder crosswalk; build their current MCP
-envelopes from the corresponding resources without dropping fields.
+## PromQL and ClickHouse panels
+
+These bypass the Builder crosswalk, but their execution envelopes are fixed. Saved
+widgets use `query.promql[]` / `query.clickhouse_sql[]` with `queryType`; never
+copy those arrays under execution `compositeQuery`.
+Map each saved `query.promql[]` item to one `compositeQuery.queries[]` entry:
+`{"type": "promql", "spec": {"name": "A", "query": "<promql>"}}`. Optional
+spec fields are `disabled`, `step`, `stats`, and `legend`. The type is exactly
+`promql`, never `promql_query`.
+Map each saved `query.clickhouse_sql[]` item to one `compositeQuery.queries[]`
+entry: `{"type": "clickhouse_sql", "spec": {"name": "A", "query": "<sql>"}}`;
+optional spec fields are `disabled` and `legend`.
+Always set `requestType` with the Builder panel mapping above. The server's
+`time_series` default when PromQL omits it is fallback only; ClickHouse has no
+default. Substitute representative literals for `$var` in dry-runs only; saved
+panels keep `$var`. Read `signoz://promql/instructions` for selector syntax and
+the matching `signoz://dashboard/clickhouse-*` resources for ClickHouse schema.
 
 ## Saved payload invariant
 

--- a/plugins/signoz/skills/signoz-modifying-dashboards/evals/evals.json
+++ b/plugins/signoz/skills/signoz-modifying-dashboards/evals/evals.json
@@ -214,6 +214,20 @@
         "The fetched and updated widget contextLinks is an object with linksData=[] and is never converted to a bare array",
         "The update is called only after the canonical dry-run succeeds"
       ]
+    },
+    {
+      "id": 14,
+      "eval_name": "promql-envelope-timeout-retry",
+      "prompt": "Using the attached offline fixture, add a PromQL 'Up Targets' graph panel using sum(up) to my Prometheus Overview dashboard. I am viewing the dashboard over the last 12 hours.",
+      "expected_output": "Agent preserves the dashboard's PromQL widget style, dry-runs the new panel with the PromQL execution envelope over a short absolute Unix-ms window, and responds to the fixture's timeout by retrying with a strictly shorter window before preparing the saved widget shape.",
+      "files": ["evals/files/promql-timeout-retry.json"],
+      "expectations": [
+        "The first and second signoz_execute_builder_query calls each use one compositeQuery.queries entry with type='promql' and spec containing name and query; neither call uses widget query.promql arrays under compositeQuery or type='promql_query'",
+        "Both dry-runs use absolute JSON integer Unix-ms start and end values and minutes-scale windows rather than the dashboard's 12-hour display range",
+        "After the first dry-run times out, the second call's end - start duration is strictly smaller than the first call's end - start duration; byte inequality or JSON key reordering alone does not satisfy this expectation",
+        "The prepared saved widget keeps queryType='promql' and the dashboard/editor query.promql[] shape rather than the execution envelope",
+        "Agent does not call signoz_update_dashboard (read-only eval constraint respected)"
+      ]
     }
   ]
 }

--- a/plugins/signoz/skills/signoz-modifying-dashboards/evals/files/promql-timeout-retry.json
+++ b/plugins/signoz/skills/signoz-modifying-dashboards/evals/files/promql-timeout-retry.json
@@ -1,0 +1,57 @@
+{
+  "mode": "offline_mcp_fixture",
+  "instructions": "Use the ordered reads and stubbed dry-runs to produce an offline simulated tool trace. Do not query a live tenant or call signoz_update_dashboard.",
+  "responses": [
+    {
+      "tool": "signoz_list_dashboards",
+      "request": {"limit": 50, "offset": 0},
+      "response": {
+        "data": [{"uuid": "88888888-8888-4888-8888-888888888888", "name": "Prometheus Overview"}],
+        "pagination": {"total": 1, "offset": 0, "limit": 50, "hasMore": false, "nextOffset": -1}
+      }
+    },
+    {
+      "tool": "signoz_get_dashboard",
+      "request": {"id": "88888888-8888-4888-8888-888888888888"},
+      "response": {
+        "status": "success",
+        "data": {
+          "uuid": "88888888-8888-4888-8888-888888888888",
+          "title": "Prometheus Overview",
+          "description": "Prometheus scrape health",
+          "tags": ["prometheus"],
+          "variables": {},
+          "widgets": [
+            {
+              "id": "99999999-9999-4999-8999-999999999999",
+              "panelTypes": "graph",
+              "title": "Scrape Rate",
+              "query": {
+                "queryType": "promql",
+                "promql": [
+                  {"name": "A", "query": "sum(rate(prometheus_tsdb_head_samples_appended_total[5m]))", "disabled": false, "legend": "Samples"}
+                ]
+              },
+              "selectedLogFields": [],
+              "selectedTracesFields": [],
+              "thresholds": [],
+              "contextLinks": {"linksData": []}
+            }
+          ],
+          "layout": [{"i": "99999999-9999-4999-8999-999999999999", "x": 0, "y": 0, "w": 12, "h": 6}],
+          "panelMap": {}
+        }
+      }
+    }
+  ],
+  "stubbed_tools": [
+    {
+      "tool": "signoz_execute_builder_query",
+      "response": {"isError": true, "code": "UPSTREAM_ERROR", "message": "context deadline exceeded"}
+    },
+    {
+      "tool": "signoz_execute_builder_query",
+      "response": {"status": "success", "data": {"result": [{"value": 12}]}}
+    }
+  ]
+}

--- a/plugins/signoz/skills/signoz-modifying-dashboards/references/dashboard-to-query-builder-v5.md
+++ b/plugins/signoz/skills/signoz-modifying-dashboards/references/dashboard-to-query-builder-v5.md
@@ -20,8 +20,21 @@ unsupported unless the tool schema exposes them. `legend` may remain saved-only.
 Saved panels persist no time range. Build the complete outer `query` with
 absolute `start` / `end` as JSON integer Unix-ms (for example, the last hour),
 request type, composite queries, format options, and representative variable
-values; omitted bounds fail with `missing start or end timestamp`. Dashboard
-request types are: graph/bar/histogram -> `time_series`;
+values; omitted bounds fail with `missing start or end timestamp`.
+Start every dry-run with the shortest representative window likely to contain
+data, usually the last 30-60 minutes; never use the panel's display range by reflex.
+If empty, widen according to signal cadence and report the exact windows tested
+rather than concluding telemetry is absent. A dry-run validates execution only
+for that window, not correctness across every dashboard range. A PromQL range
+selector looks backward from each evaluation timestamp: widening outer `start` /
+`end` adds evaluations rather than "covering" a long selector, and long selectors
+such as `[12h]` remain costly even with short outer bounds.
+
+On a timeout, never resend the identical payload. Shrink the window, coarsen the
+type-appropriate interval when available (PromQL `step`; Builder
+`stepInterval`; ClickHouse has no equivalent), or reduce query cost first.
+
+Dashboard request types are: graph/bar/histogram -> `time_series`;
 table/pie/value -> `scalar`; trace -> `trace`; list -> `raw`. These are the only
 execution values; never invent `aggregate`, `table`, or `timeseries`. MCP
 dashboard writes validate `panelTypes` against
@@ -70,8 +83,23 @@ Trace operator: emit a raw-preserved `builder_trace_operator` with `name` from
 (`count()` for a count panel; omit for raw). Never coerce it to `builder_query`,
 copy dashboard aliases, or invent `signal`, `filter`, `functions`, or `disabled`.
 
-PromQL and ClickHouse bypass this Builder crosswalk; build their current MCP
-envelopes from the corresponding resources without dropping fields.
+## PromQL and ClickHouse panels
+
+These bypass the Builder crosswalk, but their execution envelopes are fixed. Saved
+widgets use `query.promql[]` / `query.clickhouse_sql[]` with `queryType`; never
+copy those arrays under execution `compositeQuery`.
+Map each saved `query.promql[]` item to one `compositeQuery.queries[]` entry:
+`{"type": "promql", "spec": {"name": "A", "query": "<promql>"}}`. Optional
+spec fields are `disabled`, `step`, `stats`, and `legend`. The type is exactly
+`promql`, never `promql_query`.
+Map each saved `query.clickhouse_sql[]` item to one `compositeQuery.queries[]`
+entry: `{"type": "clickhouse_sql", "spec": {"name": "A", "query": "<sql>"}}`;
+optional spec fields are `disabled` and `legend`.
+Always set `requestType` with the Builder panel mapping above. The server's
+`time_series` default when PromQL omits it is fallback only; ClickHouse has no
+default. Substitute representative literals for `$var` in dry-runs only; saved
+panels keep `$var`. Read `signoz://promql/instructions` for selector syntax and
+the matching `signoz://dashboard/clickhouse-*` resources for ClickHouse schema.
 
 ## Saved payload invariant
 


### PR DESCRIPTION
Fixes the agent-skills side of [SigNoz/nerve-pod#75](https://github.com/SigNoz/nerve-pod/issues/75) (RCA: SigNoz/nerve-pod#76).

> **Stacked on #66** — this PR's base is `fix/issue-15-query-construction-guidance` because both touch the same shared reference file. Retarget to `main` after #66 merges.

## Problem (from execution telemetry)

A dashboard-modify execution wasted 4 tool calls + ~2.5 min because:

1. The PromQL execution envelope for `signoz_execute_builder_query` was undocumented in the dashboard skills — the model first sent saved widget JSON (`query.promql[]` under `compositeQuery`), then guessed `"type": "promql_query"`, before landing on the correct `{"type": "promql", "spec": {...}}`.
2. A 12h-window PromQL validation query timed out, and the retry was byte-identical.

Per the issue's follow-up comment, choosing PromQL panels to match a PromQL dashboard is *correct* behavior — so this documents the envelope rather than steering toward Builder.

## Changes

**`references/dashboard-to-query-builder-v5.md`** (both byte-identical copies, 81 → 108 lines):

- New **"PromQL and ClickHouse panels"** section: map each saved `query.promql[]` / `query.clickhouse_sql[]` item to one `compositeQuery.queries[]` entry (`{"type": "promql"|"clickhouse_sql", "spec": {"name", "query", ...}}`, exact optional spec fields); never copy widget arrays under execution `compositeQuery`; type token is exactly `promql`, never `promql_query`; panel-aware `requestType` (server's `time_series` default is fallback only; ClickHouse has no default); `$var` literals in dry-runs only.
- New **dry-run hygiene** rules (all query types): start with the shortest representative window (~30–60 min), never the panel's display range by reflex; widen per signal cadence and report windows tested; PromQL range selectors look backward from evaluation timestamps, so widening outer bounds only adds evaluations; on timeout, never resend an identical payload — shrink the window, coarsen `step`/`stepInterval`, or reduce query cost.

**`signoz-modifying-dashboards/evals/`**: new eval (id 14, `promql-envelope-timeout-retry`) with offline fixture `files/promql-timeout-retry.json` mirroring the incident — asserts the promql envelope shape, minutes-scale Unix-ms windows, a strictly smaller `end - start` on the post-timeout retry, and that the saved widget keeps the `query.promql[]` shape.

No SKILL.md changes (both dry-run sections already route through the shared reference); no version bumps (CalVer auto-bumps on merge).

## Out of scope (server-side follow-ups)

- Reject unknown `queries[].type` with an error naming the bad type (issue checkbox 4). Note: current server already preserves unknown types as raw JSON and forwards them (`pkg/types/querybuilder.go:105-115`), so the June "silently dropped → empty queries[]" behavior no longer reproduces as such.
- Stale tool description referencing `compositeQuery.queryType="promql"` (`internal/handler/tools/query_builder.go:29`) — should detect `compositeQuery.queries[].type="promql"`.
- Stale-timestamp sub-issue — caused by the Bash sandbox breakage, not skill guidance.

## Process & verification

Plan reviewed by Codex gpt-5.6-sol (high) — approved after 3 rounds; implemented by Codex; adversarially reviewed by a fresh Codex session (1 finding: single-entry cardinality implication — fixed); contracts verified against `signoz-mcp-server` `pkg/types/querybuilder.go:41-60,199-201` and `pkg/types/dashboard.go:125-127`.

- Both reference copies byte-identical (`cmp -s`)
- `claude plugin validate --strict plugins/signoz` ✔
- Eval ids unique (`jq`), fixture valid JSON
- `git diff --check` clean; no numeric timeout claims in skill text

🤖 Generated with [Claude Code](https://claude.com/claude-code)