### PR TITLE
fix(skills): require bounded query range payloads

### DIFF
--- a/plugins/signoz/skills/signoz-creating-alerts/SKILL.md
+++ b/plugins/signoz/skills/signoz-creating-alerts/SKILL.md
@@ -328,7 +328,11 @@ Builder v5 `order`. Standalone queries and formula results use `limit: 100`.
 Every `builder_query` referenced by a formula uses `limit: 10000`, because
 SigNoz limits each component before formula evaluation; independently ranking
 the top 100 numerator and denominator groups can silently prevent an alert from
-firing. Use `__result desc` for metrics/formulas and the primary aggregation
+firing. Find those inputs from every formula expression, including formulas
+with `disabled: true`, following formula references until all `builder_query`
+leaves are found. This dependency walk determines bounds only; it does not
+guarantee formula-to-formula evaluation order, so dry-run the complete composite
+payload. Use `__result desc` for metrics/formulas and the primary aggregation
 desc for logs/traces. This field is `order`, not dashboard editor `orderBy`.
 Preserve the fields when copying the validated query into the alert. If expected
 formula-input cardinality can exceed 10000, narrow the filters/grouping and tell

--- a/plugins/signoz/skills/signoz-creating-alerts/SKILL.md
+++ b/plugins/signoz/skills/signoz-creating-alerts/SKILL.md
@@ -323,12 +323,16 @@ Run the full primary query (or formula) over the last hour:
   for that.
 
 For every persisted alert and dry-run, each `builder_query` and
-`builder_formula` spec must include `limit: 100` plus a non-empty Query
-Builder v5 `order`. Use `__result desc` for metrics/formulas and the primary
-aggregation desc for logs/traces. This field is `order`, not dashboard editor
-`orderBy`. Preserve the fields when copying the validated query into the alert.
-For time series, top-N groups are ranked over the whole evaluation window, so
-a short-lived local spike may fall outside the returned set.
+`builder_formula` spec must include a positive `limit` plus a non-empty Query
+Builder v5 `order`. Standalone queries and formula results use `limit: 100`.
+Every `builder_query` referenced by a formula uses `limit: 10000`, because
+SigNoz limits each component before formula evaluation; independently ranking
+the top 100 numerator and denominator groups can silently prevent an alert from
+firing. Use `__result desc` for metrics/formulas and the primary aggregation
+desc for logs/traces. This field is `order`, not dashboard editor `orderBy`.
+Preserve the fields when copying the validated query into the alert. If expected
+formula-input cardinality can exceed 10000, narrow the filters/grouping and tell
+the user completeness cannot otherwise be guaranteed.
 
 Compute how many evaluation points breached the proposed threshold.
 Surface in the preview as **"would have fired N times in the last 1h"**.

--- a/plugins/signoz/skills/signoz-creating-alerts/SKILL.md
+++ b/plugins/signoz/skills/signoz-creating-alerts/SKILL.md
@@ -323,7 +323,7 @@ Run the full primary query (or formula) over the last hour:
   for that.
 
 For every persisted alert and dry-run, each `builder_query` and
-`builder_formula` spec must include `limit: 1000` plus a non-empty Query
+`builder_formula` spec must include `limit: 100` plus a non-empty Query
 Builder v5 `order`. Use `__result desc` for metrics/formulas and the primary
 aggregation desc for logs/traces. This field is `order`, not dashboard editor
 `orderBy`. Preserve the fields when copying the validated query into the alert.

--- a/plugins/signoz/skills/signoz-creating-alerts/SKILL.md
+++ b/plugins/signoz/skills/signoz-creating-alerts/SKILL.md
@@ -322,6 +322,14 @@ Run the full primary query (or formula) over the last hour:
   PromQL is not supported here; use `signoz_execute_builder_query`
   for that.
 
+For every persisted alert and dry-run, each `builder_query` and
+`builder_formula` spec must include `limit: 1000` plus a non-empty Query
+Builder v5 `order`. Use `__result desc` for metrics/formulas and the primary
+aggregation desc for logs/traces. This field is `order`, not dashboard editor
+`orderBy`. Preserve the fields when copying the validated query into the alert.
+For time series, top-N groups are ranked over the whole evaluation window, so
+a short-lived local spike may fall outside the returned set.
+
 Compute how many evaluation points breached the proposed threshold.
 Surface in the preview as **"would have fired N times in the last 1h"**.
 A 1h window is too short to grade most alerts — only the upper extreme

--- a/plugins/signoz/skills/signoz-creating-alerts/evals/evals.json
+++ b/plugins/signoz/skills/signoz-creating-alerts/evals/evals.json
@@ -11,7 +11,7 @@
         "Every signoz_execute_builder_query dry-run carries start and end as JSON integer Unix-millisecond values in the outer query",
         "The signoz_create_alert payload puts Slack in the warning threshold channels and PagerDuty in the critical threshold channels",
         "The threshold-rule create payload does not rely on top-level preferredChannels for its per-severity routing",
-        "Every metric builder_query in the dry-run and create payload has limit=1000 plus Query Builder v5 order by __result desc"
+        "Every metric builder_query in the dry-run and create payload has limit=100 plus Query Builder v5 order by __result desc"
       ],
       "files": []
     },
@@ -35,7 +35,7 @@
         "The log data probe calls signoz_aggregate_logs with aggregation=count, never aggregation=count()",
         "The full dry-run uses signoz_execute_builder_query with signal=logs in the builder_query spec",
         "The signoz_create_alert payload puts the chosen Slack channel in condition.thresholds.spec[].channels",
-        "Every log builder_query in the dry-run and create payload has limit=1000 plus Query Builder v5 order by count() desc (not dashboard orderBy)"
+        "Every log builder_query in the dry-run and create payload has limit=100 plus Query Builder v5 order by count() desc (not dashboard orderBy)"
       ],
       "files": []
     },
@@ -47,7 +47,7 @@
       "expectations": [
         "The metric data probe calls signoz_query_metrics with a concrete metricName and service.name='frontend'; it never uses an expression-only count() metrics aggregation",
         "The signoz_execute_builder_query dry-run validates the base metric query without claiming to validate the anomaly functions transform or anomaly score",
-        "The persisted base metric builder_query and its signoz_execute_builder_query dry-run each have limit=1000 plus Query Builder v5 order by __result desc and no dashboard orderBy",
+        "The persisted base metric builder_query and its signoz_execute_builder_query dry-run each have limit=100 plus Query Builder v5 order by __result desc and no dashboard orderBy",
         "The signoz_create_alert payload has top-level preferredChannels containing the selected Slack channel",
         "The anomaly create payload omits condition.thresholds, evaluation, notificationSettings, and schemaVersion"
       ],
@@ -63,7 +63,7 @@
         "The full dry-run preserves having.expression=count() > 50 in the Query Builder spec",
         "The actual signoz_execute_builder_query dry-run carries start and end as JSON integer Unix-millisecond values in the outer query",
         "The signoz_create_alert payload places both Slack and PagerDuty names in the critical threshold channels array",
-        "The trace builder_query persisted and dry-run has limit=1000 plus Query Builder v5 order by p99(duration_nano) desc"
+        "The trace builder_query persisted and dry-run has limit=100 plus Query Builder v5 order by p99(duration_nano) desc"
       ],
       "files": []
     },

--- a/plugins/signoz/skills/signoz-creating-alerts/evals/evals.json
+++ b/plugins/signoz/skills/signoz-creating-alerts/evals/evals.json
@@ -22,7 +22,8 @@
       "expected_output": "TRACES_BASED_ALERT with formula F1 = A*100/B (A = count of error spans, B = count of all spans) on service.name='checkoutservice', threshold target 3, targetUnit percent. CRITICAL: must paginate signoz_list_alert_rules and detect existing 'checkout-svc Error Rate > 3%' alert, surface it as a duplicate, and ask whether to proceed/modify/cancel rather than silently creating another one.",
       "expectations": [
         "The trace data probe calls signoz_aggregate_traces with aggregation=count, never aggregation=count()",
-        "If creation proceeds after duplicate resolution, the direct channel is in condition.thresholds.spec[].channels"
+        "If creation proceeds after duplicate resolution, the direct channel is in condition.thresholds.spec[].channels",
+        "If creation proceeds, trace builder_query inputs A and B use limit=10000 plus v5 order by count() desc in both the dry-run and persisted alert, while builder_formula F1 uses limit=100 plus v5 order by __result desc"
       ],
       "files": []
     },

--- a/plugins/signoz/skills/signoz-creating-alerts/evals/evals.json
+++ b/plugins/signoz/skills/signoz-creating-alerts/evals/evals.json
@@ -10,7 +10,8 @@
         "The data probe calls signoz_query_metrics with a concrete metricName and the cartservice filter; it never sends count() or count_distinct(service.name) as a metrics aggregation expression",
         "Every signoz_execute_builder_query dry-run carries start and end as JSON integer Unix-millisecond values in the outer query",
         "The signoz_create_alert payload puts Slack in the warning threshold channels and PagerDuty in the critical threshold channels",
-        "The threshold-rule create payload does not rely on top-level preferredChannels for its per-severity routing"
+        "The threshold-rule create payload does not rely on top-level preferredChannels for its per-severity routing",
+        "Every metric builder_query in the dry-run and create payload has limit=1000 plus Query Builder v5 order by __result desc"
       ],
       "files": []
     },
@@ -33,7 +34,8 @@
       "expectations": [
         "The log data probe calls signoz_aggregate_logs with aggregation=count, never aggregation=count()",
         "The full dry-run uses signoz_execute_builder_query with signal=logs in the builder_query spec",
-        "The signoz_create_alert payload puts the chosen Slack channel in condition.thresholds.spec[].channels"
+        "The signoz_create_alert payload puts the chosen Slack channel in condition.thresholds.spec[].channels",
+        "Every log builder_query in the dry-run and create payload has limit=1000 plus Query Builder v5 order by count() desc (not dashboard orderBy)"
       ],
       "files": []
     },
@@ -45,6 +47,7 @@
       "expectations": [
         "The metric data probe calls signoz_query_metrics with a concrete metricName and service.name='frontend'; it never uses an expression-only count() metrics aggregation",
         "The signoz_execute_builder_query dry-run validates the base metric query without claiming to validate the anomaly functions transform or anomaly score",
+        "The persisted base metric builder_query and its signoz_execute_builder_query dry-run each have limit=1000 plus Query Builder v5 order by __result desc and no dashboard orderBy",
         "The signoz_create_alert payload has top-level preferredChannels containing the selected Slack channel",
         "The anomaly create payload omits condition.thresholds, evaluation, notificationSettings, and schemaVersion"
       ],
@@ -59,7 +62,8 @@
         "The trace data probe calls signoz_aggregate_traces with aggregation=count, never aggregation=count()",
         "The full dry-run preserves having.expression=count() > 50 in the Query Builder spec",
         "The actual signoz_execute_builder_query dry-run carries start and end as JSON integer Unix-millisecond values in the outer query",
-        "The signoz_create_alert payload places both Slack and PagerDuty names in the critical threshold channels array"
+        "The signoz_create_alert payload places both Slack and PagerDuty names in the critical threshold channels array",
+        "The trace builder_query persisted and dry-run has limit=1000 plus Query Builder v5 order by p99(duration_nano) desc"
       ],
       "files": []
     },

--- a/plugins/signoz/skills/signoz-creating-dashboards/SKILL.md
+++ b/plugins/signoz/skills/signoz-creating-dashboards/SKILL.md
@@ -385,22 +385,18 @@ required fields, panel-type-specific shapes, the canonical
 `filters.items[].key.id` form, operator casing, and common write-shape
 errors. Re-skim it before serialising any custom widget JSON.
 
-Every dashboard `queryData` entry and `queryFormulas` entry must carry a
-positive `limit` and non-empty editor-model `orderBy` (`columnName` +
-`order`). Raw list and trace-request panels default to 100 with timestamp-desc
-ordering (raw logs add id as a tie-breaker); a deliberately smaller positive
-list page may use the same value for `limit` and `pageSize`. Aggregate panels
-use 100 with the primary aggregation desc. Formula outputs use 100 with
-`__result desc`, while every base query referenced by a formula uses 10000;
-base limits are applied before formula evaluation, so independently top-100
-inputs can drop the group with the highest formula result. During dry-run
-translation, log/trace base queries keep the primary
-aggregation as their Query Builder v5 `order` key, while metric base queries
-translate the editor primary-aggregation `orderBy` key to v5 `__result` and
-preserve its direction. Formulas use `__result` in both models. Never pass
-dashboard `orderBy` to `signoz_execute_builder_query`. Time-series top-N ranks
-groups over the whole window and can omit a short-lived local spike. Narrow
-filters/grouping if formula-input cardinality can exceed 10000.
+Every dashboard `queryData` and `queryFormulas` entry must carry a positive `limit` and non-empty editor-model
+`orderBy` (`columnName` + `order`). Raw list and trace-request panels default to 100 with timestamp-desc ordering
+(raw logs add id); a deliberately smaller list page may match `limit` to `pageSize`. Aggregate panels use 100 with
+the primary aggregation desc. Formula outputs use 100 with `__result desc`; every referenced base query uses 10000
+because base limits apply before formula evaluation. Find those inputs from every formula expression, including
+formulas with `disabled: true`, following references until every base `builder_query` leaf is reached. This dependency
+walk chooses bounds only; it does not establish deterministic formula-to-formula evaluation order, so dry-run the
+complete composite payload. During translation, log/trace bases keep the primary aggregation as their v5 `order`
+key; metric bases translate editor primary-aggregation `orderBy` to v5 `__result` while preserving direction.
+Formulas use `__result` in both models. Never pass dashboard `orderBy` to `signoz_execute_builder_query`.
+Time-series top-N ranks groups over the whole window and can omit a short-lived local spike. Narrow filters/grouping
+if formula-input cardinality can exceed 10000.
 
 One rule `widgets-examples` does not call out, but
 `signoz_create_dashboard` enforces: **no `JSON.stringify` on

--- a/plugins/signoz/skills/signoz-creating-dashboards/SKILL.md
+++ b/plugins/signoz/skills/signoz-creating-dashboards/SKILL.md
@@ -390,13 +390,17 @@ positive `limit` and non-empty editor-model `orderBy` (`columnName` +
 `order`). Raw list and trace-request panels default to 100 with timestamp-desc
 ordering (raw logs add id as a tie-breaker); a deliberately smaller positive
 list page may use the same value for `limit` and `pageSize`. Aggregate panels
-use 100 with the primary aggregation desc; formulas use 100 with `__result desc`.
-During dry-run translation, log/trace base queries keep the primary
+use 100 with the primary aggregation desc. Formula outputs use 100 with
+`__result desc`, while every base query referenced by a formula uses 10000;
+base limits are applied before formula evaluation, so independently top-100
+inputs can drop the group with the highest formula result. During dry-run
+translation, log/trace base queries keep the primary
 aggregation as their Query Builder v5 `order` key, while metric base queries
 translate the editor primary-aggregation `orderBy` key to v5 `__result` and
 preserve its direction. Formulas use `__result` in both models. Never pass
 dashboard `orderBy` to `signoz_execute_builder_query`. Time-series top-N ranks
-groups over the whole window and can omit a short-lived local spike.
+groups over the whole window and can omit a short-lived local spike. Narrow
+filters/grouping if formula-input cardinality can exceed 10000.
 
 One rule `widgets-examples` does not call out, but
 `signoz_create_dashboard` enforces: **no `JSON.stringify` on

--- a/plugins/signoz/skills/signoz-creating-dashboards/SKILL.md
+++ b/plugins/signoz/skills/signoz-creating-dashboards/SKILL.md
@@ -385,6 +385,19 @@ required fields, panel-type-specific shapes, the canonical
 `filters.items[].key.id` form, operator casing, and common write-shape
 errors. Re-skim it before serialising any custom widget JSON.
 
+Every dashboard `queryData` entry and `queryFormulas` entry must carry a
+positive `limit` and non-empty editor-model `orderBy` (`columnName` +
+`order`). Raw list and trace-request panels default to 100 with timestamp-desc
+ordering (raw logs add id as a tie-breaker); a deliberately smaller positive
+list page may use the same value for `limit` and `pageSize`. Aggregate panels
+use 1000 with the primary aggregation desc; formulas use 1000 with `__result desc`.
+During dry-run translation, log/trace base queries keep the primary
+aggregation as their Query Builder v5 `order` key, while metric base queries
+translate the editor primary-aggregation `orderBy` key to v5 `__result` and
+preserve its direction. Formulas use `__result` in both models. Never pass
+dashboard `orderBy` to `signoz_execute_builder_query`. Time-series top-N ranks
+groups over the whole window and can omit a short-lived local spike.
+
 One rule `widgets-examples` does not call out, but
 `signoz_create_dashboard` enforces: **no `JSON.stringify` on
 arrays/objects** `layout`, `widgets`, `tags`, and `variables` are

--- a/plugins/signoz/skills/signoz-creating-dashboards/SKILL.md
+++ b/plugins/signoz/skills/signoz-creating-dashboards/SKILL.md
@@ -390,7 +390,7 @@ positive `limit` and non-empty editor-model `orderBy` (`columnName` +
 `order`). Raw list and trace-request panels default to 100 with timestamp-desc
 ordering (raw logs add id as a tie-breaker); a deliberately smaller positive
 list page may use the same value for `limit` and `pageSize`. Aggregate panels
-use 1000 with the primary aggregation desc; formulas use 1000 with `__result desc`.
+use 100 with the primary aggregation desc; formulas use 100 with `__result desc`.
 During dry-run translation, log/trace base queries keep the primary
 aggregation as their Query Builder v5 `order` key, while metric base queries
 translate the editor primary-aggregation `orderBy` key to v5 `__result` and

--- a/plugins/signoz/skills/signoz-creating-dashboards/evals/evals.json
+++ b/plugins/signoz/skills/signoz-creating-dashboards/evals/evals.json
@@ -68,7 +68,7 @@
         "Agent uses OTel resource attribute names (host.name, not 'host') in filters or groupBy",
         "Agent emits a plain-language summary (no JSON dump) of the dashboard before calling signoz_create_dashboard",
         "Agent runs signoz_execute_builder_query as a per-panel dry-run for every authored panel before signoz_create_dashboard",
-        "Every saved metric query has limit=1000 plus editor orderBy on its primary aggregation, and every dry-run metric builder_query has limit=1000 plus v5 order by __result desc and no dashboard orderBy"
+        "Every saved metric query has limit=100 plus editor orderBy on its primary aggregation, and every dry-run metric builder_query has limit=100 plus v5 order by __result desc and no dashboard orderBy"
       ],
       "files": []
     },
@@ -118,7 +118,7 @@
         "Agent uses service.name (dotted, OTel resource attribute) in builder-mode filters and variables — not the underscored span-metric label 'service_name' (this skill builds in builder mode only, never PromQL) and not the bare shorthand 'service'",
         "Agent emits a plain-language summary before creation that explains the formulas and tells the user to select the 28d global viewer range",
         "The actual signoz_execute_builder_query call contains builder_query envelopes named A and B plus a sibling builder_formula envelope named F1 with its expression; no execution spec contains dashboard-only queryName or dataSource",
-        "Every saved dashboard base metric query has limit=1000 plus editor orderBy on its primary aggregation, while every translated metric builder_query has limit=1000 plus v5 order by __result desc and no orderBy; saved and translated formulas each have limit=1000 and use __result desc in their respective orderBy/order shapes",
+        "Every saved dashboard base metric query has limit=100 plus editor orderBy on its primary aggregation, while every translated metric builder_query has limit=100 plus v5 order by __result desc and no orderBy; saved and translated formulas each have limit=100 and use __result desc in their respective orderBy/order shapes",
         "Each dry-run base query carries the service restriction under filter.expression and does not send the dashboard filters alias",
         "Agent runs signoz_execute_builder_query as a per-panel dry-run for every authored panel before signoz_create_dashboard",
         "The actual signoz_create_dashboard call keeps queryName/dataSource in queryData, queryName in queryFormulas, and the service filter in dashboard/editor form"
@@ -205,7 +205,7 @@
         "The actual signoz_execute_builder_query call places the severity restriction only in filter.expression and contains no filters field",
         "The actual signoz_create_dashboard call keeps the severity filter in the dashboard/editor filter or filters shape",
         "Agent runs signoz_execute_builder_query (with signal=logs in each builder_query.spec) as a per-panel dry-run before signoz_create_dashboard",
-        "Every saved log aggregate query has limit=1000 plus editor orderBy on its primary count aggregation, and every translated dry-run has limit=1000 plus v5 order on that aggregation with no dashboard orderBy"
+        "Every saved log aggregate query has limit=100 plus editor orderBy on its primary count aggregation, and every translated dry-run has limit=100 plus v5 order on that aggregation with no dashboard orderBy"
       ],
       "files": []
     },
@@ -289,7 +289,7 @@
         "The prepared draft uses variables and widgets and contains no singular variable or legacy panels field",
         "Variable references use $service_name in filter expressions rather than bare service_name",
         "The simulated trace runs signoz_execute_builder_query for every complete active query with service_name=checkoutservice",
-        "Every prepared trace query has limit=1000 plus editor orderBy on its primary aggregation, and every dry-run builder_query has limit=1000 plus v5 order on that aggregation and no dashboard orderBy",
+        "Every prepared trace query has limit=100 plus editor orderBy on its primary aggregation, and every dry-run builder_query has limit=100 plus v5 order on that aggregation and no dashboard orderBy",
         "Agent prepares a plain-language summary that states which panels the variable filters",
         "Agent does not call signoz_create_dashboard in the offline eval"
       ],
@@ -307,7 +307,7 @@
         "Agent explicitly identifies the non-empty HAVING array as a runtime and validation parity gap because the frontend execution converter drops it",
         "If signoz_execute_builder_query is called with having.expression=count() > 10, Agent labels that call diagnostic and does not claim it validates the saved panel",
         "No having clause array is passed to signoz_execute_builder_query",
-        "The saved log query has limit=1000 plus editor orderBy on count(), and any diagnostic dry-run has limit=1000 plus v5 order on count() and no dashboard orderBy",
+        "The saved log query has limit=100 plus editor orderBy on count(), and any diagnostic dry-run has limit=100 plus v5 order on count() and no dashboard orderBy",
         "Agent warns that the saved panel may ignore HAVING and does not call signoz_create_dashboard without explicit user acceptance of the unvalidated panel"
       ],
       "files": []
@@ -350,7 +350,7 @@
         "The actual signoz_execute_builder_query payload contains builder_query A, builder_query B, and builder_trace_operator T1 as siblings in the same compositeQuery.queries array",
         "The builder_trace_operator spec has name='T1', expression='A => B', and trace aggregations such as [{expression:'count()'}]",
         "The builder_trace_operator spec is passed through the current MCP raw-preservation contract and is never coerced into builder_query",
-        "Saved base trace queries A and B each have limit=1000 plus editor orderBy on count(), and their dry-run builder_query siblings each have limit=1000 plus v5 order on count() with no dashboard orderBy",
+        "Saved base trace queries A and B each have limit=100 plus editor orderBy on count(), and their dry-run builder_query siblings each have limit=100 plus v5 order on count() with no dashboard orderBy",
         "The execution trace-operator spec does not copy dashboard aliases queryName, dataSource, pageSize, orderBy, selectColumns, or queryTraceOperator, and does not invent signal, filter, functions, or disabled fields",
         "Agent does not call signoz_create_dashboard until the complete trace-operator execution call succeeds"
       ],

--- a/plugins/signoz/skills/signoz-creating-dashboards/evals/evals.json
+++ b/plugins/signoz/skills/signoz-creating-dashboards/evals/evals.json
@@ -118,7 +118,7 @@
         "Agent uses service.name (dotted, OTel resource attribute) in builder-mode filters and variables — not the underscored span-metric label 'service_name' (this skill builds in builder mode only, never PromQL) and not the bare shorthand 'service'",
         "Agent emits a plain-language summary before creation that explains the formulas and tells the user to select the 28d global viewer range",
         "The actual signoz_execute_builder_query call contains builder_query envelopes named A and B plus a sibling builder_formula envelope named F1 with its expression; no execution spec contains dashboard-only queryName or dataSource",
-        "Every saved dashboard base metric query has limit=100 plus editor orderBy on its primary aggregation, while every translated metric builder_query has limit=100 plus v5 order by __result desc and no orderBy; saved and translated formulas each have limit=100 and use __result desc in their respective orderBy/order shapes",
+        "Every saved dashboard base metric query referenced by the formula has limit=10000 plus editor orderBy on its primary aggregation, while every translated formula-input builder_query has limit=10000 plus v5 order by __result desc and no orderBy; saved and translated formulas each have limit=100 and use __result desc in their respective orderBy/order shapes",
         "Each dry-run base query carries the service restriction under filter.expression and does not send the dashboard filters alias",
         "Agent runs signoz_execute_builder_query as a per-panel dry-run for every authored panel before signoz_create_dashboard",
         "The actual signoz_create_dashboard call keeps queryName/dataSource in queryData, queryName in queryFormulas, and the service filter in dashboard/editor form"
@@ -182,7 +182,7 @@
         "For every authored grouped panel, the actual signoz_execute_builder_query call maps queryName to name and dataSource='traces' to signal='traces', and maps groupBy to name='service.name', fieldDataType='string', fieldContext='resource', signal='traces'",
         "No groupBy entry passed to signoz_execute_builder_query contains the dashboard-only key, dataType, or type fields",
         "Agent calls signoz_create_dashboard only after every query-bearing panel has an actual signoz_execute_builder_query dry-run",
-        "Every saved trace base query/formula has a positive limit plus editor orderBy, and every dry-run builder_query/builder_formula has the same positive limit plus v5 order and no dashboard orderBy; formulas order by __result"
+        "Every saved trace base query referenced by a formula and its dry-run sibling uses limit=10000 plus count() ordering in the editor/v5 shape; every formula result uses limit=100 plus __result ordering, and no dry-run spec contains dashboard orderBy"
       ],
       "files": []
     },
@@ -248,7 +248,7 @@
         "panelMap has exactly the Overview and Breakdowns row entries; Overview contains only the three KPI widget IDs, Breakdowns only the pie, bar, and table widget IDs, and every child's x, y, w, h matches its top-level layout entry",
         "Agent emits a plain-language summary (no JSON dump) before signoz_create_dashboard",
         "Agent runs signoz_execute_builder_query as a per-panel dry-run for every authored panel (rows excluded — they have no query) before signoz_create_dashboard",
-        "Every saved queryData/queryFormulas entry has a positive limit plus editor orderBy, and every corresponding dry-run builder_query/builder_formula has the same positive limit plus v5 order and no dashboard orderBy"
+        "The error-rate formula's saved and dry-run base queries use limit=10000 with count() ordering, its formula result uses limit=100 with __result ordering, and no dry-run spec contains dashboard orderBy; standalone panels remain at limit=100"
       ],
       "files": []
     },
@@ -332,10 +332,10 @@
       "expected_output": "Agent authors formula F1 in dashboard/editor form with its deliberate top-5 bound, translates every base query and the formula into bounded Query Builder v5 sibling envelopes, runs the complete builder_formula dry-run with canonical order, and creates only after that bounded execution succeeds.",
       "expectations": [
         "The dashboard/editor draft keeps queryFormulas queryName='F1', expression='A / B * 100', limit=5, and orderBy=[{columnName:'__result',order:'desc'}]",
-        "Every saved base queryData entry has a positive limit plus editor orderBy on its primary aggregation",
+        "Every saved base queryData entry uses limit=10000 plus editor orderBy on its primary aggregation so the deliberate top-5 bound is applied only after the formula",
         "The actual signoz_execute_builder_query call contains bounded builder_query siblings A and B plus builder_formula F1 in the same compositeQuery.queries array",
         "The actual builder_formula spec is named F1, preserves expression='A / B * 100', has limit=5 and order=[{key:{name:'__result'},direction:'desc'}], and contains no queryName or orderBy",
-        "Every execution builder_query has a positive limit plus non-empty v5 order and contains no dashboard orderBy",
+        "Every execution builder_query formula input uses limit=10000 plus non-empty v5 order and contains no dashboard orderBy",
         "Agent calls signoz_create_dashboard only after the complete bounded formula dry-run succeeds"
       ],
       "files": []

--- a/plugins/signoz/skills/signoz-creating-dashboards/evals/evals.json
+++ b/plugins/signoz/skills/signoz-creating-dashboards/evals/evals.json
@@ -67,7 +67,8 @@
         "Agent reads at least one signoz://dashboard/ MCP resource (instructions, widgets-instructions, or widgets-examples) before building JSON",
         "Agent uses OTel resource attribute names (host.name, not 'host') in filters or groupBy",
         "Agent emits a plain-language summary (no JSON dump) of the dashboard before calling signoz_create_dashboard",
-        "Agent runs signoz_execute_builder_query as a per-panel dry-run for every authored panel before signoz_create_dashboard"
+        "Agent runs signoz_execute_builder_query as a per-panel dry-run for every authored panel before signoz_create_dashboard",
+        "Every saved metric query has limit=1000 plus editor orderBy on its primary aggregation, and every dry-run metric builder_query has limit=1000 plus v5 order by __result desc and no dashboard orderBy"
       ],
       "files": []
     },
@@ -99,6 +100,7 @@
         "Agent uses a sum aggregation over a numeric order-amount attribute for the revenue panel (not just a count)",
         "Agent emits a plain-language summary (no JSON dump) before calling signoz_create_dashboard",
         "Agent runs signoz_execute_builder_query as a per-panel dry-run for every authored panel before signoz_create_dashboard",
+        "Every saved dashboard queryData/queryFormulas entry has a positive limit plus editor orderBy, while every translated dry-run builder_query/builder_formula has the same limit plus v5 order and no orderBy",
         "Agent calls signoz_create_dashboard with the custom-built payload"
       ],
       "files": []
@@ -116,6 +118,7 @@
         "Agent uses service.name (dotted, OTel resource attribute) in builder-mode filters and variables — not the underscored span-metric label 'service_name' (this skill builds in builder mode only, never PromQL) and not the bare shorthand 'service'",
         "Agent emits a plain-language summary before creation that explains the formulas and tells the user to select the 28d global viewer range",
         "The actual signoz_execute_builder_query call contains builder_query envelopes named A and B plus a sibling builder_formula envelope named F1 with its expression; no execution spec contains dashboard-only queryName or dataSource",
+        "Every saved dashboard base metric query has limit=1000 plus editor orderBy on its primary aggregation, while every translated metric builder_query has limit=1000 plus v5 order by __result desc and no orderBy; saved and translated formulas each have limit=1000 and use __result desc in their respective orderBy/order shapes",
         "Each dry-run base query carries the service restriction under filter.expression and does not send the dashboard filters alias",
         "Agent runs signoz_execute_builder_query as a per-panel dry-run for every authored panel before signoz_create_dashboard",
         "The actual signoz_create_dashboard call keeps queryName/dataSource in queryData, queryName in queryFormulas, and the service filter in dashboard/editor form"
@@ -145,7 +148,8 @@
         "Each widget in the payload includes id, panelTypes, title, query, selectedLogFields, selectedTracesFields, thresholds, and contextLinks",
         "Each widget contextLinks is an object with a linksData array, never a bare array",
         "The widget's query object includes queryType and the complete active Builder payload; inactive PromQL and ClickHouse payloads need not be authored",
-        "Agent runs signoz_execute_builder_query as a dry-run for the panel before signoz_create_dashboard"
+        "Agent runs signoz_execute_builder_query as a dry-run for the panel before signoz_create_dashboard",
+        "The saved panel query has a positive limit plus editor orderBy, and its dry-run builder_query has the same positive limit plus non-empty v5 order and no dashboard orderBy"
       ],
       "files": []
     },
@@ -177,7 +181,8 @@
         "Agent emits a plain-language summary (no JSON dump) before calling signoz_create_dashboard",
         "For every authored grouped panel, the actual signoz_execute_builder_query call maps queryName to name and dataSource='traces' to signal='traces', and maps groupBy to name='service.name', fieldDataType='string', fieldContext='resource', signal='traces'",
         "No groupBy entry passed to signoz_execute_builder_query contains the dashboard-only key, dataType, or type fields",
-        "Agent calls signoz_create_dashboard only after every query-bearing panel has an actual signoz_execute_builder_query dry-run"
+        "Agent calls signoz_create_dashboard only after every query-bearing panel has an actual signoz_execute_builder_query dry-run",
+        "Every saved trace base query/formula has a positive limit plus editor orderBy, and every dry-run builder_query/builder_formula has the same positive limit plus v5 order and no dashboard orderBy; formulas order by __result"
       ],
       "files": []
     },
@@ -199,7 +204,8 @@
         "Agent emits a plain-language summary (no JSON dump) before calling signoz_create_dashboard",
         "The actual signoz_execute_builder_query call places the severity restriction only in filter.expression and contains no filters field",
         "The actual signoz_create_dashboard call keeps the severity filter in the dashboard/editor filter or filters shape",
-        "Agent runs signoz_execute_builder_query (with signal=logs in each builder_query.spec) as a per-panel dry-run before signoz_create_dashboard"
+        "Agent runs signoz_execute_builder_query (with signal=logs in each builder_query.spec) as a per-panel dry-run before signoz_create_dashboard",
+        "Every saved log aggregate query has limit=1000 plus editor orderBy on its primary count aggregation, and every translated dry-run has limit=1000 plus v5 order on that aggregation with no dashboard orderBy"
       ],
       "files": []
     },
@@ -218,7 +224,7 @@
         "Agent emits a plain-language summary (no JSON dump) before signoz_create_dashboard",
         "The actual signoz_execute_builder_query call maps pageSize=10 to limit=10, orderBy to order=[{key:{name:'timestamp'},direction:'desc'}], and selectColumns to canonical selectFields entries",
         "The dry-run builder_query.spec contains none of pageSize, orderBy, or selectColumns, and no groupBy/selectFields entry contains dashboard-only key/dataType/type; canonical order[].key is allowed",
-        "The actual signoz_create_dashboard call retains pageSize=10, orderBy with columnName/order, and selectColumns in dashboard/editor form",
+        "The actual signoz_create_dashboard call retains limit=10, pageSize=10, orderBy with columnName/order, and selectColumns in dashboard/editor form",
         "Agent runs signoz_execute_builder_query as a dry-run for the list panel before signoz_create_dashboard"
       ],
       "files": []
@@ -241,7 +247,8 @@
         "Every layout item satisfies 0 <= x < 12, 1 <= w <= 12, and x+w <= 12",
         "panelMap has exactly the Overview and Breakdowns row entries; Overview contains only the three KPI widget IDs, Breakdowns only the pie, bar, and table widget IDs, and every child's x, y, w, h matches its top-level layout entry",
         "Agent emits a plain-language summary (no JSON dump) before signoz_create_dashboard",
-        "Agent runs signoz_execute_builder_query as a per-panel dry-run for every authored panel (rows excluded — they have no query) before signoz_create_dashboard"
+        "Agent runs signoz_execute_builder_query as a per-panel dry-run for every authored panel (rows excluded — they have no query) before signoz_create_dashboard",
+        "Every saved queryData/queryFormulas entry has a positive limit plus editor orderBy, and every corresponding dry-run builder_query/builder_formula has the same positive limit plus v5 order and no dashboard orderBy"
       ],
       "files": []
     },
@@ -282,6 +289,7 @@
         "The prepared draft uses variables and widgets and contains no singular variable or legacy panels field",
         "Variable references use $service_name in filter expressions rather than bare service_name",
         "The simulated trace runs signoz_execute_builder_query for every complete active query with service_name=checkoutservice",
+        "Every prepared trace query has limit=1000 plus editor orderBy on its primary aggregation, and every dry-run builder_query has limit=1000 plus v5 order on that aggregation and no dashboard orderBy",
         "Agent prepares a plain-language summary that states which panels the variable filters",
         "Agent does not call signoz_create_dashboard in the offline eval"
       ],
@@ -299,6 +307,7 @@
         "Agent explicitly identifies the non-empty HAVING array as a runtime and validation parity gap because the frontend execution converter drops it",
         "If signoz_execute_builder_query is called with having.expression=count() > 10, Agent labels that call diagnostic and does not claim it validates the saved panel",
         "No having clause array is passed to signoz_execute_builder_query",
+        "The saved log query has limit=1000 plus editor orderBy on count(), and any diagnostic dry-run has limit=1000 plus v5 order on count() and no dashboard orderBy",
         "Agent warns that the saved panel may ignore HAVING and does not call signoz_create_dashboard without explicit user acceptance of the unvalidated panel"
       ],
       "files": []
@@ -318,15 +327,16 @@
     },
     {
       "id": 22,
-      "eval_name": "formula-order-limit-schema-gate",
+      "eval_name": "formula-order-limit-bounded-execution",
       "prompt": "Create a table of the top 5 services by error percentage using A / B * 100 as formula F1, ordered by F1 descending.",
-      "expected_output": "Agent authors formula F1 in dashboard/editor form, then checks whether the current builder_formula execution schema supports order and limit. With the current schema, it surfaces those unsupported execution-affecting fields and does not run a stripped formula or call create without explicit acceptance.",
+      "expected_output": "Agent authors formula F1 in dashboard/editor form with its deliberate top-5 bound, translates every base query and the formula into bounded Query Builder v5 sibling envelopes, runs the complete builder_formula dry-run with canonical order, and creates only after that bounded execution succeeds.",
       "expectations": [
-        "The dashboard/editor draft keeps queryFormulas queryName='F1', expression='A / B * 100', limit=5, and orderBy in dashboard form",
-        "Agent checks the current builder_formula tool schema for limit and order support",
-        "When unsupported, the agent does not omit formula limit/order and describe the resulting dry-run as successful",
-        "Agent names the formula validation gap and waits for explicit acceptance before signoz_create_dashboard",
-        "If the live schema does support them, the actual execution call instead uses a builder_formula spec named F1 with limit=5 and canonical order, never queryName/orderBy"
+        "The dashboard/editor draft keeps queryFormulas queryName='F1', expression='A / B * 100', limit=5, and orderBy=[{columnName:'__result',order:'desc'}]",
+        "Every saved base queryData entry has a positive limit plus editor orderBy on its primary aggregation",
+        "The actual signoz_execute_builder_query call contains bounded builder_query siblings A and B plus builder_formula F1 in the same compositeQuery.queries array",
+        "The actual builder_formula spec is named F1, preserves expression='A / B * 100', has limit=5 and order=[{key:{name:'__result'},direction:'desc'}], and contains no queryName or orderBy",
+        "Every execution builder_query has a positive limit plus non-empty v5 order and contains no dashboard orderBy",
+        "Agent calls signoz_create_dashboard only after the complete bounded formula dry-run succeeds"
       ],
       "files": []
     },
@@ -340,6 +350,7 @@
         "The actual signoz_execute_builder_query payload contains builder_query A, builder_query B, and builder_trace_operator T1 as siblings in the same compositeQuery.queries array",
         "The builder_trace_operator spec has name='T1', expression='A => B', and trace aggregations such as [{expression:'count()'}]",
         "The builder_trace_operator spec is passed through the current MCP raw-preservation contract and is never coerced into builder_query",
+        "Saved base trace queries A and B each have limit=1000 plus editor orderBy on count(), and their dry-run builder_query siblings each have limit=1000 plus v5 order on count() with no dashboard orderBy",
         "The execution trace-operator spec does not copy dashboard aliases queryName, dataSource, pageSize, orderBy, selectColumns, or queryTraceOperator, and does not invent signal, filter, functions, or disabled fields",
         "Agent does not call signoz_create_dashboard until the complete trace-operator execution call succeeds"
       ],
@@ -357,6 +368,20 @@
         "The actual dry-run outer query contains start and end as JSON integer Unix-millisecond values and spans a short representative window (roughly the last 30-60 minutes, not a multi-hour or multi-day display range)",
         "Every execution groupBy entry has a non-empty name equal to the discovered attribute key and contains no dashboard-only key/dataType/type aliases",
         "The saved NOT_IN values and execution NOT IN values are semantically identical"
+      ],
+      "files": []
+    },
+    {
+      "id": 25,
+      "eval_name": "custom-build-raw-log-stable-order",
+      "prompt": "Create a dashboard with one list panel showing the 20 most recent ERROR logs, including timestamp, service.name, severity_text, and body columns.",
+      "expected_output": "Agent builds a logs list panel with an intentional 20-row page, stable newest-first editor ordering, canonical selected log fields, and a raw Query Builder v5 dry-run that preserves the bound while translating dashboard orderBy to timestamp/id order.",
+      "expectations": [
+        "The saved dashboard queryData uses dataSource='logs', limit=20, pageSize=20, and editor orderBy=[{columnName:'timestamp',order:'desc'},{columnName:'id',order:'desc'}]",
+        "The saved list panel includes selectedLogFields for timestamp, service.name, severity_text, and body and filters to ERROR logs",
+        "The actual signoz_execute_builder_query call uses requestType='raw' and a logs builder_query with limit=20",
+        "The dry-run builder_query uses v5 order=[{key:{name:'timestamp'},direction:'desc'},{key:{name:'id'},direction:'desc'}] and contains no dashboard orderBy or pageSize",
+        "Agent calls signoz_create_dashboard only after the bounded raw-log dry-run succeeds"
       ],
       "files": []
     }

--- a/plugins/signoz/skills/signoz-creating-dashboards/references/dashboard-to-query-builder-v5.md
+++ b/plugins/signoz/skills/signoz-creating-dashboards/references/dashboard-to-query-builder-v5.md
@@ -12,8 +12,8 @@ the contract boundary; never pass widget JSON to the execution tool.
 Inventory every result-affecting field, including disabled dependencies. If a
 field has no exact equivalent in the current MCP tool schema, do not omit it and
 claim validation. Name the gap and write only after the user explicitly accepts
-an unvalidated panel. Treat Builder `functions` and formula `order`/`limit` as
-unsupported unless the tool schema exposes them. `legend` may remain saved-only.
+an unvalidated panel. Treat Builder `functions` as unsupported unless the tool
+schema exposes them. `legend` may remain saved-only.
 
 ## Translate one panel
 
@@ -60,8 +60,17 @@ For each `builder_query`:
 - `selectColumns[]` -> `selectFields[]`: `name` from `name` or `key`,
   `fieldDataType` from `fieldDataType` or `dataType`, `fieldContext` from
   `fieldContext` or `type`, plus `signal`. Send only canonical metadata.
-- For table/list use `limit`, falling back to `pageSize`; otherwise use `limit`.
-  `{columnName,order}` -> `{key:{name:columnName},direction:order}`.
+- Every builder query needs a positive `limit` and non-empty ordering. Raw/list
+  requests and trace-signal `requestType: trace` default to 100. An intentional
+  smaller positive list `pageSize` may override it; scalar and time-series
+  default to 1000. Preserve a positive
+  saved `limit`; otherwise apply that default. Raw and trace-request traces use
+  timestamp desc; raw logs add id desc; aggregate logs/traces use the primary
+  aggregation desc. For those signals, map editor
+  `{columnName,order}` -> v5 `{key:{name:columnName},direction:order}`. A saved
+  metric query orders by its primary aggregation in editor `orderBy`, but its
+  v5 `order` key is `__result`; preserve the direction while making that
+  special-case translation.
 - Preserve schema-supported fields such as `disabled`, `source`, and
   `stepInterval`; map `offset` only for raw/trace requests.
 - Metrics: emit one V5 aggregation from `aggregations[0]`, falling back to
@@ -75,8 +84,8 @@ For each `builder_query`:
   it; warn that the saved panel may ignore it.
 
 Formula: set `spec.name` from `queryName`, preserve `expression`/`disabled` and
-supported `legend`; map `orderBy` -> `order` and copy `limit` only when the tool
-schema accepts them.
+supported `legend`; require/copy positive `limit` (default 1000) and map
+non-empty `orderBy` to v5 `order` (default `__result desc`).
 
 Trace operator: emit a raw-preserved `builder_trace_operator` with `name` from
 `queryName`, `expression`, applicable mappings above, and trace V5 aggregations
@@ -104,6 +113,6 @@ the matching `signoz://dashboard/clickhouse-*` resources for ClickHouse schema.
 ## Saved payload invariant
 
 Dashboard writes keep editor aliases: `queryName`, `dataSource`, `filters`,
-`pageSize`, `orderBy`, `selectColumns`, clause-array HAVING,
+positive `limit`, `pageSize`, non-empty `orderBy`, `selectColumns`, clause-array HAVING,
 `queryTraceOperator`, and `groupBy[].key/dataType/type`. Canonical names belong
 only in `signoz_execute_builder_query`.

--- a/plugins/signoz/skills/signoz-creating-dashboards/references/dashboard-to-query-builder-v5.md
+++ b/plugins/signoz/skills/signoz-creating-dashboards/references/dashboard-to-query-builder-v5.md
@@ -63,7 +63,7 @@ For each `builder_query`:
 - Every builder query needs a positive `limit` and non-empty ordering. Raw/list
   requests and trace-signal `requestType: trace` default to 100. An intentional
   smaller positive list `pageSize` may override it; scalar and time-series
-  default to 1000. Preserve a positive
+  default to 100. Preserve a positive
   saved `limit`; otherwise apply that default. Raw and trace-request traces use
   timestamp desc; raw logs add id desc; aggregate logs/traces use the primary
   aggregation desc. For those signals, map editor
@@ -84,7 +84,7 @@ For each `builder_query`:
   it; warn that the saved panel may ignore it.
 
 Formula: set `spec.name` from `queryName`, preserve `expression`/`disabled` and
-supported `legend`; require/copy positive `limit` (default 1000) and map
+supported `legend`; require/copy positive `limit` (default 100) and map
 non-empty `orderBy` to v5 `order` (default `__result desc`).
 
 Trace operator: emit a raw-preserved `builder_trace_operator` with `name` from

--- a/plugins/signoz/skills/signoz-creating-dashboards/references/dashboard-to-query-builder-v5.md
+++ b/plugins/signoz/skills/signoz-creating-dashboards/references/dashboard-to-query-builder-v5.md
@@ -67,7 +67,11 @@ For each `builder_query`:
   10000 because SigNoz limits each component before formula evaluation; raise
   an existing smaller value unless it intentionally selects top N before the
   formula. Preserve other positive saved limits; otherwise apply the relevant
-  default. Raw and trace-request traces use
+  default. For bounds, inspect every formula expression, including formulas
+  with `disabled: true`, and follow formula references until all base
+  `builder_query` leaves are found. This dependency walk does not establish
+  deterministic formula-to-formula evaluation order; validate the complete
+  translated payload. Raw and trace-request traces use
   timestamp desc; raw logs add id desc; aggregate logs/traces use the primary
   aggregation desc. For those signals, map editor
   `{columnName,order}` -> v5 `{key:{name:columnName},direction:order}`. A saved
@@ -89,7 +93,8 @@ For each `builder_query`:
 Formula: set `spec.name` from `queryName`, preserve `expression`/`disabled` and
 supported `legend`; require/copy positive result `limit` (default 100) and map
 non-empty `orderBy` to v5 `order` (default `__result desc`). Keep its referenced
-base queries at 10000 so they are not independently truncated before evaluation.
+base queries at 10000 so they are not independently truncated before evaluation,
+including base-query leaves reached through a disabled formula expression.
 
 Trace operator: emit a raw-preserved `builder_trace_operator` with `name` from
 `queryName`, `expression`, applicable mappings above, and trace V5 aggregations

--- a/plugins/signoz/skills/signoz-creating-dashboards/references/dashboard-to-query-builder-v5.md
+++ b/plugins/signoz/skills/signoz-creating-dashboards/references/dashboard-to-query-builder-v5.md
@@ -63,8 +63,11 @@ For each `builder_query`:
 - Every builder query needs a positive `limit` and non-empty ordering. Raw/list
   requests and trace-signal `requestType: trace` default to 100. An intentional
   smaller positive list `pageSize` may override it; scalar and time-series
-  default to 100. Preserve a positive
-  saved `limit`; otherwise apply that default. Raw and trace-request traces use
+  standalone queries default to 100. Every query referenced by a formula uses
+  10000 because SigNoz limits each component before formula evaluation; raise
+  an existing smaller value unless it intentionally selects top N before the
+  formula. Preserve other positive saved limits; otherwise apply the relevant
+  default. Raw and trace-request traces use
   timestamp desc; raw logs add id desc; aggregate logs/traces use the primary
   aggregation desc. For those signals, map editor
   `{columnName,order}` -> v5 `{key:{name:columnName},direction:order}`. A saved
@@ -84,8 +87,9 @@ For each `builder_query`:
   it; warn that the saved panel may ignore it.
 
 Formula: set `spec.name` from `queryName`, preserve `expression`/`disabled` and
-supported `legend`; require/copy positive `limit` (default 100) and map
-non-empty `orderBy` to v5 `order` (default `__result desc`).
+supported `legend`; require/copy positive result `limit` (default 100) and map
+non-empty `orderBy` to v5 `order` (default `__result desc`). Keep its referenced
+base queries at 10000 so they are not independently truncated before evaluation.
 
 Trace operator: emit a raw-preserved `builder_trace_operator` with `name` from
 `queryName`, `expression`, applicable mappings above, and trace V5 aggregations

--- a/plugins/signoz/skills/signoz-generating-queries/SKILL.md
+++ b/plugins/signoz/skills/signoz-generating-queries/SKILL.md
@@ -147,7 +147,7 @@ For every `signoz_execute_builder_query` payload, put a positive `limit` and
 non-empty Query Builder v5 `order` on each `builder_query` and
 `builder_formula` spec. Raw requests and trace-signal `requestType: trace`
 default to 100 rows: traces order by timestamp desc, while raw logs order by
-timestamp desc then id desc. Scalar/time-series requests default to 1000 groups
+timestamp desc then id desc. Scalar/time-series requests default to 100 groups
 ordered by `__result` desc for metrics/formulas or the primary aggregation desc
 for logs/traces. This wire field is `order`, not dashboard editor `orderBy`.
 Time-series top-N ranks groups over the whole window, so a short-lived local

--- a/plugins/signoz/skills/signoz-generating-queries/SKILL.md
+++ b/plugins/signoz/skills/signoz-generating-queries/SKILL.md
@@ -143,6 +143,16 @@ default aggregation-expression descending order; explicit ordering should use a
 `groupBy` key or the aggregation expression. Custom aliases or formulas require
 `signoz_execute_builder_query`.
 
+For every `signoz_execute_builder_query` payload, put a positive `limit` and
+non-empty Query Builder v5 `order` on each `builder_query` and
+`builder_formula` spec. Raw requests and trace-signal `requestType: trace`
+default to 100 rows: traces order by timestamp desc, while raw logs order by
+timestamp desc then id desc. Scalar/time-series requests default to 1000 groups
+ordered by `__result` desc for metrics/formulas or the primary aggregation desc
+for logs/traces. This wire field is `order`, not dashboard editor `orderBy`.
+Time-series top-N ranks groups over the whole window, so a short-lived local
+spike may fall outside the returned set.
+
 **`requestType` decision for aggregations:**
 - `scalar` (default): "How many?", "What is the p99?", "Which service has the most?"
 - `time_series`: "When did errors spike?", "How did latency change?", "Show trend"

--- a/plugins/signoz/skills/signoz-generating-queries/SKILL.md
+++ b/plugins/signoz/skills/signoz-generating-queries/SKILL.md
@@ -152,10 +152,14 @@ ordered by `__result` desc for metrics/formulas or the primary aggregation desc
 for logs/traces. Formula results stay at 100, but every `builder_query`
 referenced by a formula uses 10000 because each component limit is applied
 before formula evaluation; independently top-100 inputs can drop a high-ratio
-group. Narrow filters/grouping if input cardinality can exceed 10000. This wire
-field is `order`, not dashboard editor `orderBy`. Time-series top-N ranks groups
-over the whole window, so a short-lived local spike may fall outside the
-returned set.
+group. When calculating those input bounds, inspect every formula expression,
+including formulas with `disabled: true`, and follow formula references until
+all `builder_query` leaves are found. This dependency walk sets bounds only; it
+does not prove deterministic formula-to-formula evaluation order, so validate
+the complete composite payload. Narrow filters/grouping if input cardinality
+can exceed 10000. This wire field is `order`, not dashboard editor `orderBy`.
+Time-series top-N ranks groups over the whole window, so a short-lived local
+spike may fall outside the returned set.
 
 **`requestType` decision for aggregations:**
 - `scalar` (default): "How many?", "What is the p99?", "Which service has the most?"

--- a/plugins/signoz/skills/signoz-generating-queries/SKILL.md
+++ b/plugins/signoz/skills/signoz-generating-queries/SKILL.md
@@ -149,9 +149,13 @@ non-empty Query Builder v5 `order` on each `builder_query` and
 default to 100 rows: traces order by timestamp desc, while raw logs order by
 timestamp desc then id desc. Scalar/time-series requests default to 100 groups
 ordered by `__result` desc for metrics/formulas or the primary aggregation desc
-for logs/traces. This wire field is `order`, not dashboard editor `orderBy`.
-Time-series top-N ranks groups over the whole window, so a short-lived local
-spike may fall outside the returned set.
+for logs/traces. Formula results stay at 100, but every `builder_query`
+referenced by a formula uses 10000 because each component limit is applied
+before formula evaluation; independently top-100 inputs can drop a high-ratio
+group. Narrow filters/grouping if input cardinality can exceed 10000. This wire
+field is `order`, not dashboard editor `orderBy`. Time-series top-N ranks groups
+over the whole window, so a short-lived local spike may fall outside the
+returned set.
 
 **`requestType` decision for aggregations:**
 - `scalar` (default): "How many?", "What is the p99?", "Which service has the most?"

--- a/plugins/signoz/skills/signoz-generating-queries/evals/evals.json
+++ b/plugins/signoz/skills/signoz-generating-queries/evals/evals.json
@@ -86,6 +86,7 @@
       "expectations": [
         "Agent discovers every trace field used in filters or groupBy with signoz_get_field_keys signal=traces",
         "The actual signoz_execute_builder_query call contains two trace builder_query siblings and a builder_formula sibling whose expression computes error count divided by total count",
+        "Both trace builder_query formula inputs use limit=10000 with v5 order by count() desc, while the builder_formula result uses limit=100 with v5 order by __result desc",
         "The actual outer query has schemaVersion=v1 and start/end as JSON integer Unix-millisecond values",
         "Every execution groupBy entry has a non-empty discovered name and contains no dashboard-only key alias",
         "Agent does not use signoz_aggregate_traces alone to answer the error-rate ranking"
@@ -100,6 +101,7 @@
       "expectations": [
         "Agent calls signoz_get_field_keys with signal=logs before using service or severity fields and uses returned dot-notation names verbatim",
         "The actual signoz_execute_builder_query call contains two log builder_query siblings and a builder_formula sibling computing A / B * 100 or an equivalent percentage",
+        "Both log builder_query formula inputs use limit=10000 with v5 order by count() desc, while the builder_formula result uses limit=100 with v5 order by __result desc",
         "The actual outer query has absolute start/end JSON integer Unix-ms values and every execution groupBy name is non-empty",
         "Agent does not claim signoz_aggregate_logs alone computes the requested per-service percentage"
       ],

--- a/plugins/signoz/skills/signoz-generating-queries/evals/evals.json
+++ b/plugins/signoz/skills/signoz-generating-queries/evals/evals.json
@@ -57,6 +57,7 @@
         "Agent calls signoz_get_field_keys with signal=metrics and source=meter and uses the returned service.name field descriptor",
         "Agent uses signoz_execute_builder_query with an outer query object containing Unix-millisecond start and end, requestType=time_series, formatOptions, and variables",
         "The actual signoz_execute_builder_query payload uses signal=metrics, source=meter, the discovered metricName and temporality, stepInterval=3600, raw timeAggregation=sum, and spaceAggregation=sum",
+        "Every builder_query in the actual payload has limit=1000 plus Query Builder v5 order by __result desc and no dashboard orderBy",
         "Every raw builder groupBy entry in the actual payload losslessly copies name, fieldDataType, fieldContext, and signal from signoz_get_field_keys",
         "Agent does not use signoz_query_metrics for the grouped Cost Meter total attribution",
         "Agent excludes partial=true datapoints and sums complete hourly buckets per service",

--- a/plugins/signoz/skills/signoz-generating-queries/evals/evals.json
+++ b/plugins/signoz/skills/signoz-generating-queries/evals/evals.json
@@ -57,7 +57,7 @@
         "Agent calls signoz_get_field_keys with signal=metrics and source=meter and uses the returned service.name field descriptor",
         "Agent uses signoz_execute_builder_query with an outer query object containing Unix-millisecond start and end, requestType=time_series, formatOptions, and variables",
         "The actual signoz_execute_builder_query payload uses signal=metrics, source=meter, the discovered metricName and temporality, stepInterval=3600, raw timeAggregation=sum, and spaceAggregation=sum",
-        "Every builder_query in the actual payload has limit=1000 plus Query Builder v5 order by __result desc and no dashboard orderBy",
+        "Every builder_query in the actual payload has limit=100 plus Query Builder v5 order by __result desc and no dashboard orderBy",
         "Every raw builder groupBy entry in the actual payload losslessly copies name, fieldDataType, fieldContext, and signal from signoz_get_field_keys",
         "Agent does not use signoz_query_metrics for the grouped Cost Meter total attribution",
         "Agent excludes partial=true datapoints and sums complete hourly buckets per service",

--- a/plugins/signoz/skills/signoz-generating-queries/evals/evals.json
+++ b/plugins/signoz/skills/signoz-generating-queries/evals/evals.json
@@ -119,6 +119,20 @@
         "The actual query does not use timeAggregation=latest, rate, or increase"
       ],
       "files": []
+    },
+    {
+      "id": 10,
+      "eval_name": "disabled-intermediate-formula-dependency-bounds",
+      "prompt": "Run this trace error-percentage query for the last hour: A is errors by service, B is all spans by service, hidden F1 is A / B, and visible F2 is F1 * 100. Keep that formula chain and validate the complete Query Builder payload before reporting results.",
+      "expected_output": "Agent discovers the trace fields and executes one complete Query Builder v5 payload containing A, B, disabled intermediate formula F1, and visible formula F2. It treats disabled as result visibility when calculating bounds: A and B remain formula-input queries at limit 10000 even though they are reached through F1. It validates the actual composite response rather than promising a deterministic formula-to-formula evaluation order.",
+      "expectations": [
+        "Agent discovers every trace field used in filters or groupBy with signoz_get_field_keys signal=traces",
+        "The actual signoz_execute_builder_query call contains builder_query siblings A and B, disabled builder_formula F1 with expression A / B, and builder_formula F2 with expression F1 * 100 in the same compositeQuery.queries array",
+        "Builder queries A and B each use limit=10000 with v5 order by count() desc even though their direct formula F1 is disabled",
+        "Formula results F1 and F2 each use limit=100 with v5 order by __result desc, and no execution spec contains dashboard orderBy",
+        "Agent does not claim that the dependency walk proves deterministic formula-to-formula execution order; it reports data only from a successful complete-payload response or clearly reports the validation/execution failure"
+      ],
+      "files": []
     }
   ]
 }

--- a/plugins/signoz/skills/signoz-investigating-alerts/SKILL.md
+++ b/plugins/signoz/skills/signoz-investigating-alerts/SKILL.md
@@ -119,15 +119,10 @@ threshold tickle or flap) and quantifies the magnitude.
    start: `[fire_start - 30m, fire_start + 30m]`.
    - Use `signoz_execute_builder_query` for the alert's stored builder,
      formula, PromQL, or ClickHouse query envelope.
-   - First preserve existing positive bounds/order so Tier 1 reproduces the
-     stored alert exactly. If a stored formula input uses less than 10000,
-     record pre-formula truncation as a correctness risk and run a comparison
-     with that input raised to 10000 before ruling groups out. If bounds were
-     omitted, add `limit: 10000` to each `builder_query` referenced by a formula
-     and `limit: 100` to standalone queries/formula results. Use Query Builder
-     v5 `order`: `__result desc` for metrics/formulas, or the primary aggregation
-     desc for logs/traces. Do not use dashboard `orderBy`. Time-series top-N is
-     ranked over the whole window and may omit a short-lived local spike.
+   - Preserve positive bounds/order so Tier 1 reproduces the stored alert. If a formula input is below 10000, record truncation risk and compare at 10000 before ruling groups out.
+     For omissions, use 10000 on formula-input `builder_query` leaves and 100 on standalone/formula results. Find leaves from every formula expression, including `disabled: true` formulas, following references through the dependency graph.
+     This walk sets comparison bounds only; it does not prove deterministic formula-to-formula order. Use v5 `order`: `__result desc` for metrics/formulas or primary aggregation desc for logs/traces, never dashboard `orderBy`.
+     Time-series top-N ranks over the whole window and may omit a short-lived local spike.
 2. Compute:
    - **Peak value** during the fire window.
    - **Threshold breach magnitude**: `(peak - threshold) / threshold *

--- a/plugins/signoz/skills/signoz-investigating-alerts/SKILL.md
+++ b/plugins/signoz/skills/signoz-investigating-alerts/SKILL.md
@@ -119,6 +119,11 @@ threshold tickle or flap) and quantifies the magnitude.
    start: `[fire_start - 30m, fire_start + 30m]`.
    - Use `signoz_execute_builder_query` for the alert's stored builder,
      formula, PromQL, or ClickHouse query envelope.
+   - Preserve an existing positive bound/order. If a stored `builder_query` or
+     `builder_formula` omitted them, add `limit: 1000` plus Query Builder v5
+     `order`: `__result desc` for metrics/formulas, or the primary aggregation
+     desc for logs/traces. Do not use dashboard `orderBy`. Time-series top-N is
+     ranked over the whole window and may omit a short-lived local spike.
 2. Compute:
    - **Peak value** during the fire window.
    - **Threshold breach magnitude**: `(peak - threshold) / threshold *

--- a/plugins/signoz/skills/signoz-investigating-alerts/SKILL.md
+++ b/plugins/signoz/skills/signoz-investigating-alerts/SKILL.md
@@ -120,7 +120,7 @@ threshold tickle or flap) and quantifies the magnitude.
    - Use `signoz_execute_builder_query` for the alert's stored builder,
      formula, PromQL, or ClickHouse query envelope.
    - Preserve an existing positive bound/order. If a stored `builder_query` or
-     `builder_formula` omitted them, add `limit: 1000` plus Query Builder v5
+     `builder_formula` omitted them, add `limit: 100` plus Query Builder v5
      `order`: `__result desc` for metrics/formulas, or the primary aggregation
      desc for logs/traces. Do not use dashboard `orderBy`. Time-series top-N is
      ranked over the whole window and may omit a short-lived local spike.

--- a/plugins/signoz/skills/signoz-investigating-alerts/SKILL.md
+++ b/plugins/signoz/skills/signoz-investigating-alerts/SKILL.md
@@ -119,9 +119,13 @@ threshold tickle or flap) and quantifies the magnitude.
    start: `[fire_start - 30m, fire_start + 30m]`.
    - Use `signoz_execute_builder_query` for the alert's stored builder,
      formula, PromQL, or ClickHouse query envelope.
-   - Preserve an existing positive bound/order. If a stored `builder_query` or
-     `builder_formula` omitted them, add `limit: 100` plus Query Builder v5
-     `order`: `__result desc` for metrics/formulas, or the primary aggregation
+   - First preserve existing positive bounds/order so Tier 1 reproduces the
+     stored alert exactly. If a stored formula input uses less than 10000,
+     record pre-formula truncation as a correctness risk and run a comparison
+     with that input raised to 10000 before ruling groups out. If bounds were
+     omitted, add `limit: 10000` to each `builder_query` referenced by a formula
+     and `limit: 100` to standalone queries/formula results. Use Query Builder
+     v5 `order`: `__result desc` for metrics/formulas, or the primary aggregation
      desc for logs/traces. Do not use dashboard `orderBy`. Time-series top-N is
      ranked over the whole window and may omit a short-lived local spike.
 2. Compute:

--- a/plugins/signoz/skills/signoz-investigating-alerts/evals/evals.json
+++ b/plugins/signoz/skills/signoz-investigating-alerts/evals/evals.json
@@ -13,6 +13,7 @@
         "The rule incident is bounded by distinct overallStateChanged transitions, while group-specific transitions are partitioned by fingerprint and require stateChanged=true",
         "The agent never infers flapping by alternating rows from different fingerprints",
         "Each Tier-2 signoz_execute_builder_query call has an outer query object with Unix-ms start/end, requestType=time_series, compositeQuery, formatOptions, variables, and stepInterval",
+        "Every Tier-1/Tier-2 builder_query or builder_formula has a positive limit plus Query Builder v5 order (not dashboard orderBy); metrics/formulas use __result desc and log/trace aggregations use their primary aggregation desc",
         "Trace drill-down groups by status_message rather than nonexistent error_message",
         "When drilling into a searched trace, signoz_get_trace_details receives the returned trace_id as traceId plus the same absolute start/end used for the fire-window trace search"
       ],

--- a/plugins/signoz/skills/signoz-investigating-alerts/evals/evals.json
+++ b/plugins/signoz/skills/signoz-investigating-alerts/evals/evals.json
@@ -13,7 +13,7 @@
         "The rule incident is bounded by distinct overallStateChanged transitions, while group-specific transitions are partitioned by fingerprint and require stateChanged=true",
         "The agent never infers flapping by alternating rows from different fingerprints",
         "Each Tier-2 signoz_execute_builder_query call has an outer query object with Unix-ms start/end, requestType=time_series, compositeQuery, formatOptions, variables, and stepInterval",
-        "Every Tier-1/Tier-2 builder_query or builder_formula has a positive limit plus Query Builder v5 order (not dashboard orderBy); metrics/formulas use __result desc and log/trace aggregations use their primary aggregation desc",
+        "Tier 1 preserves the stored positive bounds to reproduce the alert exactly; if a formula input is below 10000, the agent identifies pre-formula truncation risk and compares against limit=10000 before ruling groups out. New Tier-2 standalone/formula-result queries use 100, formula inputs use 10000, all with v5 order rather than dashboard orderBy",
         "Trace drill-down groups by status_message rather than nonexistent error_message",
         "When drilling into a searched trace, signoz_get_trace_details receives the returned trace_id as traceId plus the same absolute start/end used for the fire-window trace search"
       ],

--- a/plugins/signoz/skills/signoz-investigating-alerts/references/baseline-comparison.md
+++ b/plugins/signoz/skills/signoz-investigating-alerts/references/baseline-comparison.md
@@ -83,7 +83,11 @@ guide for the chosen signal. Keep the outer `query`, `formatOptions`, and
 Keep the same positive limit and Query Builder v5 `order` in the fire and
 baseline requests. For time series, the limit ranks groups over the whole
 window, so a short-lived local spike can be outside the top N. Dashboard
-`orderBy` is not valid in this execution payload.
+`orderBy` is not valid in this execution payload. For a formula alert, first
+replay the stored component limits exactly. If any formula input is below
+10000, run a second fire/baseline comparison with that input raised to 10000;
+base limits are applied before formula evaluation, so independent top-N inputs
+can hide the group that should have fired.
 
 ## Computing the delta
 

--- a/plugins/signoz/skills/signoz-investigating-alerts/references/baseline-comparison.md
+++ b/plugins/signoz/skills/signoz-investigating-alerts/references/baseline-comparison.md
@@ -57,6 +57,10 @@ guide for the chosen signal. Keep the outer `query`, `formatOptions`, and
             "signal": "traces",
             "disabled": false,
             "stepInterval": 60,
+            "limit": 1000,
+            "order": [
+              {"key": {"name": "p99(duration_nano)"}, "direction": "desc"}
+            ],
             "having": { "expression": "" },
             "filter": { "expression": "service.name = 'checkout'" },
             "aggregations": [
@@ -75,6 +79,11 @@ guide for the chosen signal. Keep the outer `query`, `formatOptions`, and
   }
 }
 ```
+
+Keep the same positive limit and Query Builder v5 `order` in the fire and
+baseline requests. For time series, the limit ranks groups over the whole
+window, so a short-lived local spike can be outside the top N. Dashboard
+`orderBy` is not valid in this execution payload.
 
 ## Computing the delta
 

--- a/plugins/signoz/skills/signoz-investigating-alerts/references/baseline-comparison.md
+++ b/plugins/signoz/skills/signoz-investigating-alerts/references/baseline-comparison.md
@@ -57,7 +57,7 @@ guide for the chosen signal. Keep the outer `query`, `formatOptions`, and
             "signal": "traces",
             "disabled": false,
             "stepInterval": 60,
-            "limit": 1000,
+            "limit": 100,
             "order": [
               {"key": {"name": "p99(duration_nano)"}, "direction": "desc"}
             ],

--- a/plugins/signoz/skills/signoz-investigating-alerts/references/baseline-comparison.md
+++ b/plugins/signoz/skills/signoz-investigating-alerts/references/baseline-comparison.md
@@ -87,7 +87,11 @@ window, so a short-lived local spike can be outside the top N. Dashboard
 replay the stored component limits exactly. If any formula input is below
 10000, run a second fire/baseline comparison with that input raised to 10000;
 base limits are applied before formula evaluation, so independent top-N inputs
-can hide the group that should have fired.
+can hide the group that should have fired. Find inputs by inspecting every
+formula expression, including formulas with `disabled: true`, and following
+formula references to all `builder_query` leaves. This dependency walk changes
+only the comparison bounds; it does not prove deterministic formula-to-formula
+evaluation order.
 
 ## Computing the delta
 

--- a/plugins/signoz/skills/signoz-managing-views/SKILL.md
+++ b/plugins/signoz/skills/signoz-managing-views/SKILL.md
@@ -118,9 +118,11 @@ optional.
    The copied queries must retain every positive `spec.limit` and v5
    `spec.order` entry losslessly. Never translate them to dashboard `orderBy`.
    Raw/list views use 100 rows (logs: timestamp/id desc; traces: timestamp
-   desc); aggregate views/formulas use 100 groups ordered by the primary
-   aggregation or `__result` desc. Time-series top-N ranks groups over the
-   whole selected window and can omit a short-lived local spike.
+   desc); standalone aggregate views and formula results use 100 groups.
+   Builder queries referenced by a formula use 10000 because their limits are
+   applied before evaluation. Order by the primary aggregation or `__result`
+   desc as appropriate. Time-series top-N ranks groups over the whole selected
+   window and can omit a short-lived local spike.
 4. **Enforce the signal rule** in every `builder_query` spec.
    - For `traces` / `logs` / `metrics`: `signal == sourcePage`. A
      `sourcePage:"traces"` view with `signal:"logs"` is a server-side error.

--- a/plugins/signoz/skills/signoz-managing-views/SKILL.md
+++ b/plugins/signoz/skills/signoz-managing-views/SKILL.md
@@ -118,7 +118,7 @@ optional.
    The copied queries must retain every positive `spec.limit` and v5
    `spec.order` entry losslessly. Never translate them to dashboard `orderBy`.
    Raw/list views use 100 rows (logs: timestamp/id desc; traces: timestamp
-   desc); aggregate views/formulas use 1000 groups ordered by the primary
+   desc); aggregate views/formulas use 100 groups ordered by the primary
    aggregation or `__result` desc. Time-series top-N ranks groups over the
    whole selected window and can omit a short-lived local spike.
 4. **Enforce the signal rule** in every `builder_query` spec.

--- a/plugins/signoz/skills/signoz-managing-views/SKILL.md
+++ b/plugins/signoz/skills/signoz-managing-views/SKILL.md
@@ -115,6 +115,12 @@ optional.
    inside the saved object.
    Choose `panelType` from the saved-view intent rather than inventing it from
    the execution envelope.
+   The copied queries must retain every positive `spec.limit` and v5
+   `spec.order` entry losslessly. Never translate them to dashboard `orderBy`.
+   Raw/list views use 100 rows (logs: timestamp/id desc; traces: timestamp
+   desc); aggregate views/formulas use 1000 groups ordered by the primary
+   aggregation or `__result` desc. Time-series top-N ranks groups over the
+   whole selected window and can omit a short-lived local spike.
 4. **Enforce the signal rule** in every `builder_query` spec.
    - For `traces` / `logs` / `metrics`: `signal == sourcePage`. A
      `sourcePage:"traces"` view with `signal:"logs"` is a server-side error.

--- a/plugins/signoz/skills/signoz-managing-views/evals/evals.json
+++ b/plugins/signoz/skills/signoz-managing-views/evals/evals.json
@@ -202,7 +202,7 @@
           "description": "A meter view is queried on the metrics signal against the meter store; omitting source='meter' silently queries the default store, and the server rejects a meter view without it"
         },
         {
-          "text": "Every copied Cost Meter builder_query retains limit=1000 plus Query Builder v5 order by __result desc and contains no dashboard orderBy",
+          "text": "Every copied Cost Meter builder_query retains limit=100 plus Query Builder v5 order by __result desc and contains no dashboard orderBy",
           "description": "Aggregate saved views must remain explicitly bounded and ordered in the v5 wire shape"
         },
         {

--- a/plugins/signoz/skills/signoz-managing-views/evals/evals.json
+++ b/plugins/signoz/skills/signoz-managing-views/evals/evals.json
@@ -25,6 +25,10 @@
           "description": "Execution and saved-view envelopes differ; the validated inner queries must be preserved while the saved wrapper is constructed explicitly"
         },
         {
+          "text": "The copied trace builder_query retains limit=100 plus Query Builder v5 order by timestamp desc and does not translate it to dashboard orderBy",
+          "description": "Saved-view queries share the execution wire shape and must remain explicitly bounded and ordered during translation"
+        },
+        {
           "text": "The actual signoz_create_view compositeQuery argument does not contain schemaVersion, start, end, requestType, formatOptions, variables, or a nested query/compositeQuery envelope",
           "description": "Execution-only range and formatting fields are invalid in the saved-view compositeQuery"
         },
@@ -165,6 +169,10 @@
           "description": "A validated execution query must be translated to the saved-view wrapper rather than copied wholesale"
         },
         {
+          "text": "Every copied builder_query/builder_formula retains its positive limit and Query Builder v5 order losslessly; no dashboard orderBy is introduced",
+          "description": "Changing a saved-view query must not drop its bounded result contract during GET-then-PUT"
+        },
+        {
           "text": "The updated view.compositeQuery excludes schemaVersion, start, end, requestType, formatOptions, variables, and nested execution query/compositeQuery fields",
           "description": "Execution-only envelope fields must not leak into the saved view"
         },
@@ -192,6 +200,10 @@
         {
           "text": "Every builder_query spec has signal='metrics' AND source='meter'",
           "description": "A meter view is queried on the metrics signal against the meter store; omitting source='meter' silently queries the default store, and the server rejects a meter view without it"
+        },
+        {
+          "text": "Every copied Cost Meter builder_query retains limit=1000 plus Query Builder v5 order by __result desc and contains no dashboard orderBy",
+          "description": "Aggregate saved views must remain explicitly bounded and ordered in the v5 wire shape"
         },
         {
           "text": "The actual signoz_create_view payload uses compositeQuery={queryType:'builder', panelType:'graph', queries:[...]} with queries copied from the validated execution query and no execution-only envelope fields",

--- a/plugins/signoz/skills/signoz-managing-views/evals/evals.json
+++ b/plugins/signoz/skills/signoz-managing-views/evals/evals.json
@@ -169,7 +169,7 @@
           "description": "A validated execution query must be translated to the saved-view wrapper rather than copied wholesale"
         },
         {
-          "text": "Every copied builder_query/builder_formula retains its positive limit and Query Builder v5 order losslessly; no dashboard orderBy is introduced",
+          "text": "Every copied builder_query/builder_formula retains its positive limit and Query Builder v5 order losslessly; formula inputs remain at 10000 and formula results at 100, with no dashboard orderBy introduced",
           "description": "Changing a saved-view query must not drop its bounded result contract during GET-then-PUT"
         },
         {

--- a/plugins/signoz/skills/signoz-modifying-dashboards/SKILL.md
+++ b/plugins/signoz/skills/signoz-modifying-dashboards/SKILL.md
@@ -183,7 +183,7 @@ dashboard state uses positive `limit` plus editor-model `orderBy`; the dry-run
 translation uses the same positive `limit` plus Query Builder v5 `order`. List
 and trace-request panels default to 100 rows ordered by timestamp desc (raw logs
 also id desc), but preserve a deliberate smaller positive list limit such as
-the panel pageSize. Aggregate panels/formulas default to 1000 groups. Saved
+the panel pageSize. Aggregate panels/formulas default to 100 groups. Saved
 base queries order by their primary aggregation and saved formulas by
 `__result`; during dry-run translation, log/trace base queries retain the
 primary aggregation key, metric base queries translate it to `__result`, and

--- a/plugins/signoz/skills/signoz-modifying-dashboards/SKILL.md
+++ b/plugins/signoz/skills/signoz-modifying-dashboards/SKILL.md
@@ -186,13 +186,17 @@ also id desc), but preserve a deliberate smaller positive list limit such as
 the panel pageSize. Standalone aggregate queries and formula outputs default to
 100 groups. Every base query referenced by a formula uses 10000 because base
 limits are applied before formula evaluation; raise an existing smaller bound
-unless it was an intentional pre-formula top-N selection. Saved base queries
-order by their primary aggregation and saved formulas by
-`__result`; during dry-run translation, log/trace base queries retain the
-primary aggregation key, metric base queries translate it to `__result`, and
-formulas use `__result`. For time series, this top-N is chosen over the whole
-window, so a short-lived local spike can be omitted. Narrow filters/grouping if
-formula-input cardinality can exceed 10000.
+unless it was an intentional pre-formula top-N selection. Find the complete
+base-query set by inspecting every formula expression, including formulas with
+`disabled: true`, and following formula references to all `builder_query`
+leaves. This dependency walk chooses bounds only; it does not establish
+deterministic formula-to-formula evaluation order, so dry-run the complete
+composite payload. Saved base queries order by their primary aggregation and
+saved formulas by `__result`; during dry-run translation, log/trace base queries
+retain the primary aggregation key, metric base queries translate it to
+`__result`, and formulas use `__result`. For time series, this top-N is chosen
+over the whole window, so a short-lived local spike can be omitted. Narrow
+filters/grouping if formula-input cardinality can exceed 10000.
 
 If the reference's safety gate finds an unsupported execution field, report the
 panel as unvalidated and continue only after explicit acceptance. Server or

--- a/plugins/signoz/skills/signoz-modifying-dashboards/SKILL.md
+++ b/plugins/signoz/skills/signoz-modifying-dashboards/SKILL.md
@@ -178,6 +178,18 @@ display range by reflex; apply the reference's dry-run hygiene rules before
 widening or retrying after a timeout. Use representative variable values and
 keep editor aliases unchanged in saved state.
 
+Preserve or add explicit result bounds on every changed builder query/formula:
+dashboard state uses positive `limit` plus editor-model `orderBy`; the dry-run
+translation uses the same positive `limit` plus Query Builder v5 `order`. List
+and trace-request panels default to 100 rows ordered by timestamp desc (raw logs
+also id desc), but preserve a deliberate smaller positive list limit such as
+the panel pageSize. Aggregate panels/formulas default to 1000 groups. Saved
+base queries order by their primary aggregation and saved formulas by
+`__result`; during dry-run translation, log/trace base queries retain the
+primary aggregation key, metric base queries translate it to `__result`, and
+formulas use `__result`. For time series, this top-N is chosen over the whole
+window, so a short-lived local spike can be omitted.
+
 If the reference's safety gate finds an unsupported execution field, report the
 panel as unvalidated and continue only after explicit acceptance. Server or
 validation errors and unexpected empty results block unless explicitly accepted.

--- a/plugins/signoz/skills/signoz-modifying-dashboards/SKILL.md
+++ b/plugins/signoz/skills/signoz-modifying-dashboards/SKILL.md
@@ -183,12 +183,16 @@ dashboard state uses positive `limit` plus editor-model `orderBy`; the dry-run
 translation uses the same positive `limit` plus Query Builder v5 `order`. List
 and trace-request panels default to 100 rows ordered by timestamp desc (raw logs
 also id desc), but preserve a deliberate smaller positive list limit such as
-the panel pageSize. Aggregate panels/formulas default to 100 groups. Saved
-base queries order by their primary aggregation and saved formulas by
+the panel pageSize. Standalone aggregate queries and formula outputs default to
+100 groups. Every base query referenced by a formula uses 10000 because base
+limits are applied before formula evaluation; raise an existing smaller bound
+unless it was an intentional pre-formula top-N selection. Saved base queries
+order by their primary aggregation and saved formulas by
 `__result`; during dry-run translation, log/trace base queries retain the
 primary aggregation key, metric base queries translate it to `__result`, and
 formulas use `__result`. For time series, this top-N is chosen over the whole
-window, so a short-lived local spike can be omitted.
+window, so a short-lived local spike can be omitted. Narrow filters/grouping if
+formula-input cardinality can exceed 10000.
 
 If the reference's safety gate finds an unsupported execution field, report the
 panel as unvalidated and continue only after explicit acceptance. Server or

--- a/plugins/signoz/skills/signoz-modifying-dashboards/evals/evals.json
+++ b/plugins/signoz/skills/signoz-modifying-dashboards/evals/evals.json
@@ -68,7 +68,7 @@
         "A new Error Rate widget is present with all required v5 fields and groupBy contains 'service.name'",
         "Net widget count equals original count (one removed, one added)",
         "Agent dry-runs the new Error Rate panel with builder_query envelopes named A and B plus a sibling builder_formula envelope named F1 before preparing the update",
-        "Every new saved base query/formula has a positive limit plus editor orderBy, and every dry-run builder_query/builder_formula has the same positive limit plus v5 order and no dashboard orderBy; formulas order by __result",
+        "Every new saved and dry-run base query referenced by the formula uses limit=10000 with the signal-specific aggregation order; every formula result uses limit=100 with __result ordering, and no dry-run spec contains dashboard orderBy",
         "Transcript indicates a single planned update_dashboard call (changes batched, not iterative)",
         "All supported non-target widget, variable, and panelMap semantics are preserved",
         "Agent did not call signoz_update_dashboard (read-only eval constraint respected)"
@@ -191,7 +191,7 @@
         "Capacity moves from y:7 to y:13 in top-level layout; CPU moves from y:8 to y:14 in both top-level layout and panelMap",
         "Overview panelMap contains Request Rate and the new Error Rate panel only; Capacity panelMap still contains CPU only",
         "The simulated trace successfully dry-runs the supplied complete Error Rate query before accepting the mutation plan",
-        "Every new saved Error Rate base query/formula has a positive limit plus editor orderBy, and every dry-run builder_query/builder_formula has the same positive limit plus v5 order and no dashboard orderBy; the formula orders by __result",
+        "Every new saved and dry-run Error Rate base query uses limit=10000 with the signal-specific aggregation order; the formula result uses limit=100 with __result ordering, and no dry-run spec contains dashboard orderBy",
         "Agent did not call signoz_update_dashboard (read-only eval constraint respected)"
       ]
     },

--- a/plugins/signoz/skills/signoz-modifying-dashboards/evals/evals.json
+++ b/plugins/signoz/skills/signoz-modifying-dashboards/evals/evals.json
@@ -21,7 +21,7 @@
         "The actual dry-run outer query contains start and end as JSON integer Unix-millisecond values",
         "Every groupBy entry passed to signoz_execute_builder_query has a non-empty name",
         "No groupBy entry passed to signoz_execute_builder_query contains the dashboard-only key, dataType, or type fields",
-        "The new saved graph query has limit=1000 plus editor orderBy by p99(duration_nano) desc, while the translated dry-run has limit=1000 plus v5 order and no orderBy",
+        "The new saved graph query has limit=100 plus editor orderBy by p99(duration_nano) desc, while the translated dry-run has limit=100 plus v5 order and no orderBy",
         "Agent did not call signoz_update_dashboard (read-only eval constraint respected)"
       ]
     },
@@ -116,7 +116,7 @@
         "The new panel appears exactly once in the Overview panelMap row and its x, y, w, h matches its top-level layout entry",
         "Every duplicated panelMap layout entry satisfies the same horizontal bounds and matches its top-level x, y, w, h",
         "Agent successfully dry-runs the new p99 panel with signoz_execute_builder_query before preparing the update",
-        "The new saved p99 query has limit=1000 plus editor orderBy on p99(duration_nano), and its dry-run has limit=1000 plus v5 order on p99(duration_nano) with no dashboard orderBy",
+        "The new saved p99 query has limit=100 plus editor orderBy on p99(duration_nano), and its dry-run has limit=100 plus v5 order on p99(duration_nano) with no dashboard orderBy",
         "Agent did not call signoz_update_dashboard (read-only eval constraint respected)"
       ]
     },
@@ -173,7 +173,7 @@
         "Consumer Lag and Throughput filters reference $deployment_environment, while Broker Health does not",
         "The prepared dashboard mutates widgets and contains no legacy panels field",
         "The simulated trace successfully dry-runs both complete changed queries with deployment_environment=prod",
-        "Each changed saved metric query has limit=1000 plus editor orderBy on its primary aggregation, while each dry-run metric builder_query has limit=1000 plus v5 order by __result desc and no dashboard orderBy",
+        "Each changed saved metric query has limit=100 plus editor orderBy on its primary aggregation, while each dry-run metric builder_query has limit=100 plus v5 order by __result desc and no dashboard orderBy",
         "Existing variables, layout, Broker Health, and all unrelated supported state remain semantically unchanged",
         "Agent did not call signoz_update_dashboard (read-only eval constraint respected)"
       ]

--- a/plugins/signoz/skills/signoz-modifying-dashboards/evals/evals.json
+++ b/plugins/signoz/skills/signoz-modifying-dashboards/evals/evals.json
@@ -21,6 +21,7 @@
         "The actual dry-run outer query contains start and end as JSON integer Unix-millisecond values",
         "Every groupBy entry passed to signoz_execute_builder_query has a non-empty name",
         "No groupBy entry passed to signoz_execute_builder_query contains the dashboard-only key, dataType, or type fields",
+        "The new saved graph query has limit=1000 plus editor orderBy by p99(duration_nano) desc, while the translated dry-run has limit=1000 plus v5 order and no orderBy",
         "Agent did not call signoz_update_dashboard (read-only eval constraint respected)"
       ]
     },
@@ -67,6 +68,7 @@
         "A new Error Rate widget is present with all required v5 fields and groupBy contains 'service.name'",
         "Net widget count equals original count (one removed, one added)",
         "Agent dry-runs the new Error Rate panel with builder_query envelopes named A and B plus a sibling builder_formula envelope named F1 before preparing the update",
+        "Every new saved base query/formula has a positive limit plus editor orderBy, and every dry-run builder_query/builder_formula has the same positive limit plus v5 order and no dashboard orderBy; formulas order by __result",
         "Transcript indicates a single planned update_dashboard call (changes batched, not iterative)",
         "All supported non-target widget, variable, and panelMap semantics are preserved",
         "Agent did not call signoz_update_dashboard (read-only eval constraint respected)"
@@ -114,6 +116,7 @@
         "The new panel appears exactly once in the Overview panelMap row and its x, y, w, h matches its top-level layout entry",
         "Every duplicated panelMap layout entry satisfies the same horizontal bounds and matches its top-level x, y, w, h",
         "Agent successfully dry-runs the new p99 panel with signoz_execute_builder_query before preparing the update",
+        "The new saved p99 query has limit=1000 plus editor orderBy on p99(duration_nano), and its dry-run has limit=1000 plus v5 order on p99(duration_nano) with no dashboard orderBy",
         "Agent did not call signoz_update_dashboard (read-only eval constraint respected)"
       ]
     },
@@ -151,6 +154,7 @@
       "files": ["evals/files/dry-run-validation-error.json"],
       "expectations": [
         "Agent does not ignore or downplay the dry-run error",
+        "Every attempted new builder_query/builder_formula remains explicitly bounded with a positive limit plus v5 order and contains no dashboard orderBy, even when another validation error blocks the dry-run",
         "Agent either corrects and successfully re-runs the exact panel query or stops with the failure explained",
         "Agent does not call signoz_update_dashboard with a panel whose dry-run failed"
       ]
@@ -169,6 +173,7 @@
         "Consumer Lag and Throughput filters reference $deployment_environment, while Broker Health does not",
         "The prepared dashboard mutates widgets and contains no legacy panels field",
         "The simulated trace successfully dry-runs both complete changed queries with deployment_environment=prod",
+        "Each changed saved metric query has limit=1000 plus editor orderBy on its primary aggregation, while each dry-run metric builder_query has limit=1000 plus v5 order by __result desc and no dashboard orderBy",
         "Existing variables, layout, Broker Health, and all unrelated supported state remain semantically unchanged",
         "Agent did not call signoz_update_dashboard (read-only eval constraint respected)"
       ]
@@ -186,6 +191,7 @@
         "Capacity moves from y:7 to y:13 in top-level layout; CPU moves from y:8 to y:14 in both top-level layout and panelMap",
         "Overview panelMap contains Request Rate and the new Error Rate panel only; Capacity panelMap still contains CPU only",
         "The simulated trace successfully dry-runs the supplied complete Error Rate query before accepting the mutation plan",
+        "Every new saved Error Rate base query/formula has a positive limit plus editor orderBy, and every dry-run builder_query/builder_formula has the same positive limit plus v5 order and no dashboard orderBy; the formula orders by __result",
         "Agent did not call signoz_update_dashboard (read-only eval constraint respected)"
       ]
     },
@@ -204,13 +210,13 @@
       "id": 13,
       "eval_name": "list-panel-execution-and-update-wrapper-contract",
       "prompt": "Using the attached offline fixture, change the Recent Errors list on Error Explorer to 25 rows and sort oldest first, then apply the update.",
-      "expected_output": "Agent fetches the complete dashboard, changes only pageSize and orderBy in saved dashboard state, executes the canonical V5 equivalent against the stub, and calls the stubbed update tool with the required {id,dashboard} wrapper.",
+      "expected_output": "Agent fetches the complete dashboard, changes limit, pageSize, and orderBy together in saved dashboard state, executes the canonical V5 equivalent against the stub, and calls the stubbed update tool with the required {id,dashboard} wrapper.",
       "files": ["evals/files/update-payload-contract.json"],
       "expectations": [
         "The actual signoz_execute_builder_query call maps filters.items to filter.expression, pageSize=25 to limit=25, orderBy to order with key.name='timestamp' and direction='asc', and selectColumns to canonical selectFields",
         "The dry-run builder_query.spec contains none of filters, pageSize, orderBy, selectColumns, queryName, or dataSource, and no groupBy/selectFields entry contains dashboard-only key/dataType/type; canonical order[].key is allowed",
         "The actual signoz_update_dashboard call has top-level id='66666666-6666-4666-8666-666666666666' and a nested dashboard object; title, widgets, layout, and variables are not flattened beside id",
-        "The nested dashboard is the complete fetched state and retains dashboard/editor filters, pageSize=25, orderBy=[{columnName:'timestamp',order:'asc'}], and selectColumns",
+        "The nested dashboard is the complete fetched state and retains dashboard/editor filters, limit=25, pageSize=25, orderBy=[{columnName:'timestamp',order:'asc'}], and selectColumns",
         "The fetched and updated widget contextLinks is an object with linksData=[] and is never converted to a bare array",
         "The update is called only after the canonical dry-run succeeds"
       ]

--- a/plugins/signoz/skills/signoz-modifying-dashboards/references/dashboard-to-query-builder-v5.md
+++ b/plugins/signoz/skills/signoz-modifying-dashboards/references/dashboard-to-query-builder-v5.md
@@ -12,8 +12,8 @@ the contract boundary; never pass widget JSON to the execution tool.
 Inventory every result-affecting field, including disabled dependencies. If a
 field has no exact equivalent in the current MCP tool schema, do not omit it and
 claim validation. Name the gap and write only after the user explicitly accepts
-an unvalidated panel. Treat Builder `functions` and formula `order`/`limit` as
-unsupported unless the tool schema exposes them. `legend` may remain saved-only.
+an unvalidated panel. Treat Builder `functions` as unsupported unless the tool
+schema exposes them. `legend` may remain saved-only.
 
 ## Translate one panel
 
@@ -60,8 +60,17 @@ For each `builder_query`:
 - `selectColumns[]` -> `selectFields[]`: `name` from `name` or `key`,
   `fieldDataType` from `fieldDataType` or `dataType`, `fieldContext` from
   `fieldContext` or `type`, plus `signal`. Send only canonical metadata.
-- For table/list use `limit`, falling back to `pageSize`; otherwise use `limit`.
-  `{columnName,order}` -> `{key:{name:columnName},direction:order}`.
+- Every builder query needs a positive `limit` and non-empty ordering. Raw/list
+  requests and trace-signal `requestType: trace` default to 100. An intentional
+  smaller positive list `pageSize` may override it; scalar and time-series
+  default to 1000. Preserve a positive
+  saved `limit`; otherwise apply that default. Raw and trace-request traces use
+  timestamp desc; raw logs add id desc; aggregate logs/traces use the primary
+  aggregation desc. For those signals, map editor
+  `{columnName,order}` -> v5 `{key:{name:columnName},direction:order}`. A saved
+  metric query orders by its primary aggregation in editor `orderBy`, but its
+  v5 `order` key is `__result`; preserve the direction while making that
+  special-case translation.
 - Preserve schema-supported fields such as `disabled`, `source`, and
   `stepInterval`; map `offset` only for raw/trace requests.
 - Metrics: emit one V5 aggregation from `aggregations[0]`, falling back to
@@ -75,8 +84,8 @@ For each `builder_query`:
   it; warn that the saved panel may ignore it.
 
 Formula: set `spec.name` from `queryName`, preserve `expression`/`disabled` and
-supported `legend`; map `orderBy` -> `order` and copy `limit` only when the tool
-schema accepts them.
+supported `legend`; require/copy positive `limit` (default 1000) and map
+non-empty `orderBy` to v5 `order` (default `__result desc`).
 
 Trace operator: emit a raw-preserved `builder_trace_operator` with `name` from
 `queryName`, `expression`, applicable mappings above, and trace V5 aggregations
@@ -104,6 +113,6 @@ the matching `signoz://dashboard/clickhouse-*` resources for ClickHouse schema.
 ## Saved payload invariant
 
 Dashboard writes keep editor aliases: `queryName`, `dataSource`, `filters`,
-`pageSize`, `orderBy`, `selectColumns`, clause-array HAVING,
+positive `limit`, `pageSize`, non-empty `orderBy`, `selectColumns`, clause-array HAVING,
 `queryTraceOperator`, and `groupBy[].key/dataType/type`. Canonical names belong
 only in `signoz_execute_builder_query`.

--- a/plugins/signoz/skills/signoz-modifying-dashboards/references/dashboard-to-query-builder-v5.md
+++ b/plugins/signoz/skills/signoz-modifying-dashboards/references/dashboard-to-query-builder-v5.md
@@ -63,7 +63,7 @@ For each `builder_query`:
 - Every builder query needs a positive `limit` and non-empty ordering. Raw/list
   requests and trace-signal `requestType: trace` default to 100. An intentional
   smaller positive list `pageSize` may override it; scalar and time-series
-  default to 1000. Preserve a positive
+  default to 100. Preserve a positive
   saved `limit`; otherwise apply that default. Raw and trace-request traces use
   timestamp desc; raw logs add id desc; aggregate logs/traces use the primary
   aggregation desc. For those signals, map editor
@@ -84,7 +84,7 @@ For each `builder_query`:
   it; warn that the saved panel may ignore it.
 
 Formula: set `spec.name` from `queryName`, preserve `expression`/`disabled` and
-supported `legend`; require/copy positive `limit` (default 1000) and map
+supported `legend`; require/copy positive `limit` (default 100) and map
 non-empty `orderBy` to v5 `order` (default `__result desc`).
 
 Trace operator: emit a raw-preserved `builder_trace_operator` with `name` from

--- a/plugins/signoz/skills/signoz-modifying-dashboards/references/dashboard-to-query-builder-v5.md
+++ b/plugins/signoz/skills/signoz-modifying-dashboards/references/dashboard-to-query-builder-v5.md
@@ -67,7 +67,11 @@ For each `builder_query`:
   10000 because SigNoz limits each component before formula evaluation; raise
   an existing smaller value unless it intentionally selects top N before the
   formula. Preserve other positive saved limits; otherwise apply the relevant
-  default. Raw and trace-request traces use
+  default. For bounds, inspect every formula expression, including formulas
+  with `disabled: true`, and follow formula references until all base
+  `builder_query` leaves are found. This dependency walk does not establish
+  deterministic formula-to-formula evaluation order; validate the complete
+  translated payload. Raw and trace-request traces use
   timestamp desc; raw logs add id desc; aggregate logs/traces use the primary
   aggregation desc. For those signals, map editor
   `{columnName,order}` -> v5 `{key:{name:columnName},direction:order}`. A saved
@@ -89,7 +93,8 @@ For each `builder_query`:
 Formula: set `spec.name` from `queryName`, preserve `expression`/`disabled` and
 supported `legend`; require/copy positive result `limit` (default 100) and map
 non-empty `orderBy` to v5 `order` (default `__result desc`). Keep its referenced
-base queries at 10000 so they are not independently truncated before evaluation.
+base queries at 10000 so they are not independently truncated before evaluation,
+including base-query leaves reached through a disabled formula expression.
 
 Trace operator: emit a raw-preserved `builder_trace_operator` with `name` from
 `queryName`, `expression`, applicable mappings above, and trace V5 aggregations

--- a/plugins/signoz/skills/signoz-modifying-dashboards/references/dashboard-to-query-builder-v5.md
+++ b/plugins/signoz/skills/signoz-modifying-dashboards/references/dashboard-to-query-builder-v5.md
@@ -63,8 +63,11 @@ For each `builder_query`:
 - Every builder query needs a positive `limit` and non-empty ordering. Raw/list
   requests and trace-signal `requestType: trace` default to 100. An intentional
   smaller positive list `pageSize` may override it; scalar and time-series
-  default to 100. Preserve a positive
-  saved `limit`; otherwise apply that default. Raw and trace-request traces use
+  standalone queries default to 100. Every query referenced by a formula uses
+  10000 because SigNoz limits each component before formula evaluation; raise
+  an existing smaller value unless it intentionally selects top N before the
+  formula. Preserve other positive saved limits; otherwise apply the relevant
+  default. Raw and trace-request traces use
   timestamp desc; raw logs add id desc; aggregate logs/traces use the primary
   aggregation desc. For those signals, map editor
   `{columnName,order}` -> v5 `{key:{name:columnName},direction:order}`. A saved
@@ -84,8 +87,9 @@ For each `builder_query`:
   it; warn that the saved panel may ignore it.
 
 Formula: set `spec.name` from `queryName`, preserve `expression`/`disabled` and
-supported `legend`; require/copy positive `limit` (default 100) and map
-non-empty `orderBy` to v5 `order` (default `__result desc`).
+supported `legend`; require/copy positive result `limit` (default 100) and map
+non-empty `orderBy` to v5 `order` (default `__result desc`). Keep its referenced
+base queries at 10000 so they are not independently truncated before evaluation.
 
 Trace operator: emit a raw-preserved `builder_trace_operator` with `name` from
 `queryName`, `expression`, applicable mappings above, and trace V5 aggregations

--- a/plugins/signoz/skills/signoz-reducing-telemetry-cost/SKILL.md
+++ b/plugins/signoz/skills/signoz-reducing-telemetry-cost/SKILL.md
@@ -299,6 +299,11 @@ a signal the workflow already analyzed.
 - **Cost totals and grouped total attribution use `signoz_execute_builder_query`** with raw
   `timeAggregation: sum`, hourly `stepInterval: 3600`, and complete datapoints only — never
   `signoz_query_metrics`.
+- Every Cost Meter `builder_query` sent through that raw escape hatch includes
+  `limit: 1000` and Query Builder v5 `order: [{key:{name:"__result"},
+  direction:"desc"}]`. This is wire `order`, not dashboard `orderBy`; preserve
+  it in grouped queries. The limit ranks groups over the whole window, so call
+  out the possibility that a short-lived group falls outside the top N.
 - **Never present an Infra-page or APM metric as safe to drop** (see
   `references/infra-do-not-drop.md`), even when usage-check shows no dashboards or alerts.
 - **Logs:** never recommend dropping/filtering a whole service or namespace that carries active

--- a/plugins/signoz/skills/signoz-reducing-telemetry-cost/SKILL.md
+++ b/plugins/signoz/skills/signoz-reducing-telemetry-cost/SKILL.md
@@ -300,7 +300,7 @@ a signal the workflow already analyzed.
   `timeAggregation: sum`, hourly `stepInterval: 3600`, and complete datapoints only — never
   `signoz_query_metrics`.
 - Every Cost Meter `builder_query` sent through that raw escape hatch includes
-  `limit: 1000` and Query Builder v5 `order: [{key:{name:"__result"},
+  `limit: 100` and Query Builder v5 `order: [{key:{name:"__result"},
   direction:"desc"}]`. This is wire `order`, not dashboard `orderBy`; preserve
   it in grouped queries. The limit ranks groups over the whole window, so call
   out the possibility that a short-lived group falls outside the top N.

--- a/plugins/signoz/skills/signoz-reducing-telemetry-cost/evals/evals.json
+++ b/plugins/signoz/skills/signoz-reducing-telemetry-cost/evals/evals.json
@@ -10,6 +10,7 @@
         "Agent starts with signoz_execute_builder_query Cost Meter queries before signal-specific analysis",
         "Agent discovers Cost Meter groupBy keys with signoz_get_field_keys signal=metrics source=meter",
         "Every raw builder groupBy entry in the actual signoz_execute_builder_query payload losslessly copies name, fieldDataType, fieldContext, and signal from the selected signoz_get_field_keys result",
+        "Every Cost Meter builder_query has limit=1000 plus Query Builder v5 order by __result desc and no dashboard orderBy",
         "Agent analyzes metrics, logs, and traces because every signal has Cost Meter data",
         "Agent orders the investigation by current weighted cost: metrics, then logs, then traces",
         "Agent returns one consolidated prioritized action list without repeating the per-signal playbooks"
@@ -40,6 +41,7 @@
         "Agent calls signoz_list_metrics with source=meter and uses the returned metric names and units rather than assuming a fixed meter list",
         "Agent calls signoz_execute_builder_query with an outer query object containing Unix-millisecond start and end, requestType=time_series, formatOptions, and variables",
         "Agent uses source=meter, the discovered metricName and temporality, stepInterval=3600, and timeAggregation=sum for Cost Meter totals",
+        "Every Cost Meter builder_query has limit=1000 plus Query Builder v5 order by __result desc and no dashboard orderBy",
         "Agent does not use signoz_query_metrics for Cost Meter totals",
         "Agent excludes datapoints marked partial=true and sums the remaining complete hourly buckets",
         "Agent converts log and span bytes to GB with the decimal 1e9 divisor",

--- a/plugins/signoz/skills/signoz-reducing-telemetry-cost/evals/evals.json
+++ b/plugins/signoz/skills/signoz-reducing-telemetry-cost/evals/evals.json
@@ -10,7 +10,7 @@
         "Agent starts with signoz_execute_builder_query Cost Meter queries before signal-specific analysis",
         "Agent discovers Cost Meter groupBy keys with signoz_get_field_keys signal=metrics source=meter",
         "Every raw builder groupBy entry in the actual signoz_execute_builder_query payload losslessly copies name, fieldDataType, fieldContext, and signal from the selected signoz_get_field_keys result",
-        "Every Cost Meter builder_query has limit=1000 plus Query Builder v5 order by __result desc and no dashboard orderBy",
+        "Every Cost Meter builder_query has limit=100 plus Query Builder v5 order by __result desc and no dashboard orderBy",
         "Agent analyzes metrics, logs, and traces because every signal has Cost Meter data",
         "Agent orders the investigation by current weighted cost: metrics, then logs, then traces",
         "Agent returns one consolidated prioritized action list without repeating the per-signal playbooks"
@@ -41,7 +41,7 @@
         "Agent calls signoz_list_metrics with source=meter and uses the returned metric names and units rather than assuming a fixed meter list",
         "Agent calls signoz_execute_builder_query with an outer query object containing Unix-millisecond start and end, requestType=time_series, formatOptions, and variables",
         "Agent uses source=meter, the discovered metricName and temporality, stepInterval=3600, and timeAggregation=sum for Cost Meter totals",
-        "Every Cost Meter builder_query has limit=1000 plus Query Builder v5 order by __result desc and no dashboard orderBy",
+        "Every Cost Meter builder_query has limit=100 plus Query Builder v5 order by __result desc and no dashboard orderBy",
         "Agent does not use signoz_query_metrics for Cost Meter totals",
         "Agent excludes datapoints marked partial=true and sums the remaining complete hourly buckets",
         "Agent converts log and span bytes to GB with the decimal 1e9 divisor",

--- a/plugins/signoz/skills/signoz-reducing-telemetry-cost/references/cost-meter-queries.md
+++ b/plugins/signoz/skills/signoz-reducing-telemetry-cost/references/cost-meter-queries.md
@@ -47,6 +47,10 @@ the example `start` and `end` integers with the requested range in Unix millisec
             "signal": "metrics",
             "source": "meter",
             "stepInterval": 3600,
+            "limit": 1000,
+            "order": [
+              {"key": {"name": "__result"}, "direction": "desc"}
+            ],
             "aggregations": [
               {
                 "metricName": "<discovered_meter_metric_name>",
@@ -68,6 +72,11 @@ the example `start` and `end` integers with the requested range in Unix millisec
   }
 }
 ```
+
+The 1000-group bound ranks groups across the whole requested window. A group
+with a short-lived local spike can fall outside the returned top N; narrow the
+window or choose a deliberate positive override when that matters. Query Range
+uses `order`; `orderBy` is only for dashboard editor payloads.
 
 Meter buckets are hourly, so keep `stepInterval: 3600`. Sum all complete hourly values across
 every returned series, excluding datapoints with `partial: true`; they are incomplete edge

--- a/plugins/signoz/skills/signoz-reducing-telemetry-cost/references/cost-meter-queries.md
+++ b/plugins/signoz/skills/signoz-reducing-telemetry-cost/references/cost-meter-queries.md
@@ -47,7 +47,7 @@ the example `start` and `end` integers with the requested range in Unix millisec
             "signal": "metrics",
             "source": "meter",
             "stepInterval": 3600,
-            "limit": 1000,
+            "limit": 100,
             "order": [
               {"key": {"name": "__result"}, "direction": "desc"}
             ],
@@ -73,7 +73,7 @@ the example `start` and `end` integers with the requested range in Unix millisec
 }
 ```
 
-The 1000-group bound ranks groups across the whole requested window. A group
+The 100-group bound ranks groups across the whole requested window. A group
 with a short-lived local spike can fall outside the returned top N; narrow the
 window or choose a deliberate positive override when that matters. Query Range
 uses `order`; `orderBy` is only for dashboard editor payloads.


### PR DESCRIPTION
## Summary

- teach every SigNoz workflow that authors Query Builder v5 payloads to set a positive limit and explicit order
- keep standalone queries and formula results at limit 100
- use limit 10000 for every builder-query leaf feeding a formula, including dependencies discovered through formulas with `disabled: true`
- distinguish dashboard editor `orderBy` from the MCP execution wire field `order`
- carry the rule through alerts, dashboards, ad-hoc queries, investigations, and saved views
- avoid promising deterministic formula-to-formula evaluation order; validate the complete composite payload
- tighten eval expectations for raw, aggregate, formula, trace-operator, update, and disabled-formula paths

## Why

The MCP server supplies centralized defaults, but skills should author complete bounded payloads so behavior remains explicit and reviewable. Independently top-100 formula inputs can discard a low-volume, high-ratio group before evaluation. Disabled formula expressions are still part of dependency discovery because upstream hides disabled results only after formula processing.

## Contract taught by the skills

- raw and standalone aggregate queries default to limit 100
- formula results default to limit 100
- every builder-query leaf referenced by any formula expression uses limit 10000
- raw logs order by timestamp desc then id desc
- raw traces and trace-detail requests order by timestamp desc
- scalar/time-series metric inputs and formulas order by `__result desc`
- scalar/time-series log and trace inputs order by their primary aggregation desc
- dashboard JSON uses `orderBy`; Query Builder v5 execution uses `order`
- alert investigations replay stored limits first, then compare formula inputs at 10000 when the stored value is lower
- filters/grouping must be narrowed when formula-input cardinality can exceed 10000

## Compatibility

This branch is based on current main and retains the query-construction regressions added by PR #66. No new skill or manifest edit is required; plugin versions are auto-bumped after merge.

## Review and verification

- three independent cross-repo review passes; all findings addressed
- changed eval JSON parses
- `claude plugin validate --strict plugins/signoz`
- dashboard Query Builder crosswalk copies remain byte-identical
- edited skill files remain within line limits
- `git diff --check`
- companion MCP server full Go tests, vet, build, and contract tests pass

Companion MCP server PR: https://github.com/SigNoz/signoz-mcp-server/pull/241

Tracks https://github.com/SigNoz/nerve-pod/issues/132

Addresses https://github.com/SigNoz/agent-skills/pull/69#discussion_r3597782255

Addresses https://github.com/SigNoz/signoz-mcp-server/pull/241#discussion_r3598038127
