### PR TITLE
fix(mcp-setup): persist Codex endpoint across plugin updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,18 @@ Then, in a Codex session started from your project:
    or run `/mcp` in a session, then call any `signoz_*` tool. Restart Codex if
    the `signoz` server does not appear.
 
+The bundled `.mcp.json` lives inside Codex's versioned plugin cache, so plugin
+updates reinstall that file from this repository and can reset it to the
+placeholder. If you want the endpoint to persist across plugin updates, also
+add a native Codex MCP entry after resolving the endpoint:
+
+```sh
+codex mcp add signoz --url http://localhost:8000/mcp
+```
+
+Replace the URL with your SigNoz Cloud MCP URL or self-hosted HTTP `/mcp`
+endpoint. Verify with `codex mcp get signoz`.
+
 The Codex plugin declares `mcpServers: "./.mcp.json"`, so normal plugin installs
 do not need a separate native Codex MCP entry. To use in another repo, copy
 `plugins/signoz` into the target repo's `plugins/` directory, add a marketplace

--- a/plugins/signoz/skills/signoz-mcp-setup/SKILL.md
+++ b/plugins/signoz/skills/signoz-mcp-setup/SKILL.md
@@ -162,6 +162,18 @@ Bundled registration files live inside the installed plugin. Plugin updates can
 reset them to the placeholder; if that happens, rerun this setup skill. For a
 more durable native-client setup, use the relevant recipe in `client-configs.md`.
 
+For Codex, if the user says the endpoint reset again, keeps resetting, or asks
+for a durable/persistent setup, also create or update the native Codex MCP
+server entry after resolving the endpoint:
+
+```sh
+codex mcp add signoz --url <resolved-mcp-url>
+```
+
+This writes the user-level `[mcp_servers.signoz]` entry in Codex config and
+survives plugin cache updates. If editing TOML directly, preserve unrelated
+config and only set `url` for `mcp_servers.signoz`.
+
 For native client setup, use `client-configs.md`:
 
 - Edit an existing native client config only when the user named that client or

--- a/plugins/signoz/skills/signoz-mcp-setup/evals/evals.json
+++ b/plugins/signoz/skills/signoz-mcp-setup/evals/evals.json
@@ -63,6 +63,31 @@
         }
       ],
       "files": []
+    },
+    {
+      "id": 3,
+      "eval_name": "codex-repeated-cache-reset-durable-config",
+      "prompt": "My Codex SigNoz plugin keeps resetting back to not-setup after plugin updates. Fix it for http://localhost:8000/mcp and make it durable.",
+      "expected_output": "Agent updates the active bundled Codex plugin .mcp.json to http://localhost:8000/mcp and also creates or updates the native Codex MCP server named signoz using `codex mcp add signoz --url http://localhost:8000/mcp` or the equivalent `[mcp_servers.signoz]` TOML entry. It explains that plugin cache files are versioned and can be regenerated from repository placeholders, while the native Codex MCP entry persists across plugin updates. It verifies the effective URL with `codex mcp get signoz` or `codex mcp list`.",
+      "assertions": [
+        {
+          "text": "Agent identifies versioned plugin cache refresh as the reason the bundled .mcp.json reset to not-setup",
+          "description": "The root cause is cache regeneration from source defaults, not an MCP runtime bug"
+        },
+        {
+          "text": "Agent updates the current bundled Codex plugin .mcp.json to the resolved endpoint",
+          "description": "The immediate plugin install is repaired"
+        },
+        {
+          "text": "Agent creates or updates native Codex MCP config for signoz using codex mcp add or [mcp_servers.signoz]",
+          "description": "The durable fix lives outside the versioned plugin cache"
+        },
+        {
+          "text": "Agent verifies the effective signoz URL with codex mcp get or codex mcp list",
+          "description": "The outcome is checked through Codex's resolved server view"
+        }
+      ],
+      "files": []
     }
   ]
 }

--- a/plugins/signoz/skills/signoz-mcp-setup/references/client-configs.md
+++ b/plugins/signoz/skills/signoz-mcp-setup/references/client-configs.md
@@ -168,6 +168,12 @@ TOML:
 url = "https://mcp.us.signoz.cloud/mcp"
 ```
 
+Use the native Codex entry when the user wants a durable setup or reports that
+the bundled plugin `.mcp.json` keeps resetting after updates. The bundled file
+is copied into a versioned plugin cache, but `codex mcp add` writes the
+user-level Codex config. Verify the effective server with
+`codex mcp get signoz` or `codex mcp list`.
+
 ### Gemini CLI
 
 CLI:

--- a/plugins/signoz/skills/signoz-mcp-setup/references/mcp-settings.md
+++ b/plugins/signoz/skills/signoz-mcp-setup/references/mcp-settings.md
@@ -106,12 +106,17 @@ the endpoint, that value can override this default. If this setup skill updates
 the default but the client still connects to the old endpoint, tell the user to
 clear the explicit plugin setting and reload the client.
 
-### Update behavior
+### Update behavior and durable Codex config
 
 These bundled files live inside the installed plugin. Plugin updates can reset
 them to the placeholder. If the `signoz` server returns to **not-setup** after
 an update, rerun `signoz-mcp-setup`. For durable native client configuration,
 use the client-specific recipes in `client-configs.md`.
+
+For Codex users who report repeated resets or ask for a persistent setup, add
+or update the native Codex MCP entry as well as the bundled `.mcp.json`. Use
+`codex mcp add signoz --url <resolved-mcp-url>` or the equivalent
+`[mcp_servers.signoz]` TOML entry, then verify with `codex mcp get signoz`.
 
 ## Endpoint Mapping
 


### PR DESCRIPTION
## Summary

- document why Codex plugin MCP endpoints can reset after plugin updates
- teach `signoz-mcp-setup` to add a native Codex MCP entry for durable setups
- add an eval covering repeated cache resets and effective URL verification

## Why

Codex installs bundled `.mcp.json` files into a versioned plugin cache. A plugin update recreates that cache from the repository's intentional `not-setup` placeholder, so edits made only inside the active cache are lost.

For users who report repeated resets, the setup skill now repairs the active bundled registration and also writes the resolved endpoint through `codex mcp add signoz --url <resolved-mcp-url>`. The resulting user-level `[mcp_servers.signoz]` entry survives plugin cache refreshes.

## Impact

Repeated plugin updates no longer require users to rediscover the durable setup path. The normal bundled-plugin flow remains unchanged for users who do not need a native override.

## Validation

- `git diff --check`
- `jq -e . plugins/signoz/skills/signoz-mcp-setup/evals/evals.json`
- verified the skill remains under the 500-line contribution limit