### PR TITLE
fix(signoz-reducing-telemetry-cost): weight cost by retention, verify config claims, and check alert/dashboard/view dependencies before recommending reductions

### DIFF
--- a/plugins/signoz/skills/signoz-reducing-telemetry-cost/SKILL.md
+++ b/plugins/signoz/skills/signoz-reducing-telemetry-cost/SKILL.md
@@ -54,9 +54,32 @@ computed; never invent a total. If the tools are unavailable, follow the prerequ
 For a rolling 7-day window (`end` = now, `start` = end − 7 days), get the per-signal totals
 (span size, log size, metric datapoints), then compute and report:
 
-- **Primary cost driver.** The signal with the highest *dollar* weight — traces/logs at
-  $0.30/GB, metrics at $0.10/M samples (orientation only; never quote dollar savings). This
-  picks by cost, not by raw volume.
+- **Ask for retention before weighting cost.** Price scales with retention tier, and traces,
+  logs, and metrics can each be retained for a different period — so ask the user for their
+  currently configured retention for each of the three signals before ranking which one costs
+  more. This is a factual input needed to weight cost accurately, not a suggestion to change
+  retention (that guardrail still applies below). If the user doesn't know, ask them to check
+  their SigNoz plan/retention settings.
+
+  | Traces / logs retention | $/GB |
+  |---|---|
+  | 15 days | 0.3 |
+  | 30 days | 0.4 |
+  | 90 days | 0.6 |
+  | 180 days | 0.8 |
+  | 1 year | 1.4 |
+
+  | Metrics retention | $/M samples |
+  |---|---|
+  | 1 month | 0.1 |
+  | 3 months | 0.12 |
+  | 6 months | 0.15 |
+  | 13 months | 0.18 |
+
+- **Primary cost driver.** The signal with the highest *dollar* weight, using each signal's own
+  retention-matched rate from the tables above (orientation only; never quote the resulting
+  dollar figure to the user — it's for ranking signals against each other, not a cost estimate).
+  This picks by cost, not by raw volume.
 - **Bytes per record.** span.size ÷ span.count and log.size ÷ log.count — tells you whether a
   signal is a payload-size problem or a volume problem.
 
@@ -128,9 +151,10 @@ it is produced and its current interval before recommending a change. A longer i
 ingested datapoints but also lowers time resolution, so preserve the resolution required by its
 dashboards and alerts. Use the source's own control: a receiver `collection_interval` for
 Collector-generated metrics, the scrape interval for Prometheus-scraped metrics, or
-`OTEL_METRIC_EXPORT_INTERVAL` for SDK push metrics when that SDK supports it. Never recommend
-switching a metric between delta and cumulative temporality; changing temporality for the same
-metric can break SigNoz queries.
+`OTEL_METRIC_EXPORT_INTERVAL` for SDK push metrics when that SDK supports it. Verify the exact
+setting name against the source's own documentation before stating it (see the verification
+guardrail below). Never recommend switching a metric between delta and cumulative temporality;
+changing temporality for the same metric can break SigNoz queries.
 
 ### Step 3: Logs
 
@@ -162,8 +186,10 @@ reduction, including a source log-level change.
 `aggregation: count`, `groupBy: "service.name,severity_text"`. Classify severities — REDUCIBLE =
 INFO, INFORMATION, DEBUG, TRACE, VERBOSE; HIGH-SIGNAL = ERROR, FATAL, CRITICAL, WARN, WARNING.
 For each top service by GB:
-- Reducible-dominant + own service code → candidate: set `LOG_LEVEL=WARN` (stops generation at
-  source).
+- Reducible-dominant + own service code → candidate: raise the log level to WARN (stops
+  generation at source). `LOG_LEVEL=WARN` is a common convention, not a universal one — confirm
+  the actual variable, config key, or logger-config call the service's language/framework uses
+  before naming it (see the verification guardrail below).
 - Reducible-dominant + third-party library → candidate: Collector filter on
   `instrumentation_scope.name`
   (read the scope from a `signoz_search_logs` sample's `scope_name`).
@@ -206,13 +232,16 @@ For each top service by GB:
   impossible).
 - `k8s.event.*` logs are often high-volume / low-value → droppable if not alerted on.
 
-**3c. Log alerts — check before any log-reduction recommendation.** `signoz_list_alert_rules`,
-**paginating through every page** (follow `pagination.nextOffset` until `pagination.hasMore` is
-false — do not stop at the first page, or an alert on a later page is missed and a filter looks
-safe when it isn't). Keep `alertType == "LOGS_BASED_ALERT"`. For each, `signoz_get_alert(id)` and read
-`condition.compositeQuery.queries[].spec.filter.expression` + `groupBy` to see which service /
-severity / namespace it guards. If a filter would blind an alert, mark it **Will break alert
-coverage** and name the alert. Docs: https://signoz.io/docs/logs-management/guides/drop-logs/
+**3c. Log alerts, dashboards, and saved views — check before any log-reduction recommendation.**
+`signoz_list_alert_rules`, **paginating through every page** (follow `pagination.nextOffset`
+until `pagination.hasMore` is false — do not stop at the first page, or an alert on a later page
+is missed and a filter looks safe when it isn't). Keep `alertType == "LOGS_BASED_ALERT"`. For
+each, `signoz_get_alert(id)` and read `condition.compositeQuery.queries[].spec.filter.expression`
++ `groupBy` to see which service / severity / namespace it guards. Check every query the alert's
+condition depends on, not just the one that looks related (see the formula-dependency guardrail
+below). If a filter would blind an alert, mark it **Will break alert coverage** and name the
+alert. Then check dashboards and saved views the same way (see the dashboard/view coverage
+guardrail below). Docs: https://signoz.io/docs/logs-management/guides/drop-logs/
 
 ### Step 4: Traces
 
@@ -239,9 +268,12 @@ service you consider reducing.
 **4c. Error rate per service.** `signoz_aggregate_traces`, `count`, `groupBy: "service.name"`
 (total), then again with `error: true`. Error rate = errors ÷ total, per service.
 
-**4d. Trace alerts.** `signoz_list_alert_rules`, **paginating through every page** (follow
-`pagination.nextOffset` until `pagination.hasMore` is false). Keep
-`alertType == "TRACES_BASED_ALERT"`; `signoz_get_alert(id)` for what each guards.
+**4d. Trace alerts, dashboards, and saved views.** `signoz_list_alert_rules`, **paginating
+through every page** (follow `pagination.nextOffset` until `pagination.hasMore` is false). Keep
+`alertType == "TRACES_BASED_ALERT"`; `signoz_get_alert(id)` for what each guards. Check every
+query the alert's condition depends on, not just the one that looks related (see the
+formula-dependency guardrail below). Then check dashboards and saved views the same way (see the
+dashboard/view coverage guardrail below).
 
 **Classify the dominant operations.**
 - Common noise candidates: health/liveness (`/health`, `/ping`, `/ready`,
@@ -255,7 +287,9 @@ service you consider reducing.
 **Fix layer.** For a confirmed noise operation, prefer the deployed SDK or instrumentation
 library's documented disable/exclusion control so generation stops at source. Identify the
 language and library before naming a setting; Java, Python, Node.js, and .NET use different
-controls. If no SDK control exists, use a Collector filter on the operation name.
+controls. Verify the exact env var, config key, or code snippet against that library's own
+documentation before stating it (see the verification guardrail below) — do not name a setting
+from memory alone. If no SDK control exists, use a Collector filter on the operation name.
 
 > **Span → APM guard (mandatory).** Never recommend or configure head, probabilistic, tail, or
 > any other trace sampling as a cost-reduction lever. When a user asks for sampling, state both
@@ -267,6 +301,19 @@ controls. If no SDK control exists, use a Collector filter on the operation name
 > Use SDK exclusions and Collector filters for confirmed noise. State that the removed operation
 > will disappear from APM before giving a configuration.
 Docs: https://signoz.io/docs/traces-management/guides/drop-spans/
+
+**4e. Span attribute and event size — only when bytes-per-span is unusually high.** Run this only
+when Step 1's bytes-per-record check (`span.size ÷ span.count`) flags a service as a payload-size
+problem, not a volume problem. Sample its spans with `signoz_search_traces`, identify which
+attributes or events are driving the size, and report them with their approximate size
+contribution — do not assert they're noise. Ask the user directly whether each large attribute or
+event is operationally necessary before recommending anything; usefulness here is contextual, not
+something to judge unilaterally. The same posture applies to attributes carrying real diagnostic
+content (`db.query.text`, `url.full`, `exception.stacktrace`, correlation IDs like
+`user.id`/`request.id`) — size alone doesn't make them noise. If the user confirms one isn't
+needed, use the `attributes` processor (`action: delete`) for span attributes, or the filter
+processor's `traces.spanevent` OTTL context for span events specifically — the `transform`
+processor cannot target individual events.
 
 ### Step 5: Report what you found
 
@@ -294,6 +341,27 @@ a signal the workflow already analyzed.
   `signoz_list_alert_rules` fully (through `pagination.hasMore`) before ruling out alert impact,
   and treat a non-empty `error` from `signoz_check_metric_usage` as *unknown* usage (needs a
   manual check) — not as "unused." An incomplete lookup is not a green light.
+- **Check every query an alert's condition depends on, not just the one that looks related.**
+  This applies to both log and trace alerts. An alert can combine two or more queries in a
+  formula (e.g., an error rate computed as errors ÷ total calls) or use a single query with no
+  filter at all (e.g., counting any log record to track instance liveness). A volume-reduction
+  recommendation can shift or trip such an alert even when it only touches data that looks
+  unrelated to what the alert is nominally about — dropping non-error spans changes the "total
+  calls" denominator of an error-rate formula just as much as dropping error spans would, and
+  dropping DEBUG logs can undercount instances a replica-count alert expects to see from every
+  record regardless of severity. When reading `condition.compositeQuery` in Step 3c or 4d,
+  identify every query the condition depends on and check whether the proposed change affects
+  any of them, not only the one whose filter matches the category being reduced.
+- **Check dashboards and saved views too, not just alerts, for log and trace reductions.** For
+  metrics, `signoz_check_metric_usage` returns both `dashboards` and `alerts` in a single call.
+  No equivalent tool exists for logs or traces, so perform this check manually before marking any
+  log-severity or trace-operation reduction "Safe to implement": call `signoz_list_dashboards`
+  and `signoz_list_views` (scoped to the affected signal), filter to the ones whose name, tags, or
+  description are plausibly related to the affected service or operation, then
+  `signoz_get_dashboard` / `signoz_get_view` on those candidates and read their queries —
+  including raw PromQL or ClickHouse SQL panels, not just structured builder queries — for any
+  reference to the data being reduced. If one depends on it, mark the finding **Will break
+  dashboards** (or name the saved view) instead of a clean drop.
 - **Volume comes from discovered Cost Meter metrics and their live units:** bytes for span/log
   volume or samples for metric volume. Never cite span/log record counts as volume.
 - **Cost totals and grouped total attribution use `signoz_execute_builder_query`** with raw
@@ -316,11 +384,22 @@ a signal the workflow already analyzed.
   and rates no longer represent all traffic.
 - **UNBOUNDED and IDENTIFIER labels are always worth flagging** — the problem is trajectory, not
   just current count.
-- **Never suggest changing retention. Never estimate dollar savings.** Never call a dashboard or
-  alert unused/noisy/redundant — report counts only.
+- **Never suggest changing retention. Never estimate dollar savings.** Asking the user their
+  currently configured retention (Step 1, to weight cost accurately) is required and does not
+  violate this guardrail — recommending they change it does. Using retention-matched rates to
+  rank signals against each other internally is required — presenting the resulting figure to the
+  user as a dollar estimate or savings number is not. Never call a dashboard or alert
+  unused/noisy/redundant — report counts only.
 - **Anchor claims to query results.** If a signal has no Cost Meter data, say so — do not
   substitute count-based proxies. Don't re-list metrics already shown in the breakdown; metrics
   outside the top ~20 by volume are individually negligible.
+- **Verify configuration specifics before stating them as fact.** An env var, config key, flag, or
+  code snippet for disabling instrumentation, changing a collection interval, or filtering logs is
+  a factual claim about a specific library or the Collector, not something to pattern-match from
+  memory. Before naming one, check it against that library's or the Collector's actual
+  documentation — WebFetch/WebSearch the official docs, changelog, or repo, or read the matching
+  `signoz://` doc resource for SigNoz-side syntax. If it can't be verified, say so explicitly and
+  present it as an unconfirmed guess to check, never as a directive to apply.
 
 ## Additional resources
 

--- a/plugins/signoz/skills/signoz-reducing-telemetry-cost/SKILL.md
+++ b/plugins/signoz/skills/signoz-reducing-telemetry-cost/SKILL.md
@@ -59,25 +59,11 @@ For a rolling 7-day window (`end` = now, `start` = end − 7 days), get the per-
   currently configured retention for each of the three signals before ranking which one costs
   more. This is a factual input needed to weight cost accurately, not a suggestion to change
   retention (that guardrail still applies below). If the user doesn't know, ask them to check
-  their SigNoz plan/retention settings.
-
-  | Traces / logs retention | $/GB |
-  |---|---|
-  | 15 days | 0.3 |
-  | 30 days | 0.4 |
-  | 90 days | 0.6 |
-  | 180 days | 0.8 |
-  | 1 year | 1.4 |
-
-  | Metrics retention | $/M samples |
-  |---|---|
-  | 1 month | 0.1 |
-  | 3 months | 0.12 |
-  | 6 months | 0.15 |
-  | 13 months | 0.18 |
+  their SigNoz plan/retention settings. Rates by tier are in
+  `references/retention-pricing.md`.
 
 - **Primary cost driver.** The signal with the highest *dollar* weight, using each signal's own
-  retention-matched rate from the tables above (orientation only; never quote the resulting
+  retention-matched rate from `references/retention-pricing.md` (orientation only; never quote the resulting
   dollar figure to the user — it's for ranking signals against each other, not a cost estimate).
   This picks by cost, not by raw volume.
 - **Bytes per record.** span.size ÷ span.count and log.size ÷ log.count — tells you whether a
@@ -356,12 +342,18 @@ a signal the workflow already analyzed.
   metrics, `signoz_check_metric_usage` returns both `dashboards` and `alerts` in a single call.
   No equivalent tool exists for logs or traces, so perform this check manually before marking any
   log-severity or trace-operation reduction "Safe to implement": call `signoz_list_dashboards`
-  and `signoz_list_views` (scoped to the affected signal), filter to the ones whose name, tags, or
-  description are plausibly related to the affected service or operation, then
-  `signoz_get_dashboard` / `signoz_get_view` on those candidates and read their queries —
-  including raw PromQL or ClickHouse SQL panels, not just structured builder queries — for any
-  reference to the data being reduced. If one depends on it, mark the finding **Will break
-  dashboards** (or name the saved view) instead of a clean drop.
+  and `signoz_list_views` (scoped to the affected signal), **paginating through every page**
+  (follow `pagination.nextOffset` until `pagination.hasMore` is false — the same rule as the
+  alert-rule check above). Name and tags are not a reliable filter: a dashboard called
+  "Operations Overview" can hold a panel querying the exact service/operation with no mention of
+  either in its metadata. Do not use name/tags/description to narrow which dashboards or views get
+  checked — call `signoz_get_dashboard` / `signoz_get_view` on **every** one returned (across all
+  pages) and read its persisted queries — including raw PromQL or ClickHouse SQL panels, not just
+  structured builder queries — for any reference to the data being reduced. If one depends on it,
+  mark the finding **Will break dashboards** (or name the saved view) instead of a clean drop. If
+  the dashboard/view count is too large to fully inspect in the investigation, do not mark the
+  reduction "Safe to implement" — mark it **Needs one check first** (dashboard/view dependency
+  unconfirmed) rather than reporting a false "Safe."
 - **Volume comes from discovered Cost Meter metrics and their live units:** bytes for span/log
   volume or samples for metric volume. Never cite span/log record counts as volume.
 - **Cost totals and grouped total attribution use `signoz_execute_builder_query`** with raw
@@ -408,5 +400,7 @@ a signal the workflow already analyzed.
 - `references/infra-do-not-drop.md` — the metrics behind the built-in Infrastructure and
   APM/Services pages that must never be recommended for dropping.
 - `references/otel-attribute-cardinality.md` — reference for classifying metric labels
+- `references/retention-pricing.md` — $/GB and $/M-samples rates by retention tier, used to
+  weight cost by signal in Step 1.
   (UNBOUNDED / ACCUMULATING / BOUNDED / IDENTIFIER).
 - `signoz-generating-queries` skill — for the ad-hoc follow-up queries this investigation points to.

--- a/plugins/signoz/skills/signoz-reducing-telemetry-cost/references/retention-pricing.md
+++ b/plugins/signoz/skills/signoz-reducing-telemetry-cost/references/retention-pricing.md
@@ -1,0 +1,22 @@
+# Retention pricing
+
+Used in Step 1 to weight cost by each signal's configured retention. Ask the user for their
+currently configured retention per signal before applying these rates — never assume a tier.
+
+These rates are for orientation only (ranking signals against each other), never quote the
+resulting dollar figure to the user as a cost estimate.
+
+| Traces / logs retention | $/GB |
+|---|---|
+| 15 days | 0.3 |
+| 30 days | 0.4 |
+| 90 days | 0.6 |
+| 180 days | 0.8 |
+| 1 year | 1.4 |
+
+| Metrics retention | $/M samples |
+|---|---|
+| 1 month | 0.1 |
+| 3 months | 0.12 |
+| 6 months | 0.15 |
+| 13 months | 0.18 |


### PR DESCRIPTION
  - Ask for the configured retention period per signal (traces, logs, metrics) and weight the primary-cost-driver ranking using the matching tier's rate instead of a fixed $/GB and $/M-samples figure
  - Clarify the 'never suggest changing retention / never estimate dollar savings' guardrail to distinguish asking about current retention from recommending a change
  - Require verifying any env var, config key, or code snippet against real documentation before stating it as fact
  - Check every query an alert's condition depends on, not just the one that matches the proposed change, before marking a log or trace reduction safe
  - Check dashboards and saved views, not just alerts, for log and trace reductions
  - Add a Step 4 sub-step to investigate span attribute/event size when bytes-per-span is high, asking the user about operational necessity instead of asserting an attribute is noise