### PR TITLE
chore: bump Signoz plugin version to 2026.07.23

### DIFF
--- a/.devin-plugin/plugin.json
+++ b/.devin-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "signoz",
-  "version": "2026.7.1600",
+  "version": "2026.7.2300",
   "description": "Official SigNoz plugin for MCP setup, docs, queries, dashboards, and alerts",
   "author": {
     "name": "SigNoz"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "signoz",
-  "version": "2026.07.16",
+  "version": "2026.07.23",
   "description": "Query SigNoz observability data(metrics, traces, logs, alerts, dashboards, services) via the SigNoz Cloud hosted MCP server.",
   "mcpServers": {
     "signoz": {

--- a/plugins/signoz/.claude-plugin/plugin.json
+++ b/plugins/signoz/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "signoz",
-  "version": "2026.07.16",
+  "version": "2026.07.23",
   "description": "Official SigNoz plugin for MCP setup, docs, queries, dashboards, and alerts",
   "author": {
     "name": "SigNoz"

--- a/plugins/signoz/.codex-plugin/plugin.json
+++ b/plugins/signoz/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "signoz",
-  "version": "2026.07.16",
+  "version": "2026.07.23",
   "description": "Official SigNoz plugin for MCP setup, docs, queries, dashboards, and alerts",
   "author": {
     "name": "SigNoz",

--- a/plugins/signoz/.cursor-plugin/plugin.json
+++ b/plugins/signoz/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "signoz",
   "displayName": "SigNoz",
-  "version": "2026.07.16",
+  "version": "2026.07.23",
   "description": "Official SigNoz plugin for MCP setup, docs, queries, dashboards, and alerts",
   "author": {
     "name": "SigNoz"


### PR DESCRIPTION
## What changed

Bumps the Signoz plugin version across every versioned distribution manifest:

- Claude Code: `2026.07.16` → `2026.07.23`
- Codex: `2026.07.16` → `2026.07.23`
- Cursor: `2026.07.16` → `2026.07.23`
- Gemini CLI: `2026.07.16` → `2026.07.23`
- Devin CLI: `2026.7.1600` → `2026.7.2300`

## Why

The existing auto-bump workflow could not push its generated commit to protected `main`, so plugin changes merged since the last successful bump have not received a new published version. This PR provides the catch-up bump while #73 fixes the automation to create follow-up pull requests.

## Validation

- strict Claude plugin validation
- strict Claude marketplace validation
- JSON parsing for all five manifests
- exact version synchronization assertions
- `git diff --check`

Agent CI reports no relevant workflows for this feature branch.