### PR TITLE
feat: add experimental Agent Plugins v1 package

### DIFF
--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -39,6 +39,7 @@ jobs:
             ':(glob)plugins/*/.claude-plugin/plugin.json' \
             ':(glob)plugins/*/.codex-plugin/plugin.json' \
             ':(glob)plugins/*/.cursor-plugin/plugin.json' \
+            ':(glob)plugins/*/plugin.json' \
             'gemini-extension.json' \
             '.devin-plugin/plugin.json')
           if [[ -z "$BASE_SHA" ]]; then
@@ -49,8 +50,10 @@ jobs:
             'plugins/' \
             'gemini-extension.json' \
             '.devin-plugin/' \
+            'LICENSE' \
             'plugin.json' \
             'mcp_config.json' \
+            'scripts/package_agent_plugin.py' \
             'skills')
 
           if [[ -z "$CHANGED" ]]; then
@@ -63,14 +66,25 @@ jobs:
           # such as plugins/README.md are repository metadata, not plugins.
           PLUGIN_DIRS=$(echo "$CHANGED" | awk -F/ '$1 == "plugins" && NF >= 3 {print $1 "/" $2}' | sort -u)
 
-          # The root Gemini, Devin, and Antigravity files are ports of the
-          # signoz plugin, so a root-only port change also bumps signoz.
-          if echo "$CHANGED" | grep -qE '^(gemini-extension\.json|\.devin-plugin/.*|plugin\.json|mcp_config\.json|skills)$'; then
+          # Root compatibility surfaces and portable package inputs belong to
+          # the signoz plugin, so their changes also bump signoz.
+          if echo "$CHANGED" | grep -qE '^(gemini-extension\.json|\.devin-plugin/.*|LICENSE|plugin\.json|mcp_config\.json|scripts/package_agent_plugin\.py|skills)$'; then
             PLUGIN_DIRS=$(printf '%s\n%s\n' "$PLUGIN_DIRS" 'plugins/signoz' | sort -u)
           fi
 
           TODAY=$(date -u +%Y.%m.%d)
           COUNT=0
+
+          set_json_version() {
+            local MANIFEST="$1"
+            local VERSION="$2"
+            local TEMP_FILE="${MANIFEST}.tmp"
+            if ! jq --arg version "$VERSION" '.version = $version' "$MANIFEST" > "$TEMP_FILE"; then
+              rm -f "$TEMP_FILE"
+              return 1
+            fi
+            mv "$TEMP_FILE" "$MANIFEST"
+          }
 
           for PLUGIN_DIR in $PLUGIN_DIRS; do
             if [[ ! -d "$PLUGIN_DIR" ]]; then
@@ -78,18 +92,12 @@ jobs:
               continue
             fi
 
-            # Read current version from the primary manifest
-            CLAUDE_JSON="$PLUGIN_DIR/.claude-plugin/plugin.json"
-            if [[ ! -f "$CLAUDE_JSON" ]]; then
-              echo "ERROR: Required plugin manifest is missing: $CLAUDE_JSON"
-              exit 1
-            fi
+            PLUGIN_NAME=$(basename "$PLUGIN_DIR")
 
-            CURRENT=$(jq -r '.version // empty' "$CLAUDE_JSON")
-            if [[ -z "$CURRENT" ]]; then
-              echo "ERROR: No version field in $CLAUDE_JSON"
-              exit 1
-            fi
+            # Use the same parity contract as pull-request validation before
+            # calculating or writing the next version.
+            python3 scripts/check_plugin_versions.py check "$PLUGIN_DIR"
+            CURRENT=$(jq -r '.version' "$PLUGIN_DIR/.claude-plugin/plugin.json")
 
             # CalVer bump logic
             if [[ "$CURRENT" == "$TODAY" ]]; then
@@ -110,25 +118,19 @@ jobs:
               continue
             fi
 
-            # Every logical plugin must ship all three versioned manifests.
-            # Fail instead of silently leaving one client on a stale version.
+            PORTABLE_JSON="$PLUGIN_DIR/plugin.json"
+            SEMVER_VERSION=$(python3 scripts/check_plugin_versions.py encode "$NEW")
+
             for MANIFEST in \
               "$PLUGIN_DIR/.claude-plugin/plugin.json" \
               "$PLUGIN_DIR/.codex-plugin/plugin.json" \
               "$PLUGIN_DIR/.cursor-plugin/plugin.json"; do
-              if [[ ! -f "$MANIFEST" ]]; then
-                echo "ERROR: Required plugin manifest is missing: $MANIFEST"
-                exit 1
-              fi
-              if ! jq --arg v "$NEW" '.version = $v' "$MANIFEST" > "${MANIFEST}.tmp"; then
-                echo "ERROR: jq failed on $MANIFEST"
-                rm -f "${MANIFEST}.tmp"
-                exit 1
-              fi
-              mv "${MANIFEST}.tmp" "$MANIFEST"
+              set_json_version "$MANIFEST" "$NEW"
             done
 
-            PLUGIN_NAME=$(basename "$PLUGIN_DIR")
+            set_json_version "$PORTABLE_JSON" "$SEMVER_VERSION"
+            echo "Bumped $PORTABLE_JSON -> $SEMVER_VERSION"
+
             COUNT=$((COUNT + 1))
             echo "Bumped $PLUGIN_NAME: $CURRENT -> $NEW"
 
@@ -136,50 +138,13 @@ jobs:
             # manifest mirror the signoz plugin, so keep their versions in
             # lockstep with the same bump.
             if [[ "$PLUGIN_NAME" == "signoz" ]]; then
-              if [[ ! -f "gemini-extension.json" ]]; then
-                echo "ERROR: Required Gemini manifest is missing: gemini-extension.json"
-                exit 1
-              fi
-              if ! jq --arg v "$NEW" '.version = $v' "gemini-extension.json" > "gemini-extension.json.tmp"; then
-                echo "ERROR: jq failed on gemini-extension.json"
-                rm -f "gemini-extension.json.tmp"
-                exit 1
-              fi
-              mv "gemini-extension.json.tmp" "gemini-extension.json"
+              set_json_version "gemini-extension.json" "$NEW"
               echo "Bumped gemini-extension.json -> $NEW (lockstep with signoz)"
 
-              if [[ ! -f ".devin-plugin/plugin.json" ]]; then
-                echo "ERROR: Required Devin manifest is missing: .devin-plugin/plugin.json"
-                exit 1
-              fi
-              # Devin's plugin loader enforces strict semver, which forbids
-              # leading zeros in numeric identifiers — CalVer's MM/DD segments
-              # have one whenever the month or day is under 10 (base-10 forced
-              # via `10#` so bash doesn't misread "08"/"09" as invalid octal).
-              # Fold the day and any same-day micro suffix into the patch
-              # number itself (day*100 + micro) rather than build metadata:
-              # semver explicitly excludes build metadata (+x) from precedence
-              # comparisons, so a same-day micro bump encoded that way would
-              # compare equal to the base version and a strict-semver update
-              # path could skip it. Encoding it in patch keeps same-day bumps
-              # strictly increasing, e.g.:
-              #   2026.07.02   -> 2026.7.200
-              #   2026.07.02.1 -> 2026.7.201
-              #   2026.07.02.2 -> 2026.7.202
-              IFS='.' read -ra VER_PARTS <<< "$NEW"
-              DEVIN_DAY=$((10#${VER_PARTS[2]}))
-              DEVIN_MICRO="${VER_PARTS[3]:-0}"
-              DEVIN_MICRO=$((10#$DEVIN_MICRO))
-              DEVIN_PATCH=$((DEVIN_DAY * 100 + DEVIN_MICRO))
-              DEVIN_VERSION="${VER_PARTS[0]}.$((10#${VER_PARTS[1]})).${DEVIN_PATCH}"
-
-              if ! jq --arg v "$DEVIN_VERSION" '.version = $v' ".devin-plugin/plugin.json" > ".devin-plugin/plugin.json.tmp"; then
-                echo "ERROR: jq failed on .devin-plugin/plugin.json"
-                rm -f ".devin-plugin/plugin.json.tmp"
-                exit 1
-              fi
-              mv ".devin-plugin/plugin.json.tmp" ".devin-plugin/plugin.json"
-              echo "Bumped .devin-plugin/plugin.json -> $DEVIN_VERSION (semver form of $NEW, lockstep with signoz)"
+              # Devin also enforces strict SemVer, so reuse the portable
+              # manifest's monotonic SemVer encoding.
+              set_json_version ".devin-plugin/plugin.json" "$SEMVER_VERSION"
+              echo "Bumped .devin-plugin/plugin.json -> $SEMVER_VERSION (semver form of $NEW, lockstep with signoz)"
             fi
           done
 
@@ -204,7 +169,7 @@ jobs:
 
           # The branch is automation-owned and is regenerated from current main.
           git switch -C "$BUMP_BRANCH"
-          git add plugins/**/.claude-plugin/plugin.json plugins/**/.codex-plugin/plugin.json plugins/**/.cursor-plugin/plugin.json gemini-extension.json .devin-plugin/plugin.json
+          git add plugins/**/.claude-plugin/plugin.json plugins/**/.codex-plugin/plugin.json plugins/**/.cursor-plugin/plugin.json plugins/**/plugin.json gemini-extension.json .devin-plugin/plugin.json
           PR_TITLE="chore: auto-bump CalVer for $BUMP_COUNT plugin(s)"
           git commit -m "$PR_TITLE"
           git push --force-with-lease --set-upstream origin "$BUMP_BRANCH"

--- a/.github/workflows/validate-agent-plugin.yml
+++ b/.github/workflows/validate-agent-plugin.yml
@@ -65,6 +65,35 @@ jobs:
             skills-ref validate "${SKILL_MD%/SKILL.md}"
           done
 
+          frontmatter_hint() {
+            local FILE="$1"
+            local INDENT="$2"
+            awk -v prefix="${INDENT}argument-hint:" '
+              NR == 1 { next }
+              $0 == "---" { exit }
+              index($0, prefix) == 1 {
+                value = substr($0, length(prefix) + 1)
+                sub(/^[[:space:]]*/, "", value)
+                print value
+                exit
+              }
+            ' "$FILE"
+          }
+
+          for SOURCE_SKILL_MD in plugins/signoz/skills/*/SKILL.md; do
+            HINT=$(frontmatter_hint "$SOURCE_SKILL_MD" "")
+            if [[ -z "$HINT" ]]; then
+              continue
+            fi
+            SKILL_NAME=$(basename "$(dirname "$SOURCE_SKILL_MD")")
+            PACKAGED_SKILL_MD="$RUNNER_TEMP/signoz/skills/$SKILL_NAME/SKILL.md"
+            PACKAGED_HINT=$(frontmatter_hint "$PACKAGED_SKILL_MD" "  ")
+            if [[ "$PACKAGED_HINT" != "$HINT" ]]; then
+              echo "Portable argument-hint mismatch: $SKILL_NAME"
+              exit 1
+            fi
+          done
+
       - name: Check portable package boundary
         run: |
           EXPECTED=$'LICENSE\nmcp.json\nplugin.json\nskills'
@@ -72,5 +101,14 @@ jobs:
           if [[ "$ACTUAL" != "$EXPECTED" ]]; then
             echo "Unexpected portable package entries:"
             echo "$ACTUAL"
+            exit 1
+          fi
+
+          INTERNAL_DIRS=$(find "$RUNNER_TEMP/signoz/skills" \
+            -mindepth 2 -maxdepth 2 -type d \
+            \( -name evals -o -name tests \) -print)
+          if [[ -n "$INTERNAL_DIRS" ]]; then
+            echo "Internal test directories leaked into the portable package:"
+            echo "$INTERNAL_DIRS"
             exit 1
           fi

--- a/.github/workflows/validate-agent-plugin.yml
+++ b/.github/workflows/validate-agent-plugin.yml
@@ -1,0 +1,75 @@
+name: Validate Agent Plugin
+
+on:
+  pull_request:
+    paths:
+      - 'plugins/signoz/.claude-plugin/plugin.json'
+      - 'plugins/signoz/.codex-plugin/plugin.json'
+      - 'plugins/signoz/.cursor-plugin/plugin.json'
+      - 'plugins/signoz/plugin.json'
+      - 'plugins/signoz/mcp.json'
+      - 'plugins/signoz/skills/**'
+      - 'gemini-extension.json'
+      - '.devin-plugin/plugin.json'
+      - 'LICENSE'
+      - 'scripts/check_plugin_versions.py'
+      - 'scripts/package_agent_plugin.py'
+      - '.github/workflows/validate-agent-plugin.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: validate-agent-plugin-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Check plugin version parity
+        run: python3 scripts/check_plugin_versions.py check plugins/signoz
+
+      - name: Build clean portable package
+        run: python3 scripts/package_agent_plugin.py "$RUNNER_TEMP/signoz"
+
+      - name: Install validators
+        run: |
+          python3 -m pip install \
+            'check-jsonschema==0.37.4' \
+            'git+https://github.com/agentskills/agentskills.git@217be548739f21d6008915c29aefe320ea1a90af#subdirectory=skills-ref'
+
+      - name: Validate Agent Plugins schemas
+        run: |
+          check-jsonschema \
+            --schemafile https://agent-plugins.org/schemas/1.0.0/plugin.schema.json \
+            "$RUNNER_TEMP/signoz/plugin.json"
+          check-jsonschema \
+            --schemafile https://agent-plugins.org/schemas/1.0.0/mcp.schema.json \
+            "$RUNNER_TEMP/signoz/mcp.json"
+
+      - name: Validate portable Agent Skills
+        run: |
+          for SKILL_MD in "$RUNNER_TEMP"/signoz/skills/*/SKILL.md; do
+            skills-ref validate "${SKILL_MD%/SKILL.md}"
+          done
+
+      - name: Check portable package boundary
+        run: |
+          EXPECTED=$'LICENSE\nmcp.json\nplugin.json\nskills'
+          ACTUAL=$(find "$RUNNER_TEMP/signoz" -mindepth 1 -maxdepth 1 -printf '%f\n' | sort)
+          if [[ "$ACTUAL" != "$EXPECTED" ]]; then
+            echo "Unexpected portable package entries:"
+            echo "$ACTUAL"
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 __pycache__/
 *.pyc
 .claude
+dist/
 
 # Skill eval workspaces and local eval prompts (skill-creator output)
 plugins/*/skills/*-workspace/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,13 +26,14 @@ npx skills add https://github.com/anthropics/skills --skill skill-creator
 
 - **Skill naming.** Domain action skills use gerund form prefixed with `signoz-`, lowercase with hyphens — e.g. `signoz-creating-alerts`, `signoz-modifying-dashboards`, `signoz-investigating-alerts`. Setup/maintenance skills may use precise object-action names such as `signoz-mcp-setup`; avoid broad command names like `signoz-setup`. Both Anthropic's best-practices doc and the SigNoz Skills/MCP spec recommend gerund form for action skills. The `name` in SKILL.md frontmatter must exactly match the directory name.
 - **Descriptions.** Imperative, pushy, and third-person. State both what the skill does and when to trigger it, with explicit user-phrase examples and an "even if they don't say X explicitly" clause. Aim well under the 1024-char limit.
+- **Portable frontmatter.** Compatibility-source skills may use documented client extensions such as Claude Code's top-level `argument-hint`. `scripts/package_agent_plugin.py` preserves the value while moving it under `metadata` in the generated portable artifact. All other portable frontmatter must use fields defined by the Agent Skills specification.
 - **"Do NOT use" lists.** Only mention sibling skills that are genuinely similar or competing — i.e. ones a user could plausibly invoke instead. Don't enumerate every other skill in the plugin; rotting cross-references erode trust faster than any clarity they add.
 - **MCP tool references.** Use the bare tool name (e.g. `` `signoz_get_alert` ``) in skill bodies. Every SigNoz tool is `signoz_`-prefixed, so the names are self-namespacing and resolve unambiguously even when other MCP servers are loaded. Bare names also stay correct regardless of the registration key — the Claude Code plugin keys the server `mcp`, so a `signoz:` qualifier no longer matches the live `mcp__plugin_signoz_mcp__*` namespace.
 - **MCP vs skill split.** MCP is the API; skills are the playbook. Tool definitions, input schemas, schema validation, searchable corpora, live tenant data, and release-sensitive reference data belong in MCP tools/resources. Workflows, conventions, decision rules, interpretation hints, pitfalls, and curated examples belong in skills.
 - **Schema reference.** The MCP server is the source of truth for tool input schemas, alert/dashboard JSON shape, and validation rules. Read the `signoz://*` resources rather than transcribing schema into a skill — duplicated schema rots out of sync.
 - **Reference files.** Move material >300 lines into `references/`, `scripts/`, or `assets/`. Any reference file longer than 100 lines must start with a `## Contents` table-of-contents.
 - **SKILL.md length.** Keep the body under 500 lines. Use progressive disclosure — link to specific reference files with a clear "read this when X" pointer rather than burying detail inline.
-- **Plugin manifests.** Keep `plugins/signoz/.codex-plugin/plugin.json` and `plugins/signoz/.cursor-plugin/plugin.json` in sync with the Claude manifest when adding or removing skills. The **Antigravity** plugin is native to the **repo root**: `plugin.json` (marker) + `mcp_config.json` (MCP registration, remote key `serverUrl`) + the root `skills` symlink. This lets `agy plugin install https://github.com/SigNoz/agent-skills` stage the repo root as a native Antigravity plugin. Antigravity's `plugin.json` schema is strict (`name` + `description` only, `additionalProperties: false`), so it intentionally carries **no `version`** and is not part of the CalVer bump. Do not point the root `mcp_config.json` at `${...}` interpolation — Antigravity does not resolve it (unlike `gemini-extension.json`, which keeps its `${SIGNOZ_MCP_URL}` prompt for Gemini CLI).
+- **Plugin manifests.** Keep shared metadata synchronized across the portable Agent Plugins manifest at `plugins/signoz/plugin.json` and the client-specific manifests at `plugins/signoz/.claude-plugin/plugin.json`, `plugins/signoz/.codex-plugin/plugin.json`, and `plugins/signoz/.cursor-plugin/plugin.json`. Skills are discovered from the fixed `skills/` location; manifests do not need per-skill lists. Portable MCP registration belongs in `plugins/signoz/mcp.json` and must follow the Agent Plugins schema. The source tree also carries client-native files, so validate or publish only the clean artifact produced by `scripts/package_agent_plugin.py`; it contains `plugin.json`, `mcp.json`, `LICENSE`, and `skills/`. The **Antigravity** plugin is native to the **repo root**: `plugin.json` (marker) + `mcp_config.json` (MCP registration, remote key `serverUrl`) + the root `skills` symlink. This lets `agy plugin install https://github.com/SigNoz/agent-skills` stage the repo root as a native Antigravity plugin. Antigravity's `plugin.json` schema is strict (`name` + `description` only, `additionalProperties: false`), so it cannot double as the portable Agent Plugins manifest, intentionally carries **no `version`**, and is not part of the CalVer bump. Do not point the root `mcp_config.json` at `${...}` interpolation — Antigravity does not resolve it (unlike `gemini-extension.json`, which keeps its `${SIGNOZ_MCP_URL}` prompt for Gemini CLI).
 
 ### Further reading
 
@@ -43,21 +44,29 @@ These guides and internal specs shape the conventions above. When in doubt, foll
 - agentskills.io — [Evaluating skill output quality](https://agentskills.io/skill-creation/evaluating-skills)
 - agentskills.io — [Optimizing skill descriptions](https://agentskills.io/skill-creation/optimizing-descriptions)
 - Agent Skills [specification](https://agentskills.io/specification)
+- Agent Plugins [specification](https://agent-plugins.org/specification)
 - SigNoz internal — [Skills & MCP Spec](https://www.notion.so/signoz/Skills-MCP-Spec-352fcc6bcd1980c89215deec882df42e#200b80ec35cb4012a246da1ccdc9d580)
 
 ## Plugin Versioning (CalVer)
 
-This repository uses **CalVer** (`YYYY.MM.DD`, with an optional `.N` micro suffix for same-day releases) for plugin versions. The version field lives in three manifests per plugin:
+This repository uses **CalVer** (`YYYY.MM.DD`, with an optional `.N` micro suffix for same-day releases) for plugin versions. The version field lives in three client-specific manifests per plugin:
 
 - `plugins/signoz/.claude-plugin/plugin.json`
 - `plugins/signoz/.codex-plugin/plugin.json`
 - `plugins/signoz/.cursor-plugin/plugin.json`
 
-Users of Claude Code, Codex, and Cursor receive updates based on these versions. If the version is not bumped, downstream users will not pick up the changes.
+The portable Agent Plugins manifest at `plugins/signoz/plugin.json` uses a
+SemVer-compatible encoding of the same release
+(`YYYY.M.<DD*100+micro>`), matching the Devin CLI encoding. The micro suffix is
+limited to `0`–`99`; for example, `2026.08.06.1` becomes `2026.8.601`.
+
+Claude Code, Codex, and Cursor use the CalVer form; Agent Plugins and Devin use
+the strict-SemVer form. If the version is not bumped, downstream users may not
+pick up the changes.
 
 ### Auto-bump workflow
 
-A GitHub Actions workflow (`.github/workflows/auto-version-bump.yml`) opens or updates a version-bump pull request after plugin changes land on `main`. It aggregates every plugin changed since the last successful bump and sets the version to today's date (or appends a micro suffix for multiple bumps in the same day). The root `gemini-extension.json` and `.devin-plugin/plugin.json` manifests mirror the `signoz` plugin and are bumped in lockstep with it. Root-only changes to the Gemini, Devin, or versionless Antigravity ports also trigger a `signoz` version bump.
+A GitHub Actions workflow (`.github/workflows/auto-version-bump.yml`) opens or updates a version-bump pull request after plugin changes land on `main`. It aggregates every plugin changed since the last successful bump and sets the version to today's date (or appends a micro suffix for multiple bumps in the same day). The root `gemini-extension.json` and `.devin-plugin/plugin.json` manifests mirror the `signoz` plugin and are bumped in lockstep with it. Root-only changes to the Gemini, Devin, versionless Antigravity ports, or portable packaging script also trigger a `signoz` version bump.
 
 Repository maintainers must enable **Settings → Actions → General → Allow GitHub Actions to create and approve pull requests** so the workflow's `GITHUB_TOKEN` can open the follow-up PR.
 
@@ -68,6 +77,7 @@ Repository maintainers must enable **Settings → Actions → General → Allow 
 - [ ] Skill follows the [Agent Skills specification](https://agentskills.io/specification)
 - [ ] `name` in SKILL.md frontmatter matches the directory name
 - [ ] `README.md` updated if a new skill was added
+- [ ] Clean Agent Plugins artifact builds and passes the portable schema/skill checks
 - [ ] **Plugin versions left unchanged** for the follow-up auto-bump PR
 - [ ] Changes tested locally with the relevant tool (Claude Code, Codex, or Cursor)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ downstream users may not pick up the changes.
 
 ### Auto-bump workflow
 
-A GitHub Actions workflow (`.github/workflows/auto-version-bump.yml`) opens or updates a version-bump pull request after plugin changes land on `main`. It aggregates every plugin changed since the last successful bump and sets the version to today's date (or appends a micro suffix for multiple bumps in the same day). The root `gemini-extension.json` and `.devin-plugin/plugin.json` manifests mirror the `signoz` plugin and are bumped in lockstep with it. Root-only changes to the Gemini, Devin, versionless Antigravity ports, or portable packaging script also trigger a `signoz` version bump.
+A GitHub Actions workflow (`.github/workflows/auto-version-bump.yml`) opens or updates a version-bump pull request after plugin changes land on `main`. It aggregates every plugin changed since the last successful bump and sets the version to today's date (or appends a micro suffix for multiple bumps in the same day). The root `gemini-extension.json` and `.devin-plugin/plugin.json` manifests mirror the `signoz` plugin and are bumped in lockstep with it. Root-only changes to the Gemini, Devin, versionless Antigravity ports, portable packaging script, or `LICENSE` also trigger a `signoz` version bump.
 
 Repository maintainers must enable **Settings → Actions → General → Allow GitHub Actions to create and approve pull requests** so the workflow's `GITHUB_TOKEN` can open the follow-up PR.
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ compatibility source tree:
 python3 scripts/package_agent_plugin.py
 ```
 
+The builder refuses to overwrite an existing output directory. Before
+rebuilding, deliberately remove or rename `dist/signoz`, or pass a different
+new output path as the command's final argument.
+
 This creates `dist/signoz` containing only `plugin.json`, `mcp.json`, `LICENSE`,
 and immediate-child Agent Skills under `skills/`. It can be loaded locally in a
 [compatible Agent Plugins client](https://agent-plugins.org/compatible-clients)

--- a/README.md
+++ b/README.md
@@ -1,16 +1,19 @@
 # SigNoz Agent Skills
 
 Official SigNoz skills and MCP configuration for Claude Code, Codex, Cursor,
-Gemini CLI, Devin CLI, Antigravity CLI, and the [skills.sh](https://skills.sh) ecosystem. The MCP setup skill also
+Gemini CLI, Devin CLI, Antigravity CLI, and the
+[skills.sh](https://skills.sh) ecosystem. The repository also includes an
+experimental [Agent Plugins v1](https://agent-plugins.org/) package for local
+conformance testing. The MCP setup skill
 includes client-specific recipes for VS Code/GitHub Copilot, Claude Desktop,
-Gemini CLI, Devin CLI, Windsurf, Zed, Antigravity CLI, OpenCode, and generic HTTP
-MCP clients.
+Gemini CLI, Devin CLI, Windsurf, Zed, Antigravity CLI, OpenCode, and generic
+HTTP MCP clients.
 
 ## Skills
 
 | Skill | Description |
 |-------|-------------|
-| [signoz-mcp-setup](plugins/signoz/skills/signoz-mcp-setup/SKILL.md) | Initialize or repair the SigNoz MCP server configuration for Claude Code, Codex, Cursor, VS Code/GitHub Copilot, Claude Desktop, Gemini CLI, Devin CLI, Windsurf, Zed, Antigravity CLI, OpenCode, or another MCP client. |
+| [signoz-mcp-setup](plugins/signoz/skills/signoz-mcp-setup/SKILL.md) | Initialize or repair the SigNoz Agent Plugins v1 or client-specific MCP server configuration for Claude Code, Codex, Cursor, VS Code/GitHub Copilot, Claude Desktop, Gemini CLI, Devin CLI, Windsurf, Zed, Antigravity CLI, OpenCode, or another MCP client. |
 | [signoz-creating-alerts](plugins/signoz/skills/signoz-creating-alerts/SKILL.md) | Create SigNoz alert rules for threshold breaches, error rates, latency, anomaly detection, and absent-data conditions across metrics, logs, and traces. |
 | [signoz-explaining-alerts](plugins/signoz/skills/signoz-explaining-alerts/SKILL.md) | Explain and interpret an existing SigNoz alert rule's configuration, evaluation behavior, notification routing, and recent fire frequency. |
 | [signoz-investigating-alerts](plugins/signoz/skills/signoz-investigating-alerts/SKILL.md) | Diagnose why a SigNoz alert fired by correlating its signal with neighbor metrics, traces, and logs around the fire window, and ranking likely causes. |
@@ -26,14 +29,13 @@ MCP clients.
 
 ## Installation
 
-The Claude Code, Codex, and Cursor plugins ship with MCP registration files so
-users do not have to hand-edit MCP configuration. Claude Code asks for the MCP
-endpoint URL during install. Codex and Cursor can use `signoz-mcp-setup` when an
-endpoint needs to be initialized or repaired; it accepts a SigNoz Cloud region
+The Claude Code, Codex, and Cursor packages ship with native MCP registration
+files. Claude Code asks for the MCP endpoint URL during install; Codex and
+Cursor can use `signoz-mcp-setup` to initialize or repair it. The setup skill
+accepts a SigNoz Cloud region
 such as `us`, `us2`, `eu`, `eu2`, `in`, or `in2`, any hosted MCP URL, or a
-self-hosted HTTP `/mcp` endpoint. Plugin updates can reset bundled MCP
-registration files to the placeholder; if that happens, rerun
-`signoz-mcp-setup`.
+self-hosted `/mcp` endpoint. Plugin updates can reset bundled MCP registration
+files to the placeholder; if that happens, rerun `signoz-mcp-setup`.
 
 The Devin CLI plugin ships skills only — Devin's plugin system does not bundle
 MCP servers or prompt for install-time config. Run `signoz-mcp-setup` after
@@ -45,6 +47,35 @@ describes, update or reconfigure the SigNoz MCP server before changing the
 workflow.
 
 See the full setup guide in the [SigNoz MCP Server docs](https://signoz.io/docs/ai/signoz-mcp-server/).
+
+### Agent Plugins v1 (experimental)
+
+Agent Plugins v1 standardizes the portable package format but leaves
+distribution and installation to individual clients. SigNoz does not currently
+publish this package as a public installation path; the client-specific packages
+below remain the supported user-facing integrations.
+
+For local development and conformance testing, build the clean package from the
+compatibility source tree:
+
+```sh
+python3 scripts/package_agent_plugin.py
+```
+
+This creates `dist/signoz` containing only `plugin.json`, `mcp.json`, `LICENSE`,
+and immediate-child Agent Skills under `skills/`. It can be loaded locally in a
+[compatible Agent Plugins client](https://agent-plugins.org/compatible-clients)
+for testing. The source tree at [`plugins/signoz`](plugins/signoz) intentionally
+also contains native Claude, Codex, and Cursor files and is not itself a
+portable package.
+
+The portable MCP registration intentionally starts at
+`https://not-setup/mcp`, because Agent Plugins v1 does not define portable
+install-time configuration or credential fields. After installing, run
+`signoz-mcp-setup <region-or-mcp-url>` and complete the client's OAuth flow for
+SigNoz Cloud. Portable non-loopback endpoints must use HTTPS; for a self-hosted
+HTTP endpoint on another host, the skill configures the named client's native
+MCP surface instead.
 
 ### Claude Code
 
@@ -254,11 +285,17 @@ npx skills add SigNoz/agent-skills --skill signoz-writing-clickhouse-queries    
 ├── .claude-plugin/marketplace.json         # Claude Code marketplace
 ├── .cursor-plugin/marketplace.json         # Cursor marketplace
 ├── .devin-plugin/plugin.json               # Devin CLI plugin manifest
+├── .github/workflows/
+│   ├── auto-version-bump.yml               # Follow-up version PR automation
+│   └── validate-agent-plugin.yml           # Portable schema and skill checks
 ├── gemini-extension.json                   # Gemini CLI extension manifest
 ├── plugin.json                             # Antigravity plugin manifest (native, repo root)
 ├── mcp_config.json                         # Antigravity MCP config (serverUrl)
+├── scripts/package_agent_plugin.py         # Builds clean dist/signoz package
 ├── skills -> plugins/signoz/skills         # Gemini CLI, Devin CLI & Antigravity skills (symlink)
 ├── plugins/signoz/
+│   ├── plugin.json                         # Portable manifest source
+│   ├── mcp.json                            # Portable MCP config source
 │   ├── .codex-plugin/plugin.json           # Codex plugin manifest
 │   ├── .claude-plugin/plugin.json          # Claude Code plugin manifest
 │   ├── .cursor-plugin/plugin.json          # Cursor plugin manifest
@@ -277,7 +314,7 @@ npx skills add SigNoz/agent-skills --skill signoz-writing-clickhouse-queries    
 │       ├── signoz-modifying-dashboards/
 │       ├── signoz-searching-docs/
 │       ├── signoz-generating-queries/
-│       └── signoz-managing-views/
+│       └── ...                             # See the complete Skills table
 └── README.md
 ```
 
@@ -286,7 +323,7 @@ npx skills add SigNoz/agent-skills --skill signoz-writing-clickhouse-queries    
 | Marketplace | `signoz-skills` |
 | Plugin | `signoz` |
 | Repository | `SigNoz/agent-skills` |
-| Versioning | CalVer (`YYYY.MM.DD`) — auto-bumped |
+| Versioning | Client CalVer `YYYY.MM.DD`; portable/Devin SemVer `YYYY.M.<DD*100+micro>` — auto-bumped |
 
 ## Contributing
 

--- a/plugins/signoz/mcp.json
+++ b/plugins/signoz/mcp.json
@@ -1,6 +1,8 @@
 {
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
   "mcpServers": {
     "signoz": {
+      "type": "streamable-http",
       "url": "https://not-setup/mcp"
     }
   }

--- a/plugins/signoz/plugin.json
+++ b/plugins/signoz/plugin.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "signoz",
+  "version": "2026.8.600",
+  "description": "Official SigNoz plugin for MCP setup, docs, queries, dashboards, and alerts",
+  "author": {
+    "name": "SigNoz",
+    "url": "https://signoz.io"
+  },
+  "homepage": "https://signoz.io",
+  "repository": "https://github.com/SigNoz/agent-skills",
+  "license": "MIT",
+  "keywords": [
+    "signoz",
+    "opentelemetry",
+    "observability",
+    "mcp",
+    "clickhouse",
+    "tracing",
+    "logging"
+  ]
+}

--- a/plugins/signoz/skills/signoz-mcp-setup/SKILL.md
+++ b/plugins/signoz/skills/signoz-mcp-setup/SKILL.md
@@ -43,6 +43,12 @@ client is named, infer it only when the active environment is obvious (which
 agent CLI or editor is running this skill, not just what files happen to exist
 on disk):
 
+If the installed plugin root contains `.signoz_claude_mcp.json`, `.mcp.json`,
+`.signoz_cursor_mcp.json`, or `.signoz_grok_mcp.json`, treat it as a
+compatibility package and route by the active client even though the same root
+also contains the portable `mcp.json`. Only use the portable path when none of
+those client-specific registration files is present.
+
 - Portable Agent Plugins v1 install: use the standard `mcp.json` in the
   installed plugin root.
 - Claude Code, Codex, or Cursor compatibility-package install: use the bundled

--- a/plugins/signoz/skills/signoz-mcp-setup/SKILL.md
+++ b/plugins/signoz/skills/signoz-mcp-setup/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: signoz-mcp-setup
 description: >
-  Initialize or repair SigNoz MCP server configuration for Claude Code, Codex,
-  Cursor, VS Code/GitHub Copilot, Claude Desktop, Gemini CLI, Devin CLI,
-  Windsurf, Zed, Antigravity CLI, OpenCode, or another MCP client. Use this skill before any
-  SigNoz docs, query, dashboard, alert, or view workflow when
+  Initialize or repair SigNoz MCP server configuration for Agent Plugins v1,
+  Claude Code, Codex, Cursor, VS Code/GitHub Copilot, Claude Desktop, Gemini
+  CLI, Devin CLI, Windsurf, Zed, Antigravity CLI, OpenCode, or another MCP
+  client. Use this skill before any SigNoz docs, query, dashboard, alert, or view workflow when
   `signoz_*` tools are unavailable, or when the user says "setup SigNoz
   MCP", "configure SigNoz plugin", "wrong region", "change SigNoz region",
   "MCP auth failed", or asks to connect SigNoz Cloud or a self-hosted MCP
@@ -25,10 +25,10 @@ state, mapping user input, or editing registration files. It contains the
 server-state check, registration file locations, editing rules, and region
 mapping used by this procedure.
 
-Read [references/client-configs.md](references/client-configs.md) when the
-user names a client other than the bundled Claude Code, Codex, or Cursor
-plugin path, when a native client config already exists, or when self-hosted
-stdio/local-binary setup is requested.
+Read [references/client-configs.md](references/client-configs.md) for a portable
+Agent Plugins v1 install, when the user names a client other than the bundled
+Claude Code, Codex, or Cursor plugin path, when a native client config already
+exists, or when self-hosted stdio/local-binary setup is requested.
 
 ## Configuration procedure
 
@@ -42,8 +42,10 @@ client is named, infer it only when the active environment is obvious (which
 agent CLI or editor is running this skill, not just what files happen to exist
 on disk):
 
-- Claude Code, Codex, or Cursor plugin install: use the bundled plugin
-  registration files.
+- Portable Agent Plugins v1 install: use the standard `mcp.json` in the
+  installed plugin root.
+- Claude Code, Codex, or Cursor compatibility-package install: use the bundled
+  client-specific registration files.
 - VS Code / GitHub Copilot, Claude Desktop, Gemini CLI, Devin CLI, Windsurf,
   Zed, Antigravity CLI, or OpenCode: use the matching native client recipe in
   `client-configs.md`.
@@ -61,16 +63,18 @@ Silently determine the SigNoz MCP server state using the reference flow,
 Probe with `signoz_list_services(timeRange: "1h", limit: 1)`. Do not use docs
 tools (`signoz_search_docs` or `signoz_fetch_doc`) for this check.
 
-- For a Claude Code, Codex, or Cursor bundled plugin install, the reference
-  flow's registration-file fallback applies.
+- For a portable Agent Plugins v1 install or a Claude Code, Codex, or Cursor
+  bundled plugin install, the reference flow's registration-file fallback
+  applies.
 - For every other client — including Devin CLI — do not read or search for
-  `.signoz_claude_mcp.json`, `.mcp.json`, or `.signoz_cursor_mcp.json`. Those
-  are bundled files for a different client's plugin distribution and are
-  irrelevant here even if a file-search tool happens to find them (for
-  example when this skill is linked from a local checkout of the
-  `agent-skills` source repo itself, which ships all three files side by
-  side). Check that client's own native config location instead, per
-  `client-configs.md`.
+  the plugin-root `mcp.json`, `.signoz_claude_mcp.json`, `.mcp.json`, or
+  `.signoz_cursor_mcp.json`. Those are bundled files for a different plugin
+  distribution and are irrelevant here even if a file-search tool happens to
+  find them (for example when this skill is linked from a local checkout of
+  the `agent-skills` source repo itself, which ships all four files side by
+  side). This does not exclude native files such as `.vscode/mcp.json` or
+  `.cursor/mcp.json`; check the identified client's own native config location
+  per `client-configs.md`.
 
 State outcomes:
 
@@ -117,18 +121,23 @@ cannot complete interactive OAuth, use the header-based fallback in
 
 ### Step 4: Apply the endpoint
 
-For bundled Claude Code, Codex, and Cursor plugin installs, edit the registration
-files using the reference editing rules:
+For a portable Agent Plugins v1 install or bundled Claude Code, Codex, and
+Cursor plugin installs, edit the registration files using the reference editing
+rules:
 
-1. In `.signoz_claude_mcp.json` for Claude Code, replace only the `url` value
+1. For Agent Plugins v1, apply the portable endpoint eligibility rules in
+   `mcp-settings.md` and the canonical file shape in `client-configs.md`. When
+   the endpoint is not portable, follow the reference routing to the identified
+   client's native MCP configuration instead.
+2. In `.signoz_claude_mcp.json` for Claude Code, replace only the `url` value
    with the resolved MCP endpoint. Preserve the existing server key and `type`:
    this file ships the server key `mcp`, and renaming it changes the tool
    namespace (`plugin:signoz:mcp`) and forces re-authentication.
-2. In `.mcp.json` for Codex, replace only the `url` value with the resolved MCP
+3. In `.mcp.json` for Codex, replace only the `url` value with the resolved MCP
    endpoint, preserving the existing `signoz` server key.
-3. In `.signoz_cursor_mcp.json` for Cursor, replace only the `url` value with the
+4. In `.signoz_cursor_mcp.json` for Cursor, replace only the `url` value with the
    resolved MCP endpoint, preserving the existing `signoz` server key.
-4. Preserve unrelated MCP servers and settings.
+5. Preserve unrelated MCP servers and settings.
 
 Claude Code target shape (keep the `mcp` server key and `type`):
 
@@ -158,9 +167,10 @@ Codex and Cursor target shape (keep the `signoz` server key):
 If either bundled file still uses any `SIGNOZ_MCP_URL` wrapper from an older
 version, replace it with the concrete resolved URL.
 
-Bundled registration files live inside the installed plugin. Plugin updates can
-reset them to the placeholder; if that happens, rerun this setup skill. For a
-more durable native-client setup, use the relevant recipe in `client-configs.md`.
+Portable and client-specific registration files live inside the installed
+plugin. Plugin updates can reset them to the placeholder; if that happens,
+rerun this setup skill. For a more durable native-client setup, use the relevant
+recipe in `client-configs.md`.
 
 For Codex, if the user says the endpoint reset again, keeps resetting, or asks
 for a durable/persistent setup, also create or update the native Codex MCP
@@ -204,6 +214,10 @@ paste elevated keys into chat or tracked config.
 Tell the user that the SigNoz MCP endpoint has been configured, then give the
 client-specific authentication step:
 
+- **Agent Plugins v1 client** — reload the installed plugin if the client does
+  not pick up the changed `mcp.json`, then use that client's MCP authentication
+  flow for the `signoz` server. Agent Plugins v1 leaves OAuth interaction and
+  credential storage to the client.
 - **Cursor** — reload the window, then authenticate the `signoz` MCP server in
   Tools & MCP if prompted.
 - **VS Code / GitHub Copilot** — open Copilot Chat in Agent mode, approve the

--- a/plugins/signoz/skills/signoz-mcp-setup/evals/evals.json
+++ b/plugins/signoz/skills/signoz-mcp-setup/evals/evals.json
@@ -151,6 +151,27 @@
         }
       ],
       "files": []
+    },
+    {
+      "id": 7,
+      "eval_name": "compatibility-package-wins-over-portable-files",
+      "prompt": "I installed the SigNoz marketplace plugin in Claude Code. Its plugin root contains mcp.json as well as .signoz_claude_mcp.json. Configure it for the eu region.",
+      "expected_output": "Agent recognizes the client-specific registration file as evidence that this is the Claude Code compatibility package, despite the colocated portable mcp.json. It updates only .signoz_claude_mcp.json to https://mcp.eu.signoz.cloud/mcp, preserves the mcp server key and type=http, and leaves the portable mcp.json unchanged.",
+      "assertions": [
+        {
+          "text": "Agent treats the install as the Claude Code compatibility package rather than a portable package",
+          "description": "Client-specific registration files take precedence over the colocated portable files"
+        },
+        {
+          "text": "Agent updates only .signoz_claude_mcp.json and leaves the plugin-root mcp.json unchanged",
+          "description": "The endpoint is written to the registration file Claude Code actually loads"
+        },
+        {
+          "text": "Agent preserves the mcp server key and type http",
+          "description": "The compatibility package keeps its client-specific MCP contract"
+        }
+      ],
+      "files": []
     }
   ]
 }

--- a/plugins/signoz/skills/signoz-mcp-setup/evals/evals.json
+++ b/plugins/signoz/skills/signoz-mcp-setup/evals/evals.json
@@ -88,6 +88,69 @@
         }
       ],
       "files": []
+    },
+    {
+      "id": 4,
+      "eval_name": "portable-non-loopback-http-routes-native",
+      "prompt": "I installed the portable Agent Plugins v1 package in VS Code. Configure SigNoz at http://signoz.internal:8000/mcp.",
+      "expected_output": "Agent does not write the non-loopback HTTP URL into the plugin-root mcp.json because Agent Plugins v1 requires HTTPS for non-loopback endpoints. It routes the endpoint to VS Code's native .vscode/mcp.json or user MCP configuration instead, preserving unrelated native servers.",
+      "assertions": [
+        {
+          "text": "Agent does not write http://signoz.internal:8000/mcp into the portable plugin-root mcp.json",
+          "description": "Non-loopback HTTP is invalid in the Agent Plugins v1 remote transport"
+        },
+        {
+          "text": "Agent explains that portable non-loopback endpoints must use HTTPS",
+          "description": "The user receives the contract reason rather than a silent failure"
+        },
+        {
+          "text": "Agent configures the endpoint through VS Code native MCP configuration",
+          "description": "The unsupported portable value is routed to the identified client's native surface"
+        }
+      ],
+      "files": []
+    },
+    {
+      "id": 5,
+      "eval_name": "vscode-native-mcp-json-is-not-portable-file",
+      "prompt": "My VS Code workspace already has .vscode/mcp.json. Change its SigNoz server to https://mcp.eu.signoz.cloud/mcp without touching plugin files.",
+      "expected_output": "Agent treats .vscode/mcp.json as the active native VS Code configuration rather than confusing it with the portable plugin-root mcp.json. It updates only the existing signoz server URL, preserves unrelated servers and settings, and gives the VS Code authentication finish step.",
+      "assertions": [
+        {
+          "text": "Agent reads and updates .vscode/mcp.json instead of skipping it because its basename is mcp.json",
+          "description": "The plugin-root exclusion must not hide native VS Code configuration"
+        },
+        {
+          "text": "Agent changes only the existing signoz server URL and preserves unrelated native configuration",
+          "description": "The repair avoids duplicate or destructive native entries"
+        },
+        {
+          "text": "Agent provides the VS Code approval or authentication finish step",
+          "description": "The native registration is completed through the identified client"
+        }
+      ],
+      "files": []
+    },
+    {
+      "id": 6,
+      "eval_name": "portable-https-happy-path-preserves-contract",
+      "prompt": "I installed the portable Agent Plugins v1 package. Configure its SigNoz MCP server for the eu2 region.",
+      "expected_output": "Agent resolves eu2 to https://mcp.eu2.signoz.cloud/mcp and updates only the url in the installed plugin-root mcp.json. It preserves the Agent Plugins v1 schema URL, the signoz server key, and type=streamable-http, then gives the client-specific OAuth or reload finish step.",
+      "assertions": [
+        {
+          "text": "Agent updates the installed portable plugin-root mcp.json URL to https://mcp.eu2.signoz.cloud/mcp",
+          "description": "The portable hosted-region happy path edits the correct registration file"
+        },
+        {
+          "text": "Agent preserves $schema, the signoz server key, and type streamable-http",
+          "description": "The edit retains every required part of the Agent Plugins v1 MCP contract"
+        },
+        {
+          "text": "Agent changes only the URL and provides the identified client's authentication or reload finish step",
+          "description": "The update is minimal and completes the client workflow"
+        }
+      ],
+      "files": []
     }
   ]
 }

--- a/plugins/signoz/skills/signoz-mcp-setup/references/client-configs.md
+++ b/plugins/signoz/skills/signoz-mcp-setup/references/client-configs.md
@@ -14,9 +14,11 @@ SigNoz MCP Server docs and adds OpenCode's native config shape.
 
 ## Safety Rules
 
-- Keep each file's existing server key. The bundled Claude Code file
-  (`.signoz_claude_mcp.json`) ships `mcp`; the Codex and Cursor bundled files and
-  native client configs use `signoz`. Do not rename it.
+- Keep each file's existing server key. The plugin-root `mcp.json`, bundled
+  Codex and Cursor files, and native client configs use `signoz`; the bundled
+  Claude Code file (`.signoz_claude_mcp.json`) uses `mcp`. Do not rename either
+  key. In the portable file, also preserve the canonical `$schema` and
+  `type: "streamable-http"`.
 - Prefer SigNoz Cloud OAuth over header-based auth whenever the client supports
   interactive OAuth.
 - Do not write service account API keys, bearer tokens, or header-based auth
@@ -49,6 +51,28 @@ SigNoz MCP Server docs and adds OpenCode's native config shape.
 Use these shapes for SigNoz Cloud hosted MCP URLs such as
 `https://mcp.us.signoz.cloud/mcp` and self-hosted HTTP MCP URLs such as
 `http://localhost:8000/mcp`.
+
+### Portable Agent Plugins v1 package
+
+In `mcp.json` in the installed SigNoz plugin root, replace only the `url` value
+with the resolved MCP endpoint. Preserve the canonical `$schema`, the `signoz`
+server key, and `type: "streamable-http"`. Agent Plugins v1 does not expand
+environment variables in remote URLs and leaves OAuth to the client.
+
+Apply the portable endpoint eligibility and native-client routing rules from
+`mcp-settings.md` before editing this file.
+
+```json
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "signoz": {
+      "type": "streamable-http",
+      "url": "https://mcp.us.signoz.cloud/mcp"
+    }
+  }
+}
+```
 
 ### Bundled Claude Code plugin
 

--- a/plugins/signoz/skills/signoz-mcp-setup/references/mcp-settings.md
+++ b/plugins/signoz/skills/signoz-mcp-setup/references/mcp-settings.md
@@ -27,8 +27,10 @@ Silently determine `signoz-server-state`, **only after the client is known**
 2. If the call succeeds, including with an empty service list, state is
    **working**.
 3. If the call fails, returns no tools, or cannot be attempted:
+   - **Portable Agent Plugins v1 install** — read the standard `mcp.json` in
+     the installed plugin root.
    - **Claude Code, Codex, or Cursor bundled plugin install** — read the
-     plugin registration files below.
+     client-specific plugin registration file below.
    - **Any other client** — do not read or file-search for the bundled
      registration files below. They belong to a different client's plugin
      distribution and can exist on disk for unrelated reasons — most
@@ -47,10 +49,12 @@ only the plain outcome: working, not set up, or configured but not connected.
 
 ## Registration Files
 
-These bundled registration files exist only for the Claude Code, Codex, and
-Cursor plugin installs — never read or edit them for any other client, even if
-a file search finds them:
+These registration files exist only for the portable Agent Plugins package and
+the Claude Code, Codex, and Cursor compatibility packages — never read or edit
+them for any other client, even if a file search finds them:
 
+- plugin-root `mcp.json` for Agent Plugins v1 (not native `.vscode/mcp.json` or
+  `.cursor/mcp.json` files)
 - `.signoz_claude_mcp.json` for Claude Code
 - `.mcp.json` for Codex
 - `.signoz_cursor_mcp.json` for Cursor
@@ -58,26 +62,29 @@ a file search finds them:
 This reference file lives at `skills/signoz-mcp-setup/references/mcp-settings.md`,
 so the plugin root is two directories up from `skills/signoz-mcp-setup/`. That
 relative path also happens to resolve inside the `agent-skills` source repo
-itself (this plugin's own monorepo), which ships all three files side by side
-for their respective bundled installs — resolving to a real file there does
-not mean it is the active client's configuration.
+itself (this plugin's own monorepo), which ships all four files side by side for
+their respective packages — resolving to a real file there does not mean it is
+the active client's configuration.
 
-Update every registration file that exists **for the identified client only**.
-Replace only the `url` value and preserve each file's existing server key and
-`type`: the Claude Code file (`.signoz_claude_mcp.json`) ships the server key
-`mcp`, while the Codex and Cursor files ship `signoz`. Do not create duplicate
-MCP server entries, and do not rename the existing server — renaming the
-Claude Code key changes the tool namespace (`plugin:signoz:mcp`) and forces
-re-authentication.
+Update the registration file **for the identified client only**. Use the
+canonical portable shape and transport restrictions in `client-configs.md` for
+the Agent Plugins v1 file. For the compatibility files, replace only the `url`
+value and preserve each file's existing server key and `type`: the Claude Code file
+(`.signoz_claude_mcp.json`) ships the server key `mcp`, while the Codex and Cursor
+files ship `signoz`. Do not create duplicate MCP server entries, and do not
+rename the existing server — renaming the Claude Code key changes the tool
+namespace (`plugin:signoz:mcp`) and forces re-authentication.
 
 ## Editing Rules
 
 Use the client-specific shape for the registration file you are editing.
 
-### Bundled plugin MCP files
+### Portable and client-specific plugin MCP files
 
-The URL should use a concrete endpoint in all bundled registration files:
+The URL should use a concrete endpoint in the registration file for the active
+plugin package:
 
+- plugin-root `mcp.json` for Agent Plugins v1
 - `.signoz_claude_mcp.json` for Claude Code
 - `.mcp.json` for Codex
 - `.signoz_cursor_mcp.json` for Cursor
@@ -86,10 +93,11 @@ The URL should use a concrete endpoint in all bundled registration files:
 "url": "https://mcp.us.signoz.cloud/mcp"
 ```
 
-Replace the entire `url` value with the resolved MCP endpoint. Do not keep
-`${SIGNOZ_MCP_URL:-...}` in bundled plugin MCP files; Codex treats it as a
-literal URL, and Cursor documents interpolation syntax that does not include
-shell-style defaults.
+Replace the entire `url` value with the resolved MCP endpoint. For the portable
+file, follow `client-configs.md`; it is the canonical source for its complete
+shape and HTTPS restriction. Do not keep `${SIGNOZ_MCP_URL:-...}` in bundled
+plugin MCP files; Codex treats it as a literal URL, and Cursor documents
+interpolation syntax that does not include shell-style defaults.
 
 If either bundled file contains any legacy `SIGNOZ_MCP_URL` wrapper, replace
 the full value with the concrete resolved URL.
@@ -108,10 +116,10 @@ clear the explicit plugin setting and reload the client.
 
 ### Update behavior and durable Codex config
 
-These bundled files live inside the installed plugin. Plugin updates can reset
-them to the placeholder. If the `signoz` server returns to **not-setup** after
-an update, rerun `signoz-mcp-setup`. For durable native client configuration,
-use the client-specific recipes in `client-configs.md`.
+These files live inside the installed plugin. Plugin updates can reset them to
+the placeholder. If the `signoz` server returns to **not-setup** after an
+update, rerun `signoz-mcp-setup`. For durable native client configuration, use
+the client-specific recipes in `client-configs.md`.
 
 For Codex users who report repeated resets or ask for a persistent setup, add
 or update the native Codex MCP entry as well as the bundled `.mcp.json`. Use
@@ -146,6 +154,11 @@ Mapping rules:
   configuration path configures URL-based HTTP MCP. For stdio/local-binary
   mode, tell the user to register the SigNoz MCP server separately as
   `signoz`.
+- **Portable Agent Plugins restriction** — a non-loopback endpoint must use
+  `https://`. Plain `http://` is portable only when the host is exactly
+  `localhost` or an IP literal in a loopback range. For any other HTTP host,
+  leave the plugin-root `mcp.json` unchanged and use the identified client's
+  native MCP recipe from `client-configs.md`.
 - **SigNoz workspace URL** — do not infer the region from
   `https://<workspace>.signoz.cloud`. Ask the user for the region from
   **Settings -> Ingestion**.

--- a/plugins/signoz/skills/signoz-mcp-setup/references/mcp-settings.md
+++ b/plugins/signoz/skills/signoz-mcp-setup/references/mcp-settings.md
@@ -27,8 +27,8 @@ Silently determine `signoz-server-state`, **only after the client is known**
 2. If the call succeeds, including with an empty service list, state is
    **working**.
 3. If the call fails, returns no tools, or cannot be attempted:
-   - **Portable Agent Plugins v1 install**: read the standard `mcp.json` in
-     the installed plugin root.
+   - **Portable Agent Plugins v1 install**: after Step 1 identifies the package
+     as portable, read the standard `mcp.json` in the installed plugin root.
    - **Claude Code, Codex, or Cursor bundled plugin install**: read the
      client-specific plugin registration file below.
    - **Grok Build**: read `[mcp_servers.signoz]` from `./.grok/config.toml`,

--- a/scripts/check_plugin_versions.py
+++ b/scripts/check_plugin_versions.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Check plugin manifest version parity and encode CalVer as strict SemVer."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CLIENT_MANIFESTS = (
+    Path(".claude-plugin/plugin.json"),
+    Path(".codex-plugin/plugin.json"),
+    Path(".cursor-plugin/plugin.json"),
+)
+
+
+def encode_calver(calver: str) -> str:
+    """Encode YYYY.MM.DD[.MICRO] as monotonic strict SemVer."""
+    parts = calver.split(".")
+    if len(parts) not in (3, 4) or any(not part.isdigit() for part in parts):
+        raise ValueError(f"invalid CalVer: {calver}")
+
+    year_text, month_text, day_text = parts[:3]
+    micro_text = parts[3] if len(parts) == 4 else "0"
+    year = int(year_text)
+    month = int(month_text)
+    day = int(day_text)
+    micro = int(micro_text)
+
+    if year < 1 or year_text != str(year):
+        raise ValueError(f"invalid CalVer year: {calver}")
+    if not 1 <= month <= 12 or not 1 <= day <= 31:
+        raise ValueError(f"invalid CalVer date: {calver}")
+    if not 0 <= micro <= 99:
+        raise ValueError(
+            f"CalVer micro suffix exceeds the supported 0-99 range: {calver}"
+        )
+
+    # Strict SemVer forbids leading zeroes in numeric identifiers. Folding the
+    # micro suffix into patch precedence also avoids build metadata, which
+    # SemVer deliberately ignores during comparisons.
+    return f"{year}.{month}.{day * 100 + micro}"
+
+
+def read_version(path: Path) -> str:
+    if not path.is_file():
+        raise ValueError(f"required plugin manifest is missing: {path}")
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError(f"cannot read plugin manifest {path}: {error}") from error
+
+    version = data.get("version")
+    if not isinstance(version, str) or not version:
+        raise ValueError(f"no version field in {path}")
+    return version
+
+
+def check_versions(plugin_dir: Path) -> None:
+    plugin_dir = plugin_dir.resolve()
+    primary_path = plugin_dir / CLIENT_MANIFESTS[0]
+    calver = read_version(primary_path)
+
+    for relative_path in CLIENT_MANIFESTS[1:]:
+        manifest = plugin_dir / relative_path
+        version = read_version(manifest)
+        if version != calver:
+            raise ValueError(
+                f"version mismatch: {manifest} has {version}, expected {calver}"
+            )
+
+    expected_semver = encode_calver(calver)
+    portable_manifest = plugin_dir / "plugin.json"
+    portable_version = read_version(portable_manifest)
+    if portable_version != expected_semver:
+        raise ValueError(
+            f"version mismatch: {portable_manifest} has {portable_version}, "
+            f"expected {expected_semver}"
+        )
+
+    if plugin_dir.name == "signoz":
+        compatibility_versions = (
+            (REPO_ROOT / "gemini-extension.json", calver),
+            (REPO_ROOT / ".devin-plugin/plugin.json", expected_semver),
+        )
+        for manifest, expected in compatibility_versions:
+            version = read_version(manifest)
+            if version != expected:
+                raise ValueError(
+                    f"version mismatch: {manifest} has {version}, expected {expected}"
+                )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    encode_parser = subparsers.add_parser("encode", help="encode a CalVer value")
+    encode_parser.add_argument("calver")
+
+    check_parser = subparsers.add_parser("check", help="check manifest parity")
+    check_parser.add_argument("plugin_dir", type=Path)
+
+    args = parser.parse_args()
+    try:
+        if args.command == "encode":
+            print(encode_calver(args.calver))
+        else:
+            check_versions(args.plugin_dir)
+            print(f"Plugin versions are consistent: {args.plugin_dir}")
+    except ValueError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        raise SystemExit(1) from error
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/package_agent_plugin.py
+++ b/scripts/package_agent_plugin.py
@@ -17,7 +17,7 @@ PORTABLE_ROOT_FILES = ("plugin.json", "mcp.json")
 
 
 def ignore_nonportable_files(directory: str, names: list[str]) -> set[str]:
-    """Exclude caches everywhere and eval workspaces only at the skills root."""
+    """Exclude caches, eval workspaces, and immediate skill test data."""
     ignored = {
         name
         for name in names
@@ -25,6 +25,8 @@ def ignore_nonportable_files(directory: str, names: list[str]) -> set[str]:
     }
     if Path(directory) == SKILLS_ROOT:
         ignored.update(name for name in names if name.endswith("-workspace"))
+    elif Path(directory).parent == SKILLS_ROOT:
+        ignored.update({"evals", "tests"}.intersection(names))
     return ignored
 
 

--- a/scripts/package_agent_plugin.py
+++ b/scripts/package_agent_plugin.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Build a clean Agent Plugins package from the SigNoz compatibility source."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SOURCE_ROOT = REPO_ROOT / "plugins" / "signoz"
+SKILLS_ROOT = SOURCE_ROOT / "skills"
+PORTABLE_ROOT_FILES = ("plugin.json", "mcp.json")
+
+
+def ignore_nonportable_files(directory: str, names: list[str]) -> set[str]:
+    """Exclude caches everywhere and eval workspaces only at the skills root."""
+    ignored = {
+        name
+        for name in names
+        if name == "__pycache__" or name == ".DS_Store" or name.endswith(".pyc")
+    }
+    if Path(directory) == SKILLS_ROOT:
+        ignored.update(name for name in names if name.endswith("-workspace"))
+    return ignored
+
+
+def normalize_skill_frontmatter(skill_md: Path) -> None:
+    """Move Claude-only argument-hint into portable Agent Skills metadata."""
+    lines = skill_md.read_text(encoding="utf-8").splitlines(keepends=True)
+    if not lines or lines[0].strip() != "---":
+        raise ValueError(f"missing YAML frontmatter: {skill_md}")
+
+    try:
+        frontmatter_end = next(
+            index for index, line in enumerate(lines[1:], start=1) if line.strip() == "---"
+        )
+    except StopIteration as error:
+        raise ValueError(f"unterminated YAML frontmatter: {skill_md}") from error
+
+    hint_indexes = [
+        index
+        for index, line in enumerate(lines[1:frontmatter_end], start=1)
+        if line.startswith("argument-hint:")
+    ]
+    if not hint_indexes:
+        return
+    if len(hint_indexes) != 1:
+        raise ValueError(f"multiple top-level argument-hint fields: {skill_md}")
+
+    hint_index = hint_indexes[0]
+    hint_value = lines[hint_index].split(":", 1)[1].strip()
+    if not hint_value or hint_value.startswith((">", "|")):
+        raise ValueError(
+            f"argument-hint must use a non-empty single-line scalar: {skill_md}"
+        )
+    metadata_indexes = [
+        index
+        for index, line in enumerate(lines[1:frontmatter_end], start=1)
+        if line.rstrip("\r\n") == "metadata:"
+    ]
+
+    if metadata_indexes:
+        if len(metadata_indexes) != 1:
+            raise ValueError(f"multiple top-level metadata fields: {skill_md}")
+        metadata_index = metadata_indexes[0]
+        metadata_end = metadata_index + 1
+        while metadata_end < frontmatter_end and (
+            not lines[metadata_end].strip() or lines[metadata_end].startswith((" ", "\t"))
+        ):
+            if lines[metadata_end].lstrip().startswith("argument-hint:"):
+                raise ValueError(f"metadata.argument-hint already exists: {skill_md}")
+            metadata_end += 1
+        del lines[hint_index]
+        if hint_index < metadata_end:
+            metadata_end -= 1
+        lines.insert(metadata_end, f"  argument-hint: {hint_value}\n")
+    else:
+        lines[hint_index : hint_index + 1] = [
+            "metadata:\n",
+            f"  argument-hint: {hint_value}\n",
+        ]
+
+    skill_md.write_text("".join(lines), encoding="utf-8")
+
+
+def build(output: Path) -> Path:
+    output = output.resolve()
+    if output.exists():
+        raise FileExistsError(f"output already exists: {output}")
+
+    for filename in PORTABLE_ROOT_FILES:
+        source = SOURCE_ROOT / filename
+        if not source.is_file():
+            raise FileNotFoundError(f"required portable source is missing: {source}")
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    temporary_parent = Path(tempfile.mkdtemp(prefix=".signoz-agent-plugin-", dir=output.parent))
+    temporary_package = temporary_parent / output.name
+    try:
+        temporary_package.mkdir()
+        for filename in PORTABLE_ROOT_FILES:
+            shutil.copy2(SOURCE_ROOT / filename, temporary_package / filename)
+        shutil.copy2(REPO_ROOT / "LICENSE", temporary_package / "LICENSE")
+        shutil.copytree(
+            SKILLS_ROOT,
+            temporary_package / "skills",
+            ignore=ignore_nonportable_files,
+        )
+
+        for skill_md in sorted((temporary_package / "skills").glob("*/SKILL.md")):
+            normalize_skill_frontmatter(skill_md)
+
+        os.replace(temporary_package, output)
+    finally:
+        shutil.rmtree(temporary_parent, ignore_errors=True)
+
+    return output
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "output",
+        nargs="?",
+        type=Path,
+        default=REPO_ROOT / "dist" / "signoz",
+        help="new directory to create (default: dist/signoz)",
+    )
+    args = parser.parse_args()
+    print(build(args.output))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- add an experimental Agent Plugins v1 manifest and standards-valid MCP configuration
- build a clean portable package without client-specific compatibility files
- validate package schemas, Agent Skills, package boundaries, and manifest version parity in CI
- extend the MCP setup skill, references, and evals for portable-package behavior
- keep existing Claude Code, Codex, Cursor, Gemini, Devin, and Antigravity installation paths as the supported user-facing integrations

## Why

Agent Plugins v1 provides a shared package format for skills and MCP servers, but currently leaves distribution and installation to individual clients. This adds a locally testable, conformance-validated package without presenting it as a new public SigNoz installation path or changing the public SigNoz documentation.

The package builder also preserves Claude Code's top-level `argument-hint` compatibility while producing portable Agent Skills frontmatter.

## Validation

- Agent CI: portable validation workflow passed (1/1)
- `actionlint` on both changed workflows
- Agent Plugins manifest and MCP schema validation
- `skills-ref` validation for all packaged skills
- Claude strict plugin and marketplace validation
- Python compilation and focused failure-case checks
- JSON parsing and manifest version-parity checks
- multi-agent, Claude Opus 5, and Claude Fable 5 reviews; valid findings addressed
- `git diff --check`

## Release behavior

Plugin versions are intentionally unchanged in this PR. After merge, the protected-main auto-version workflow will open or update its separate synchronized version-bump PR.