### PR TITLE
fix(alerts): support policy-routed notifications

### DIFF
--- a/plugins/signoz/skills/signoz-creating-alerts/SKILL.md
+++ b/plugins/signoz/skills/signoz-creating-alerts/SKILL.md
@@ -263,11 +263,9 @@ dotted attribute name with underscores: `service.name` → `service_name`).
 
 #### Common query shapes — conventions
 
-Read `signoz://alert/examples` for the authoritative JSON of all
-patterns (error rate, p99 latency, log volume, combined threshold + absence,
-anomaly,
-PromQL, ClickHouse SQL). The conventions that don't live in the
-schema:
+Read `signoz://alert/examples` for the authoritative JSON patterns: error rate,
+p99 latency, log volume, combined threshold + absence, anomaly, PromQL, and
+ClickHouse SQL. The conventions that don't live in the schema:
 
 - **Error-rate formula:** set `disabled: true` on the component
   queries A and B so only the formula F1 renders in the alert chart

--- a/plugins/signoz/skills/signoz-creating-alerts/SKILL.md
+++ b/plugins/signoz/skills/signoz-creating-alerts/SKILL.md
@@ -377,11 +377,11 @@ channel does not by itself authorize policy routing.
 - Use it only when the user or trusted task context explicitly confirms that an existing org notification policy should match this rule.
 - Set `notificationSettings.usePolicy: true`. Omit direct references in `condition.thresholds.spec[].channels`, and always omit top-level `preferredChannels`; preserve the confirmed user labels and threshold tier that the policy matches.
 - This skill does not create org policies; they are managed in the SigNoz UI or Terraform. Never imply the alert write created one; if its existence or match is unconfirmed, stop and ask.
-- If the payload includes any channel name, verify every supplied name with fully paginated `signoz_list_notification_channels`; the backend still validates supplied names even though policy routing ignores them for delivery.
+- If the payload includes any channel name, reuse a fully paginated result only from the same still-current prepared operation; otherwise call `signoz_list_notification_channels`, refreshing only if state may have changed. The backend validates supplied names even though policy routing ignores them for delivery.
 
 **Direct routing:**
 
-1. Call `signoz_list_notification_channels` and follow `pagination.nextOffset` while `pagination.hasMore` is true.
+1. Reuse a fully paginated `signoz_list_notification_channels` result only from the same still-current prepared operation; otherwise call it and follow `pagination.nextOffset` while `pagination.hasMore` is true. Refresh only if state may have changed.
 2. If the user named a channel ("send to slack-infra"), use it if it exists; otherwise offer the available choices.
 3. If no existing channel fits, offer to call `signoz_create_notification_channel` with the user-provided name, type, and provider-specific config.
 4. If neither path resolves a channel, stop and ask the user for one (see *Required inputs* above).

--- a/plugins/signoz/skills/signoz-creating-alerts/SKILL.md
+++ b/plugins/signoz/skills/signoz-creating-alerts/SKILL.md
@@ -50,7 +50,7 @@ guesses create noisy alerts on the wrong service:
 | Resource attribute filter (e.g. `service.name`, `k8s.namespace.name`, `host.name`) | yes | discover via `signoz_get_field_keys` + `signoz_get_field_values` |
 | Threshold value(s) | inferred from intent | derive a sensible default and surface in the preview |
 | Severity | inferred from intent | default `warning`; promote to `critical` only if user said "page", "wake up", "critical" |
-| Notification channel | yes | `signoz_list_notification_channels` + offer "create new" |
+| Notification routing | yes | direct: verified channel name(s); policy: confirmation that an existing org policy should route this rule |
 
 If a required input is missing and undiscoverable, **stop before any write**
 and ask through the host's supported clarification UI.
@@ -78,7 +78,7 @@ Extract from the user's request:
 3. **Threshold** — numeric value and comparison ("above 80%", "below 100/s").
 4. **Severity** — implicit from urgency words ("page" → critical, default
    warning otherwise).
-5. **Channel** — explicit channel name if the user provided one.
+5. **Routing** — explicit direct-channel name(s), or an explicit request to use a confirmed existing org notification policy.
 
 Map signal phrasing to alert type:
 
@@ -365,23 +365,24 @@ flow mid-stream), the no-data stop rule applies here too: empty result →
 stop and ask the user (see *Required inputs* above) instead of saving an
 alert that will never fire.
 
-### Step 7: Resolve notification channels
+### Step 7: Resolve notification routing
 
-Resolve at least one channel after dry-run and final severity; otherwise the
-alert saves but never notifies.
+Choose direct or org-policy routing after dry-run and final severity. A missing
+channel does not by itself authorize policy routing.
 
-1. Call `signoz_list_notification_channels` and follow
-   `pagination.nextOffset` while `pagination.hasMore` is true.
-2. If the user named a channel ("send to slack-infra"), use it if it exists;
-   if not, fall through.
-3. Otherwise present the user with two options:
-   - **Pick from existing** — list channels with their type (Slack, PagerDuty,
-     email, webhook) so the user can choose.
-   - **Create new inline** — call `signoz_create_notification_channel` with
-     channel parameters the user provides (name, type, type-specific config
-     like Slack webhook URL or PagerDuty integration key).
-4. If neither path resolves a channel, stop and ask the user for a
-   notification channel (see *Required inputs* above).
+**Org-policy routing (`threshold_rule` / `promql_rule` only):**
+
+- Use it only when the user or trusted task context explicitly confirms that an existing org notification policy should match this rule.
+- Set `notificationSettings.usePolicy: true`. Direct references in `condition.thresholds.spec[].channels` and `preferredChannels` may be omitted; preserve the confirmed user labels and threshold tier that the policy matches.
+- This skill does not create org policies; they are managed in the SigNoz UI or Terraform. Never imply the alert write created one; if its existence or match is unconfirmed, stop and ask.
+- If the payload includes any channel name, verify every supplied name with fully paginated `signoz_list_notification_channels`; the backend still validates supplied names even though policy routing ignores them for delivery.
+
+**Direct routing:**
+
+1. Call `signoz_list_notification_channels` and follow `pagination.nextOffset` while `pagination.hasMore` is true.
+2. If the user named a channel ("send to slack-infra"), use it if it exists; otherwise offer the available choices.
+3. If no existing channel fits, offer to call `signoz_create_notification_channel` with the user-provided name, type, and provider-specific config.
+4. If neither path resolves a channel, stop and ask the user for one (see *Required inputs* above).
 
 Channel creation is admin-gated. On `PERMISSION_DENIED`, have an admin create it
 out of band or configure a dedicated, short-lived minimum-role credential via
@@ -438,7 +439,7 @@ does).
 
 > **Summary**: This alert fires when [condition] for [resource scope],
 > evaluated every [frequency] over the last [window]. Thresholds:
-> warning at X, critical at Y. Notifications go to [channels]. Dry-run on
+> warning at X, critical at Y. Notifications route through [direct channels / confirmed org policy]. Dry-run on
 > the last hour: would have fired N times.
 
 ### Step 9: Save and report
@@ -452,13 +453,13 @@ does).
 3. On success, report:
    - The alert ID and name.
    - What it watches and at what threshold.
-   - Which channels are wired up.
+   - How notifications route (direct channels or the confirmed org policy).
    - The dry-run summary ("would have fired N times in last 1h").
 
 ## Guardrails
 
-- **Strict inputs over guessing** Resource attribute and channel are required;
-  if missing, stop and ask rather than guessing a service.
+- **Strict inputs over guessing** Resource attribute and notification routing are
+  required. Direct routing needs a channel; policy routing needs confirmation of an existing matching policy.
 - **Always paginate `signoz_list_alert_rules`** Stopping at page 1 misses
   duplicates and produces noise.
 - **Dry-run is mandatory** Complete Steps 4 and 6 before
@@ -471,10 +472,9 @@ does).
   `LOGS_BASED_ALERT`. Mismatches fail validation.
 - **Anomaly rules are metrics-only** `anomaly_rule` + non-metric alertType
   is rejected.
-- **Channels must exist and use the rule's routing field.** Use exact names
-  from `signoz_list_notification_channels`; put them in per-threshold
-  `channels` for threshold/PromQL rules, or top-level `preferredChannels` for
-  anomaly and absent-only threshold/PromQL rules without thresholds.
+- **Routing must match the selected mode.** Direct routes use exact names from `signoz_list_notification_channels`
+  in per-threshold `channels`, or `preferredChannels` for anomaly and absent-only rules. Confirmed policy routes set
+  `notificationSettings.usePolicy: true` and may omit direct channels; verify every name supplied in either mode.
 - **Never echo channel secrets.** Slack webhook URLs, PagerDuty integration
   keys, and similar webhook tokens are secrets. Pass them to
   `signoz_create_notification_channel` once and never repeat the

--- a/plugins/signoz/skills/signoz-creating-alerts/SKILL.md
+++ b/plugins/signoz/skills/signoz-creating-alerts/SKILL.md
@@ -48,7 +48,7 @@ guesses create noisy alerts on the wrong service:
 |---|---|---|
 | Alert intent (NL goal) | yes | `$ARGUMENTS` or recent user turn |
 | Resource attribute filter (e.g. `service.name`, `k8s.namespace.name`, `host.name`) | yes | discover via `signoz_get_field_keys` + `signoz_get_field_values` |
-| Threshold value(s) | inferred from intent | derive a sensible default and surface in the preview |
+| Threshold value(s) | threshold / PromQL rules | derive a sensible default and surface in the preview; never substitute one for an absent-only request |
 | Severity | inferred from intent | default `warning`; promote to `critical` only if user said "page", "wake up", "critical" |
 | Notification routing | yes | direct: verified channel name(s); policy: confirmation that an existing org policy should route this rule |
 
@@ -173,9 +173,6 @@ result and ask the user to confirm before save. Treat this exception
 narrowly: it applies to "alert me when bad thing happens" log queries,
 not to alerts that depend on continuous data flow.
 
-This cheap probe catches no-data before the user reviews an alert that cannot
-fire.
-
 ### Step 5: Build the alert config
 
 The MCP server is the source of truth for the alert JSON schema, threshold
@@ -183,9 +180,15 @@ codes, and validation rules. Read the `signoz://alert/instructions` and
 `signoz://alert/examples` MCP resources for the canonical, version-current
 shape.
 
-Threshold/PromQL `condition.thresholds` requires `kind` (use `"basic"`) and
-non-empty `spec[]`, except when `alertOnAbsent` is the sole trigger. Anomaly
-rules omit it.
+Threshold/PromQL `condition.thresholds` requires `kind` (use `"basic"`) and a
+non-empty `spec[]`. Anomaly rules omit it.
+
+**Exact absent-only requests.** Current v2 cannot represent `alertOnAbsent` as
+the sole trigger: threshold/PromQL rules still require `condition.thresholds`.
+Stop before `signoz_create_alert`, explain that the exact alert is unavailable,
+and offer a combined threshold + absence rule only with explicit approval of
+its changed semantics; never select a threshold or substitute semantics
+silently.
 
 For most user intents, the config is one of a small number of patterns:
 
@@ -196,7 +199,7 @@ For most user intents, the config is one of a small number of patterns:
 | Trace-based count or p-tile | "p99 span duration > 2s on checkout" |
 | Error-rate formula (A/B*100) — see "Common query shapes" below | "error rate > 5%" |
 | Anomaly detection (Z-score) | "alert me on anomalous traffic" |
-| Absent-data alert | "alert if data stops arriving" |
+| Combined threshold + absence (only after approval) | "alert if data stops arriving" |
 | ClickHouse SQL alert — author SQL using the schema in `signoz://alert/examples` | non-trivial joins, custom aggregations the builder cannot express |
 | PromQL alert — delegate to `signoz-generating-queries` for the query, then return here | when user already has PromQL |
 
@@ -261,7 +264,8 @@ dotted attribute name with underscores: `service.name` → `service_name`).
 #### Common query shapes — conventions
 
 Read `signoz://alert/examples` for the authoritative JSON of all
-patterns (error rate, p99 latency, log volume, absent-data, anomaly,
+patterns (error rate, p99 latency, log volume, combined threshold + absence,
+anomaly,
 PromQL, ClickHouse SQL). The conventions that don't live in the
 schema:
 
@@ -370,10 +374,10 @@ alert that will never fire.
 Choose direct or org-policy routing after dry-run and final severity. A missing
 channel does not by itself authorize policy routing.
 
-**Org-policy routing (`threshold_rule` / `promql_rule` only):**
+**Org-policy routing (`threshold_rule` / `promql_rule` only; `anomaly_rule` is direct-only):**
 
 - Use it only when the user or trusted task context explicitly confirms that an existing org notification policy should match this rule.
-- Set `notificationSettings.usePolicy: true`. Direct references in `condition.thresholds.spec[].channels` and `preferredChannels` may be omitted; preserve the confirmed user labels and threshold tier that the policy matches.
+- Set `notificationSettings.usePolicy: true`. Omit direct references in `condition.thresholds.spec[].channels`, and always omit top-level `preferredChannels`; preserve the confirmed user labels and threshold tier that the policy matches.
 - This skill does not create org policies; they are managed in the SigNoz UI or Terraform. Never imply the alert write created one; if its existence or match is unconfirmed, stop and ask.
 - If the payload includes any channel name, verify every supplied name with fully paginated `signoz_list_notification_channels`; the backend still validates supplied names even though policy routing ignores them for delivery.
 
@@ -393,14 +397,11 @@ Place the resolved channel according to the rule schema:
 
 - `threshold_rule` / `promql_rule` (v2alpha1): attach direct-routing channels
   to each `condition.thresholds.spec[N].channels` array — typically warning →
-  Slack only, critical → Slack + PagerDuty. When `alertOnAbsent` is the sole
-  trigger and thresholds are omitted, put fallback channels in top-level
-  `preferredChannels`.
-- `anomaly_rule` (v1): thresholds are forbidden, so put channel names in the
-  top-level `preferredChannels` array.
+  Slack only, critical → Slack + PagerDuty.
+- `anomaly_rule` (v1): direct routing only; thresholds are forbidden, so put channel names in top-level `preferredChannels`.
 
-Never put a chosen anomaly or absent-only channel in a nonexistent thresholds
-block, or substitute `preferredChannels` for per-tier multi-severity routing.
+Never put a chosen anomaly channel in a nonexistent thresholds block, or
+substitute `preferredChannels` for per-tier multi-severity routing.
 
 #### Handling secret-bearing channel config
 
@@ -472,8 +473,8 @@ does).
   `LOGS_BASED_ALERT`. Mismatches fail validation.
 - **Anomaly rules are metrics-only** `anomaly_rule` + non-metric alertType
   is rejected.
-- **Routing must match the selected mode.** Direct routes use exact names from `signoz_list_notification_channels`
-  in per-threshold `channels`, or `preferredChannels` for anomaly and absent-only rules. Confirmed policy routes set
+- **Routing must match the selected mode.** Direct threshold/PromQL routes use exact names from `signoz_list_notification_channels`
+  in per-threshold `channels`; direct anomaly routes use `preferredChannels`. Confirmed policy routes (threshold/PromQL only) set
   `notificationSettings.usePolicy: true` and may omit direct channels; verify every name supplied in either mode.
 - **Never echo channel secrets.** Slack webhook URLs, PagerDuty integration
   keys, and similar webhook tokens are secrets. Pass them to

--- a/plugins/signoz/skills/signoz-creating-alerts/evals/evals.json
+++ b/plugins/signoz/skills/signoz-creating-alerts/evals/evals.json
@@ -81,6 +81,19 @@
         "The signoz_create_alert payload puts #staging-alerts in top-level preferredChannels"
       ],
       "files": []
+    },
+    {
+      "id": 6,
+      "eval_name": "confirmed-org-policy-routing-without-direct-channels",
+      "prompt": "Create a critical alert when checkoutservice error rate exceeds 5%. Route it through our existing org notification policy — it is already configured to match critical alerts for team=checkout. Do not attach direct channels.",
+      "expected_output": "After the normal duplicate check, data probe, and full-query dry-run, creates a TRACES_BASED_ALERT whose notificationSettings.usePolicy is true and whose confirmed labels allow the existing org policy to match. It omits threshold channels and preferredChannels, does not block on choosing a direct notification channel, and says that the policy was already confirmed rather than claiming this skill created it.",
+      "expectations": [
+        "The signoz_create_alert payload sets notificationSettings.usePolicy=true",
+        "The policy-routed create payload omits condition.thresholds.spec[].channels and top-level preferredChannels without asking the user to choose a direct channel",
+        "The alert carries labels.team=checkout and labels.severity=critical and names the threshold critical so the confirmed policy match inputs are preserved; it does not invent different matcher labels",
+        "The response does not call signoz_create_notification_channel or claim that the alert write created the org notification policy"
+      ],
+      "files": []
     }
   ]
 }

--- a/plugins/signoz/skills/signoz-creating-alerts/evals/evals.json
+++ b/plugins/signoz/skills/signoz-creating-alerts/evals/evals.json
@@ -9,6 +9,7 @@
       "expectations": [
         "The data probe calls signoz_query_metrics with a concrete metricName and the cartservice filter; it never sends count() or count_distinct(service.name) as a metrics aggregation expression",
         "Every signoz_execute_builder_query dry-run carries start and end as JSON integer Unix-millisecond values in the outer query",
+        "Before direct-routing creation, the agent reuses a fully paginated signoz_list_notification_channels result only from the same still-current prepared operation or calls it until pagination.hasMore=false; if a requested name is unavailable, it presents exact returned choices and asks the user instead of guessing",
         "The signoz_create_alert payload puts Slack in the warning threshold channels and PagerDuty in the critical threshold channels",
         "The threshold-rule create payload does not rely on top-level preferredChannels for its per-severity routing",
         "Every metric builder_query in the dry-run and create payload has limit=100 plus Query Builder v5 order by __result desc"

--- a/plugins/signoz/skills/signoz-creating-alerts/evals/evals.json
+++ b/plugins/signoz/skills/signoz-creating-alerts/evals/evals.json
@@ -70,15 +70,14 @@
     },
     {
       "id": 5,
-      "eval_name": "absent-data-sole-trigger-omits-thresholds",
+      "eval_name": "absent-data-sole-trigger-stops-before-write",
       "prompt": "Create an alert for checkoutservice that fires only when its request metric stops arriving. Notify #staging-alerts.",
-      "expected_output": "Agent discovers and probes a concrete checkoutservice request metric, builds a threshold/PromQL-family absent-data rule whose sole trigger is alertOnAbsent, validates the full query with absolute integer Unix-ms bounds, and creates the alert without condition.thresholds. It routes #staging-alerts through top-level preferredChannels rather than inventing an empty thresholds block or numeric threshold.",
+      "expected_output": "Agent explains that the current v2 threshold/PromQL contract requires condition.thresholds, so it cannot create the requested exact absent-only alert whose sole trigger is alertOnAbsent. It stops before any write, does not invent an empty threshold spec or silently change the request, and offers a combined threshold + absence rule only if the user explicitly approves the changed semantics.",
       "expectations": [
-        "Agent discovers a concrete metric and verifies the checkoutservice filter before authoring the alert",
-        "The full signoz_execute_builder_query dry-run has start and end as JSON integer Unix-millisecond values in the outer query",
-        "The signoz_create_alert payload enables alertOnAbsent as the sole trigger",
-        "The signoz_create_alert payload omits condition.thresholds entirely rather than sending an empty or fabricated threshold spec",
-        "The signoz_create_alert payload puts #staging-alerts in top-level preferredChannels"
+        "The agent stops before signoz_create_alert and does not create a notification channel or any alert",
+        "The response says an exact absent-only rule is unavailable because current v2 threshold/PromQL rules require condition.thresholds",
+        "The agent does not send alertOnAbsent as a sole trigger, omit condition.thresholds, or fabricate an empty threshold spec",
+        "The agent does not silently choose a numeric threshold or create a combined threshold + absence rule; it asks for explicit approval of the changed semantics before creating one"
       ],
       "files": []
     },
@@ -92,6 +91,19 @@
         "The policy-routed create payload omits condition.thresholds.spec[].channels and top-level preferredChannels without asking the user to choose a direct channel",
         "The alert carries labels.team=checkout and labels.severity=critical and names the threshold critical so the confirmed policy match inputs are preserved; it does not invent different matcher labels",
         "The response does not call signoz_create_notification_channel or claim that the alert write created the org notification policy"
+      ],
+      "files": []
+    },
+    {
+      "id": 7,
+      "eval_name": "unconfirmed-org-policy-routing-stops-for-clarification",
+      "prompt": "Create a critical alert when checkoutservice error rate exceeds 5%. Route it through an org notification policy if one applies.",
+      "expected_output": "Agent stops for routing clarification because no specific existing matching policy or match criteria are confirmed. It asks the user to confirm that an existing org policy should match this threshold/PromQL rule (including the relevant labels or tier), and it does not treat the missing direct channel as permission to use policy routing.",
+      "expectations": [
+        "The agent does not set notificationSettings.usePolicy=true or imply that policy routing is confirmed",
+        "The agent does not call signoz_create_notification_channel, signoz_create_alert, or otherwise create a channel or alert before clarification",
+        "The clarification asks for confirmation of an existing matching org policy and its relevant matcher labels or threshold tier",
+        "The agent does not silently fall back to a direct channel or invent policy-match labels"
       ],
       "files": []
     }

--- a/plugins/signoz/skills/signoz-creating-alerts/references/examples.md
+++ b/plugins/signoz/skills/signoz-creating-alerts/references/examples.md
@@ -13,8 +13,10 @@ log-volume groupBy, and anomaly detection.
    on the higher level because "page me" was used.
 2. `signoz_list_metrics searchText=cpu` → confirms `system.cpu.utilization`.
 3. `signoz_list_alert_rules` (paginated) → no existing CPU alert for checkout.
-4. `signoz_list_notification_channels` → presents existing channels;
-   user picks `slack-infra` for warning and `pagerduty-oncall` for critical.
+4. Reuses a fully paginated same-operation `signoz_list_notification_channels`
+   result, or calls it through `pagination.hasMore=false`; the user picks
+   `slack-infra` and `pagerduty-oncall`. If none fits, it offers
+   `signoz_create_notification_channel` with user-provided provider config.
 5. Builds JSON: `METRIC_BASED_ALERT`, `threshold_rule`,
    `signal=metrics`, two thresholds (`op="above"`,
    `matchType="on_average"`, `targetUnit="percent"`), filter
@@ -40,7 +42,10 @@ log-volume groupBy, and anomaly detection.
    service, formula F1 = `A * 100 / B`, `selectedQueryName: "F1"`,
    threshold target 5, `targetUnit: "percent"`,
    `op: "above"`, `matchType: "at_least_once"` (catch any breach).
-5. Channel: user picks `slack-payments`.
+5. No channel was named, so it reuses a fully paginated same-operation
+   `signoz_list_notification_channels` result, or calls it through
+   `pagination.hasMore=false`; the user picks `slack-payments`. If none fits,
+   it offers `signoz_create_notification_channel` with user-provided config.
 6. Dry-run on last 1h: payments error rate hovered around 0.3%, would have
    fired 0 times. Clean — not too tight.
 7. Preview, save, report.
@@ -61,7 +66,10 @@ log-volume groupBy, and anomaly detection.
    `groupBy: [{name: "service.name", fieldContext: "resource", fieldDataType: "string"}]`,
    threshold 1000, `targetUnit: ""`, `evalWindow: 1m0s`,
    `matchType: "at_least_once"` (catch any minute that breaches).
-4. Channels: user picks slack channel.
+4. No channel was named, so it reuses a fully paginated same-operation
+   `signoz_list_notification_channels` result, or calls it through
+   `pagination.hasMore=false`; the user picks a Slack channel. If none fits,
+   it offers `signoz_create_notification_channel` with user-provided config.
 5. Dry-run: returned per-service counts, max in last 1h was 87 — would
    have fired 0 times. Within reasonable headroom.
 6. Preview, save, report.
@@ -79,7 +87,10 @@ log-volume groupBy, and anomaly detection.
 3. Builds: `anomaly_rule`, `algorithm=standard` (z-score based), `seasonality=daily`,
    threshold target 3 (3 standard deviations), `op: "above"`,
    `matchType: "at_least_once"`.
-4. Channel: user picks slack-api.
+4. No channel was named, so it reuses a fully paginated same-operation
+   `signoz_list_notification_channels` result, or calls it through
+   `pagination.hasMore=false`; the user picks `slack-api`. If none fits, it
+   offers `signoz_create_notification_channel` with user-provided config.
 5. Dry-run validates query returns data. Skip breach-count for
    anomaly alerts.
 6. Preview emphasizes that the threshold is in standard deviations, not raw


### PR DESCRIPTION
## Summary

- teach `signoz-creating-alerts` that org-policy routing is limited to v2 threshold/PromQL rules
- require direct v2 channels on every threshold tier and keep v1 anomaly routing on top-level `preferredChannels`
- stop before writing an exact absent-only v2 request because current v2 rules still require thresholds
- require explicit confirmation before using an existing org policy
- reuse a fully paginated channel-list result only from the same still-current prepared operation; otherwise list and refresh only when state may have changed
- make every canonical direct-routing example explicitly use `signoz_list_notification_channels`, offer exact returned choices, and offer `signoz_create_notification_channel` only with user-provided configuration
- pin channel discovery, full pagination, and unavailable-name behavior in the canonical direct-routing eval
- add focused eval coverage for absent-only rejection and confirmed/unconfirmed policy routing

## Why

The skill previously required a direct channel for valid policy-routed alerts and taught an absent-only payload shape that current SigNoz rejects. It also needed explicit negative guidance so conditional policy intent cannot silently authorize a write, and precise channel-list reuse guidance so completed preflights are not repeated or reused after becoming stale. Supporting examples must name the discovery tool rather than merely saying the user picks a channel.

Part of SigNoz/nerve-pod#160. This does not close the umbrella issue.

## Validation

- `claude plugin validate --strict plugins/signoz`
- eval JSON structure and unique-ID validation
- focused static assertion for `signoz_list_notification_channels`, `pagination.hasMore=false`, unavailable-name choices, and no guessing
- canonical examples contain no remaining shorthand `Channel(s): user picks` guidance
- skill length guard: under 500 lines; reference remains under the 100-line table-of-contents threshold
- `git diff --check`
- independent multi-agent guidance/efficiency/reuse sweep completed; all valid findings fixed

## Companion

- SigNoz/signoz-mcp-server#264 carries the runtime validation, metadata, docs, recovery guidance, regression changes, and live E2E evidence.
