### PR TITLE
fix(plugin): add privacy policy link

### DIFF
--- a/plugins/signoz/.claude-plugin/plugin.json
+++ b/plugins/signoz/.claude-plugin/plugin.json
@@ -5,6 +5,7 @@
   "author": {
     "name": "SigNoz"
   },
+  "homepage": "https://signoz.io/privacy/",
   "repository": "https://github.com/SigNoz/agent-skills",
   "license": "MIT",
   "mcpServers": "./.signoz_claude_mcp.json",


### PR DESCRIPTION
## Summary

- add the SigNoz privacy policy as the Claude plugin manifest homepage
- make the policy directly discoverable during Claude plugin directory review

## Why

The SigNoz plugin connects to a remote MCP service, but its packaged Claude manifest did not expose a privacy policy link. This blocked the directory review in #70.

## Impact

Claude plugin users and directory reviewers can open the SigNoz privacy policy directly from the plugin metadata. There is no runtime behavior change.

## Validation

- `claude plugin validate ./plugins/signoz --strict`
- confirmed the branch is one commit ahead of `main`
- confirmed the diff changes only `plugins/signoz/.claude-plugin/plugin.json` with one added line

Fixes #70