### PR TITLE
fix: create PRs for automatic version bumps

### DIFF
--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -50,7 +50,8 @@ jobs:
             'gemini-extension.json' \
             '.devin-plugin/' \
             'plugin.json' \
-            'mcp_config.json')
+            'mcp_config.json' \
+            'skills')
 
           if [[ -z "$CHANGED" ]]; then
             echo "No plugin changes detected"
@@ -64,7 +65,7 @@ jobs:
 
           # The root Gemini, Devin, and Antigravity files are ports of the
           # signoz plugin, so a root-only port change also bumps signoz.
-          if echo "$CHANGED" | grep -qE '^(gemini-extension\.json|\.devin-plugin/.*|plugin\.json|mcp_config\.json)$'; then
+          if echo "$CHANGED" | grep -qE '^(gemini-extension\.json|\.devin-plugin/.*|plugin\.json|mcp_config\.json|skills)$'; then
             PLUGIN_DIRS=$(printf '%s\n%s\n' "$PLUGIN_DIRS" 'plugins/signoz' | sort -u)
           fi
 

--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -211,12 +211,14 @@ jobs:
 
           PR_BODY=$'Automated CalVer update for plugin changes merged to `main`.\n\nThis PR updates every versioned manifest for the affected plugin(s).'
 
-          PR_NUMBER=$(gh pr list \
-            --repo "$GITHUB_REPOSITORY" \
-            --base main \
-            --head "$BUMP_BRANCH" \
-            --state open \
-            --json number \
+          # REST's owner:branch filter prevents a fork with the same branch
+          # name from being mistaken for this repository's automation PR.
+          PR_NUMBER=$(gh api \
+            --method GET \
+            "/repos/$GITHUB_REPOSITORY/pulls" \
+            -f state=open \
+            -f base=main \
+            -f head="${GITHUB_REPOSITORY%%/*}:$BUMP_BRANCH" \
             --jq '.[0].number // empty')
 
           if [[ -n "$PR_NUMBER" ]]; then

--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -1,9 +1,7 @@
 name: Auto CalVer Bump
 
-# Runs on push to main — auto-bumps CalVer for changed plugins.
-# Loop prevention: the commit-message check on the `if` line below is the
-# real safety net. GITHUB_TOKEN's no-retrigger behaviour is not guaranteed
-# across all repository configurations.
+# Runs on push to main, then opens or updates a PR with CalVer bumps for every
+# plugin changed since the last successful auto-bump.
 
 on:
   push:
@@ -13,19 +11,15 @@ on:
 # Serialise runs so concurrent pushes don't race each other.
 concurrency:
   group: auto-bump-main
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   auto-bump:
     runs-on: ubuntu-latest
 
-    # Skip if this push was already an auto-bump (null-safe).
-    if: >-
-      github.event.head_commit != null &&
-      !contains(github.event.head_commit.message, 'chore: auto-bump CalVer')
-
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout code
@@ -35,18 +29,28 @@ jobs:
 
       - name: Detect changed plugins and bump CalVer
         id: bump
-        env:
-          BEFORE_SHA: ${{ github.event.before }}
         run: |
-          # Compare against the pre-push ref for reliable diffs across
-          # merge commits, squash merges, and multi-commit pushes.
-          # On the first push to a branch (or some force-pushes),
-          # github.event.before is all zeros — fall back to diffing
-          # against the parent commit.
-          if [[ "$BEFORE_SHA" =~ ^0+$ ]]; then
-            BEFORE_SHA="HEAD~1"
+          # Use the last version-manifest commit authored by this automation as
+          # the baseline. This remains stable if a maintainer edits a squash
+          # title, and it aggregates multiple main merges before the bump lands.
+          BASE_SHA=$(git log --format=%H \
+            --author='github-actions\[bot\]' \
+            -n 1 -- \
+            ':(glob)plugins/*/.claude-plugin/plugin.json' \
+            ':(glob)plugins/*/.codex-plugin/plugin.json' \
+            ':(glob)plugins/*/.cursor-plugin/plugin.json' \
+            'gemini-extension.json' \
+            '.devin-plugin/plugin.json')
+          if [[ -z "$BASE_SHA" ]]; then
+            BASE_SHA=$(git rev-list --max-parents=0 HEAD | tail -1)
           fi
-          CHANGED=$(git diff --name-only "$BEFORE_SHA" HEAD -- 'plugins/' || true)
+
+          CHANGED=$(git diff --name-only "$BASE_SHA" HEAD -- \
+            'plugins/' \
+            'gemini-extension.json' \
+            '.devin-plugin/' \
+            'plugin.json' \
+            'mcp_config.json')
 
           if [[ -z "$CHANGED" ]]; then
             echo "No plugin changes detected"
@@ -54,25 +58,36 @@ jobs:
             exit 0
           fi
 
-          # Extract unique plugin dirs (e.g. plugins/signoz)
-          PLUGIN_DIRS=$(echo "$CHANGED" | grep -oE '^plugins/[^/]+' | sort -u)
+          # A plugin change must be nested under plugins/<name>/. Direct files
+          # such as plugins/README.md are repository metadata, not plugins.
+          PLUGIN_DIRS=$(echo "$CHANGED" | awk -F/ '$1 == "plugins" && NF >= 3 {print $1 "/" $2}' | sort -u)
+
+          # The root Gemini, Devin, and Antigravity files are ports of the
+          # signoz plugin, so a root-only port change also bumps signoz.
+          if echo "$CHANGED" | grep -qE '^(gemini-extension\.json|\.devin-plugin/.*|plugin\.json|mcp_config\.json)$'; then
+            PLUGIN_DIRS=$(printf '%s\n%s\n' "$PLUGIN_DIRS" 'plugins/signoz' | sort -u)
+          fi
 
           TODAY=$(date -u +%Y.%m.%d)
-          BUMPED=""
           COUNT=0
 
           for PLUGIN_DIR in $PLUGIN_DIRS; do
+            if [[ ! -d "$PLUGIN_DIR" ]]; then
+              echo "Skipping removed plugin: $PLUGIN_DIR"
+              continue
+            fi
+
             # Read current version from the primary manifest
             CLAUDE_JSON="$PLUGIN_DIR/.claude-plugin/plugin.json"
             if [[ ! -f "$CLAUDE_JSON" ]]; then
-              echo "WARNING: No .claude-plugin/plugin.json in $PLUGIN_DIR, skipping"
-              continue
+              echo "ERROR: Required plugin manifest is missing: $CLAUDE_JSON"
+              exit 1
             fi
 
             CURRENT=$(jq -r '.version // empty' "$CLAUDE_JSON")
             if [[ -z "$CURRENT" ]]; then
-              echo "WARNING: No version field in $CLAUDE_JSON, skipping"
-              continue
+              echo "ERROR: No version field in $CLAUDE_JSON"
+              exit 1
             fi
 
             # CalVer bump logic
@@ -94,23 +109,25 @@ jobs:
               continue
             fi
 
-            # Bump all three plugin manifests using jq
+            # Every logical plugin must ship all three versioned manifests.
+            # Fail instead of silently leaving one client on a stale version.
             for MANIFEST in \
               "$PLUGIN_DIR/.claude-plugin/plugin.json" \
               "$PLUGIN_DIR/.codex-plugin/plugin.json" \
               "$PLUGIN_DIR/.cursor-plugin/plugin.json"; do
-              if [[ -f "$MANIFEST" ]]; then
-                if ! jq --arg v "$NEW" '.version = $v' "$MANIFEST" > "${MANIFEST}.tmp"; then
-                  echo "ERROR: jq failed on $MANIFEST"
-                  rm -f "${MANIFEST}.tmp"
-                  exit 1
-                fi
-                mv "${MANIFEST}.tmp" "$MANIFEST"
+              if [[ ! -f "$MANIFEST" ]]; then
+                echo "ERROR: Required plugin manifest is missing: $MANIFEST"
+                exit 1
               fi
+              if ! jq --arg v "$NEW" '.version = $v' "$MANIFEST" > "${MANIFEST}.tmp"; then
+                echo "ERROR: jq failed on $MANIFEST"
+                rm -f "${MANIFEST}.tmp"
+                exit 1
+              fi
+              mv "${MANIFEST}.tmp" "$MANIFEST"
             done
 
             PLUGIN_NAME=$(basename "$PLUGIN_DIR")
-            BUMPED="$BUMPED $PLUGIN_NAME"
             COUNT=$((COUNT + 1))
             echo "Bumped $PLUGIN_NAME: $CURRENT -> $NEW"
 
@@ -118,65 +135,105 @@ jobs:
             # manifest mirror the signoz plugin, so keep their versions in
             # lockstep with the same bump.
             if [[ "$PLUGIN_NAME" == "signoz" ]]; then
-              if [[ -f "gemini-extension.json" ]]; then
-                if ! jq --arg v "$NEW" '.version = $v' "gemini-extension.json" > "gemini-extension.json.tmp"; then
-                  echo "ERROR: jq failed on gemini-extension.json"
-                  rm -f "gemini-extension.json.tmp"
-                  exit 1
-                fi
-                mv "gemini-extension.json.tmp" "gemini-extension.json"
-                echo "Bumped gemini-extension.json -> $NEW (lockstep with signoz)"
+              if [[ ! -f "gemini-extension.json" ]]; then
+                echo "ERROR: Required Gemini manifest is missing: gemini-extension.json"
+                exit 1
               fi
-
-              if [[ -f ".devin-plugin/plugin.json" ]]; then
-                # Devin's plugin loader enforces strict semver, which forbids
-                # leading zeros in numeric identifiers — CalVer's MM/DD segments
-                # have one whenever the month or day is under 10 (base-10 forced
-                # via `10#` so bash doesn't misread "08"/"09" as invalid octal).
-                # Fold the day and any same-day micro suffix into the patch
-                # number itself (day*100 + micro) rather than build metadata:
-                # semver explicitly excludes build metadata (+x) from precedence
-                # comparisons, so a same-day micro bump encoded that way would
-                # compare equal to the base version and a strict-semver update
-                # path could skip it. Encoding it in patch keeps same-day bumps
-                # strictly increasing, e.g.:
-                #   2026.07.02   -> 2026.7.200
-                #   2026.07.02.1 -> 2026.7.201
-                #   2026.07.02.2 -> 2026.7.202
-                IFS='.' read -ra VER_PARTS <<< "$NEW"
-                DEVIN_DAY=$((10#${VER_PARTS[2]}))
-                DEVIN_MICRO="${VER_PARTS[3]:-0}"
-                DEVIN_MICRO=$((10#$DEVIN_MICRO))
-                DEVIN_PATCH=$((DEVIN_DAY * 100 + DEVIN_MICRO))
-                DEVIN_VERSION="${VER_PARTS[0]}.$((10#${VER_PARTS[1]})).${DEVIN_PATCH}"
-
-                if ! jq --arg v "$DEVIN_VERSION" '.version = $v' ".devin-plugin/plugin.json" > ".devin-plugin/plugin.json.tmp"; then
-                  echo "ERROR: jq failed on .devin-plugin/plugin.json"
-                  rm -f ".devin-plugin/plugin.json.tmp"
-                  exit 1
-                fi
-                mv ".devin-plugin/plugin.json.tmp" ".devin-plugin/plugin.json"
-                echo "Bumped .devin-plugin/plugin.json -> $DEVIN_VERSION (semver form of $NEW, lockstep with signoz)"
+              if ! jq --arg v "$NEW" '.version = $v' "gemini-extension.json" > "gemini-extension.json.tmp"; then
+                echo "ERROR: jq failed on gemini-extension.json"
+                rm -f "gemini-extension.json.tmp"
+                exit 1
               fi
+              mv "gemini-extension.json.tmp" "gemini-extension.json"
+              echo "Bumped gemini-extension.json -> $NEW (lockstep with signoz)"
+
+              if [[ ! -f ".devin-plugin/plugin.json" ]]; then
+                echo "ERROR: Required Devin manifest is missing: .devin-plugin/plugin.json"
+                exit 1
+              fi
+              # Devin's plugin loader enforces strict semver, which forbids
+              # leading zeros in numeric identifiers — CalVer's MM/DD segments
+              # have one whenever the month or day is under 10 (base-10 forced
+              # via `10#` so bash doesn't misread "08"/"09" as invalid octal).
+              # Fold the day and any same-day micro suffix into the patch
+              # number itself (day*100 + micro) rather than build metadata:
+              # semver explicitly excludes build metadata (+x) from precedence
+              # comparisons, so a same-day micro bump encoded that way would
+              # compare equal to the base version and a strict-semver update
+              # path could skip it. Encoding it in patch keeps same-day bumps
+              # strictly increasing, e.g.:
+              #   2026.07.02   -> 2026.7.200
+              #   2026.07.02.1 -> 2026.7.201
+              #   2026.07.02.2 -> 2026.7.202
+              IFS='.' read -ra VER_PARTS <<< "$NEW"
+              DEVIN_DAY=$((10#${VER_PARTS[2]}))
+              DEVIN_MICRO="${VER_PARTS[3]:-0}"
+              DEVIN_MICRO=$((10#$DEVIN_MICRO))
+              DEVIN_PATCH=$((DEVIN_DAY * 100 + DEVIN_MICRO))
+              DEVIN_VERSION="${VER_PARTS[0]}.$((10#${VER_PARTS[1]})).${DEVIN_PATCH}"
+
+              if ! jq --arg v "$DEVIN_VERSION" '.version = $v' ".devin-plugin/plugin.json" > ".devin-plugin/plugin.json.tmp"; then
+                echo "ERROR: jq failed on .devin-plugin/plugin.json"
+                rm -f ".devin-plugin/plugin.json.tmp"
+                exit 1
+              fi
+              mv ".devin-plugin/plugin.json.tmp" ".devin-plugin/plugin.json"
+              echo "Bumped .devin-plugin/plugin.json -> $DEVIN_VERSION (semver form of $NEW, lockstep with signoz)"
             fi
           done
 
-          if [[ -z "$BUMPED" ]]; then
+          if (( COUNT == 0 )); then
             echo "bumped=false" >> "$GITHUB_OUTPUT"
           else
             {
               echo "bumped=true"
-              echo "names=$BUMPED"
               echo "count=$COUNT"
             } >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Commit and push
+      - name: Commit, push branch, and open pull request
         if: steps.bump.outputs.bumped == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BUMP_BRANCH: automation/calver-version-bump
+          BUMP_COUNT: ${{ steps.bump.outputs.count }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # The branch is automation-owned and is regenerated from current main.
+          git switch -C "$BUMP_BRANCH"
           git add plugins/**/.claude-plugin/plugin.json plugins/**/.codex-plugin/plugin.json plugins/**/.cursor-plugin/plugin.json gemini-extension.json .devin-plugin/plugin.json
-          git commit -m "chore: auto-bump CalVer for ${{ steps.bump.outputs.count }} plugin(s)"
-          git pull --rebase origin main || { git rebase --abort 2>/dev/null; echo "ERROR: rebase failed"; exit 1; }
-          git push
+          PR_TITLE="chore: auto-bump CalVer for $BUMP_COUNT plugin(s)"
+          git commit -m "$PR_TITLE"
+          git push --force-with-lease --set-upstream origin "$BUMP_BRANCH"
+
+          PR_BODY=$'Automated CalVer update for plugin changes merged to `main`.\n\nThis PR updates every versioned manifest for the affected plugin(s).'
+
+          PR_NUMBER=$(gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --base main \
+            --head "$BUMP_BRANCH" \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')
+
+          if [[ -n "$PR_NUMBER" ]]; then
+            gh pr edit "$PR_NUMBER" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "$PR_TITLE" \
+              --body "$PR_BODY"
+            echo "Updated existing version-bump PR #$PR_NUMBER"
+          else
+            if ! PR_URL=$(gh pr create \
+              --repo "$GITHUB_REPOSITORY" \
+              --base main \
+              --head "$BUMP_BRANCH" \
+              --title "$PR_TITLE" \
+              --body "$PR_BODY" 2>&1); then
+              echo "$PR_URL"
+              echo "::error::Unable to create the version-bump PR. Verify that Settings > Actions > General > Allow GitHub Actions to create and approve pull requests is enabled."
+              exit 1
+            fi
+            echo "Created version-bump PR: $PR_URL"
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,16 +57,18 @@ Users of Claude Code, Codex, and Cursor receive updates based on these versions.
 
 ### Auto-bump workflow
 
-A GitHub Actions workflow (`.github/workflows/auto-version-bump.yml`) automatically bumps all three manifests on push to `main`. It detects which plugins have changed files and sets the version to today's date (or appends a micro suffix for multiple bumps in the same day). The root `gemini-extension.json` and `.devin-plugin/plugin.json` manifests mirror the `signoz` plugin and are bumped in lockstep with it.
+A GitHub Actions workflow (`.github/workflows/auto-version-bump.yml`) opens or updates a version-bump pull request after plugin changes land on `main`. It aggregates every plugin changed since the last successful bump and sets the version to today's date (or appends a micro suffix for multiple bumps in the same day). The root `gemini-extension.json` and `.devin-plugin/plugin.json` manifests mirror the `signoz` plugin and are bumped in lockstep with it. Root-only changes to the Gemini, Devin, or versionless Antigravity ports also trigger a `signoz` version bump.
 
-**You do not need to manually bump versions** — the workflow handles it when your PR is merged to `main`.
+Repository maintainers must enable **Settings → Actions → General → Allow GitHub Actions to create and approve pull requests** so the workflow's `GITHUB_TOKEN` can open the follow-up PR.
+
+**You do not need to manually bump versions** — after your PR is merged to `main`, the workflow opens or refreshes a follow-up version-bump PR.
 
 ## Pull Request Checklist
 
 - [ ] Skill follows the [Agent Skills specification](https://agentskills.io/specification)
 - [ ] `name` in SKILL.md frontmatter matches the directory name
 - [ ] `README.md` updated if a new skill was added
-- [ ] **Plugin versions bumped** in all three manifests (auto-bumped on merge to `main`)
+- [ ] **Plugin versions left unchanged** for the follow-up auto-bump PR
 - [ ] Changes tested locally with the relevant tool (Claude Code, Codex, or Cursor)
 
 ## License


### PR DESCRIPTION
## What changed

- replace the protected-branch push with an automation-owned version-bump branch and draft PR upsert
- aggregate plugin changes since the last successful automated manifest bump
- cover Claude, Codex, and Cursor manifests for every plugin, plus the Signoz Gemini and Devin manifests
- treat root Gemini, Devin, and versionless Antigravity port changes as Signoz plugin changes
- handle repository metadata and deleted plugins without deadlocking the bump baseline
- fail loudly for missing required manifests or Git failures
- document the required GitHub Actions pull-request setting and update the contributor checklist

## Why

The auto-bump workflow committed successfully but then attempted to push directly to protected `main`, which GitHub rejected with GH013. The workflow now creates or refreshes a pull request instead.

## Validation

- `actionlint -color`
- `git diff --check`
- Agent CI: 1/1 workflow passed on the original `main`-based working tree
- strict Claude plugin and marketplace validation
- JSON validation for all version manifests
- behavioral fixtures for normal plugin changes, root port changes, direct files under `plugins/`, deleted plugins, and squash-title-independent baseline detection
- two Fable 5 high reviews; all valid findings addressed, with no remaining P0/P1 findings

## Repository prerequisite

Maintainers must enable **Settings → Actions → General → Allow GitHub Actions to create and approve pull requests** so the workflow's `GITHUB_TOKEN` can open the follow-up PR.