### PR TITLE
feat: add Grok Build CLI support

### DIFF
--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -39,6 +39,7 @@ jobs:
             ':(glob)plugins/*/.claude-plugin/plugin.json' \
             ':(glob)plugins/*/.codex-plugin/plugin.json' \
             ':(glob)plugins/*/.cursor-plugin/plugin.json' \
+            ':(glob)plugins/*/.grok-plugin/plugin.json' \
             'gemini-extension.json' \
             '.devin-plugin/plugin.json')
           if [[ -z "$BASE_SHA" ]]; then
@@ -110,12 +111,13 @@ jobs:
               continue
             fi
 
-            # Every logical plugin must ship all three versioned manifests.
+            # Every logical plugin must ship all four versioned manifests.
             # Fail instead of silently leaving one client on a stale version.
             for MANIFEST in \
               "$PLUGIN_DIR/.claude-plugin/plugin.json" \
               "$PLUGIN_DIR/.codex-plugin/plugin.json" \
-              "$PLUGIN_DIR/.cursor-plugin/plugin.json"; do
+              "$PLUGIN_DIR/.cursor-plugin/plugin.json" \
+              "$PLUGIN_DIR/.grok-plugin/plugin.json"; do
               if [[ ! -f "$MANIFEST" ]]; then
                 echo "ERROR: Required plugin manifest is missing: $MANIFEST"
                 exit 1
@@ -204,7 +206,7 @@ jobs:
 
           # The branch is automation-owned and is regenerated from current main.
           git switch -C "$BUMP_BRANCH"
-          git add plugins/**/.claude-plugin/plugin.json plugins/**/.codex-plugin/plugin.json plugins/**/.cursor-plugin/plugin.json gemini-extension.json .devin-plugin/plugin.json
+          git add plugins/**/.claude-plugin/plugin.json plugins/**/.codex-plugin/plugin.json plugins/**/.cursor-plugin/plugin.json plugins/**/.grok-plugin/plugin.json gemini-extension.json .devin-plugin/plugin.json
           PR_TITLE="chore: auto-bump CalVer for $BUMP_COUNT plugin(s)"
           git commit -m "$PR_TITLE"
           git push --force-with-lease --set-upstream origin "$BUMP_BRANCH"

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -1,0 +1,29 @@
+{
+  "name": "signoz-skills",
+  "description": "Official SigNoz marketplace for Grok Build skills and MCP",
+  "owner": {
+    "name": "SigNoz"
+  },
+  "plugins": [
+    {
+      "name": "signoz",
+      "description": "Official SigNoz plugin for MCP setup, docs, queries, dashboards, and alerts. Investigate metrics, traces, and logs, build dashboards and alert rules, and manage saved views through the SigNoz MCP server.",
+      "category": "observability",
+      "source": {
+        "type": "local",
+        "path": "./plugins/signoz"
+      },
+      "homepage": "https://signoz.io/docs/ai/signoz-mcp-server/",
+      "keywords": [
+        "signoz",
+        "signoz cloud",
+        "signoz dashboard",
+        "signoz alert",
+        "signoz mcp"
+      ],
+      "domains": [
+        "signoz.io"
+      ]
+    }
+  ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ npx skills add https://github.com/anthropics/skills --skill skill-creator
 - **Schema reference.** The MCP server is the source of truth for tool input schemas, alert/dashboard JSON shape, and validation rules. Read the `signoz://*` resources rather than transcribing schema into a skill — duplicated schema rots out of sync.
 - **Reference files.** Move material >300 lines into `references/`, `scripts/`, or `assets/`. Any reference file longer than 100 lines must start with a `## Contents` table-of-contents.
 - **SKILL.md length.** Keep the body under 500 lines. Use progressive disclosure — link to specific reference files with a clear "read this when X" pointer rather than burying detail inline.
-- **Plugin manifests.** Keep `plugins/signoz/.codex-plugin/plugin.json` and `plugins/signoz/.cursor-plugin/plugin.json` in sync with the Claude manifest when adding or removing skills. The **Antigravity** plugin is native to the **repo root**: `plugin.json` (marker) + `mcp_config.json` (MCP registration, remote key `serverUrl`) + the root `skills` symlink. This lets `agy plugin install https://github.com/SigNoz/agent-skills` stage the repo root as a native Antigravity plugin. Antigravity's `plugin.json` schema is strict (`name` + `description` only, `additionalProperties: false`), so it intentionally carries **no `version`** and is not part of the CalVer bump. Do not point the root `mcp_config.json` at `${...}` interpolation — Antigravity does not resolve it (unlike `gemini-extension.json`, which keeps its `${SIGNOZ_MCP_URL}` prompt for Gemini CLI).
+- **Plugin manifests.** Keep `plugins/signoz/.codex-plugin/plugin.json`, `plugins/signoz/.cursor-plugin/plugin.json`, and `plugins/signoz/.grok-plugin/plugin.json` in sync with the Claude manifest when adding or removing skills. **Grok Build** reads `.grok-plugin/plugin.json` in preference to `.claude-plugin/plugin.json`, which is exactly why it exists: Claude's manifest points at `.signoz_claude_mcp.json`, whose `${user_config.SIGNOZ_MCP_URL}` placeholder is Claude-only syntax that Grok cannot expand (it fails the handshake with `RelativeUrlWithoutBase`). The Grok manifest points at `.signoz_grok_mcp.json` instead, which uses `${SIGNOZ_MCP_URL:-https://mcp.us.signoz.cloud/mcp}` — Grok expands `${VAR}` and `${VAR:-default}` in MCP `url`, `command`, `args`, `env`, and `headers` at load time. Keep the Grok server key as `signoz`: Grok's `[mcp_servers]` config **replaces** a plugin-provided server of the same name, so the shared key is what makes `grok mcp add signoz` an override instead of a duplicate. Do not give it a unique key like `signoz-grok` — that would leave two live servers and duplicate every tool. The shared key matters for de-duplication too: Grok scans `~/.claude.json`, `~/.cursor/mcp.json`, and `.mcp.json` as compatibility sources, so a user with SigNoz already configured in Claude Code or Cursor gets a second `signoz` from there, and only a same-named `[mcp_servers.signoz]` entry outranks both it and the plugin. The **Antigravity** plugin is native to the **repo root**: `plugin.json` (marker) + `mcp_config.json` (MCP registration, remote key `serverUrl`) + the root `skills` symlink. This lets `agy plugin install https://github.com/SigNoz/agent-skills` stage the repo root as a native Antigravity plugin. Antigravity's `plugin.json` schema is strict (`name` + `description` only, `additionalProperties: false`), so it intentionally carries **no `version`** and is not part of the CalVer bump. Do not point the root `mcp_config.json` at `${...}` interpolation — Antigravity does not resolve it (unlike `gemini-extension.json`, which keeps its `${SIGNOZ_MCP_URL}` prompt for Gemini CLI).
 
 ### Further reading
 
@@ -47,13 +47,14 @@ These guides and internal specs shape the conventions above. When in doubt, foll
 
 ## Plugin Versioning (CalVer)
 
-This repository uses **CalVer** (`YYYY.MM.DD`, with an optional `.N` micro suffix for same-day releases) for plugin versions. The version field lives in three manifests per plugin:
+This repository uses **CalVer** (`YYYY.MM.DD`, with an optional `.N` micro suffix for same-day releases) for plugin versions. The version field lives in four manifests per plugin:
 
 - `plugins/signoz/.claude-plugin/plugin.json`
 - `plugins/signoz/.codex-plugin/plugin.json`
 - `plugins/signoz/.cursor-plugin/plugin.json`
+- `plugins/signoz/.grok-plugin/plugin.json`
 
-Users of Claude Code, Codex, and Cursor receive updates based on these versions. If the version is not bumped, downstream users will not pick up the changes.
+Users of Claude Code, Codex, Cursor, and Grok Build receive updates based on these versions. If the version is not bumped, downstream users will not pick up the changes.
 
 ### Auto-bump workflow
 
@@ -69,7 +70,7 @@ Repository maintainers must enable **Settings → Actions → General → Allow 
 - [ ] `name` in SKILL.md frontmatter matches the directory name
 - [ ] `README.md` updated if a new skill was added
 - [ ] **Plugin versions left unchanged** for the follow-up auto-bump PR
-- [ ] Changes tested locally with the relevant tool (Claude Code, Codex, or Cursor)
+- [ ] Changes tested locally with the relevant tool (Claude Code, Codex, Cursor, or Grok Build)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # SigNoz Agent Skills
 
 Official SigNoz skills and MCP configuration for Claude Code, Codex, Cursor,
-Gemini CLI, Devin CLI, Antigravity CLI, and the [skills.sh](https://skills.sh) ecosystem. The MCP setup skill also
+Gemini CLI, Devin CLI, Grok Build, Antigravity CLI, and the [skills.sh](https://skills.sh) ecosystem. The MCP setup skill also
 includes client-specific recipes for VS Code/GitHub Copilot, Claude Desktop,
-Gemini CLI, Devin CLI, Windsurf, Zed, Antigravity CLI, OpenCode, and generic HTTP
-MCP clients.
+Gemini CLI, Devin CLI, Grok Build, Windsurf, Zed, Antigravity CLI, OpenCode, and
+generic HTTP MCP clients.
 
 ## Skills
 
 | Skill | Description |
 |-------|-------------|
-| [signoz-mcp-setup](plugins/signoz/skills/signoz-mcp-setup/SKILL.md) | Initialize or repair the SigNoz MCP server configuration for Claude Code, Codex, Cursor, VS Code/GitHub Copilot, Claude Desktop, Gemini CLI, Devin CLI, Windsurf, Zed, Antigravity CLI, OpenCode, or another MCP client. |
+| [signoz-mcp-setup](plugins/signoz/skills/signoz-mcp-setup/SKILL.md) | Initialize or repair the SigNoz MCP server configuration for Claude Code, Codex, Cursor, VS Code/GitHub Copilot, Claude Desktop, Gemini CLI, Devin CLI, Grok Build, Windsurf, Zed, Antigravity CLI, OpenCode, or another MCP client. |
 | [signoz-creating-alerts](plugins/signoz/skills/signoz-creating-alerts/SKILL.md) | Create SigNoz alert rules for threshold breaches, error rates, latency, anomaly detection, and absent-data conditions across metrics, logs, and traces. |
 | [signoz-explaining-alerts](plugins/signoz/skills/signoz-explaining-alerts/SKILL.md) | Explain and interpret an existing SigNoz alert rule's configuration, evaluation behavior, notification routing, and recent fire frequency. |
 | [signoz-investigating-alerts](plugins/signoz/skills/signoz-investigating-alerts/SKILL.md) | Diagnose why a SigNoz alert fired by correlating its signal with neighbor metrics, traces, and logs around the fire window, and ranking likely causes. |
@@ -38,6 +38,13 @@ registration files to the placeholder; if that happens, rerun
 The Devin CLI plugin ships skills only — Devin's plugin system does not bundle
 MCP servers or prompt for install-time config. Run `signoz-mcp-setup` after
 installing to write the `signoz` MCP server into `.devin/config.json`.
+
+The Grok Build plugin bundles an MCP registration that works out of the box on
+the SigNoz Cloud `us` endpoint. Grok has no install-time prompt, but unlike the
+other bundled registrations it expands `${SIGNOZ_MCP_URL}`, and a
+`[mcp_servers.signoz]` entry in Grok's own config replaces the bundled server
+rather than duplicating it — so the endpoint survives plugin updates instead of
+resetting.
 
 The skills are authored against the current SigNoz MCP server contract. If a
 tool call fails because a parameter or schema looks different from what a skill
@@ -193,6 +200,63 @@ For SigNoz Cloud, start a new session and run `devin mcp login signoz` to
 complete OAuth. For self-hosted SigNoz, no OAuth step is needed unless the
 server runs with `OAUTH_ENABLED=true`.
 
+### Grok Build
+
+```sh
+grok plugin marketplace add SigNoz/agent-skills
+grok plugin install signoz --trust
+```
+
+`--trust` is required for the bundled MCP server and hooks to activate; without
+it the skills load but the `signoz` server stays inactive. To skip the
+marketplace source, install the plugin subdirectory directly with
+`grok plugin install SigNoz/agent-skills#plugins/signoz --trust`.
+
+The plugin registers the `signoz` MCP server against the SigNoz Cloud `us`
+endpoint by default, so `us` users need no further configuration.
+
+**Set the endpoint.** For any other region, or for self-hosted SigNoz:
+
+```sh
+grok mcp add signoz -t http https://mcp.<region>.signoz.cloud/mcp -s user
+```
+
+Replace `<region>` with `us`, `us2`, `eu`, `eu2`, `in`, or `in2`. Find your
+region under **Settings -> Ingestion** in SigNoz, or see the
+[region reference](https://signoz.io/docs/ingestion/signoz-cloud/keys/). For
+self-hosted SigNoz, pass your own HTTP `/mcp` URL, for example
+`http://localhost:8000/mcp`. You can also run `/signoz-mcp-setup <region>` in a
+Grok session and let the skill do it.
+
+Use `-s user` to write `~/.grok/config.toml` (per machine, the default) or
+`-s project` to commit the endpoint to `./.grok/config.toml` for the whole team.
+Re-running the command updates the entry in place, so switching regions later is
+the same command again. A `[mcp_servers.signoz]` entry **replaces** the
+plugin-provided server of the same name, so you always end up with exactly one
+`signoz` server rather than a duplicate. For a one-off or CI run, skip config
+entirely and export `SIGNOZ_MCP_URL` instead — the bundled registration reads it.
+
+**Authenticate (SigNoz Cloud).** Run `/mcps` (or press Ctrl+L and open the MCP
+Servers tab), press `r` to reload after a config change, then select `signoz`
+and press `i` to start the OAuth flow. Self-hosted endpoints need no OAuth
+unless the server runs with `OAUTH_ENABLED=true`. Verify with
+`grok mcp doctor signoz`, which should report `1 healthy`.
+
+Update:
+
+```sh
+grok plugin marketplace update
+grok plugin update signoz
+```
+
+> **Already using SigNoz in Claude Code or Cursor?** Grok also reads
+> `~/.claude.json`, `~/.cursor/mcp.json`, and `.mcp.json` as compatibility
+> sources. If one of them already defines a `signoz` server, Grok loads it
+> *alongside* the plugin's — two live servers with the same name pointing at
+> different endpoints, which `grok mcp doctor` reports as two. Setting
+> `[mcp_servers.signoz]` with the `grok mcp add` command above outranks both
+> and collapses them to one.
+
 ### Antigravity CLI
 
 Install directly from this repository — Antigravity CLI stages the repo root as
@@ -229,8 +293,8 @@ with `OAUTH_ENABLED=true`). You can also edit the `serverUrl` value directly.
 ### Other MCP Clients
 
 The setup skill includes native config recipes for VS Code/GitHub Copilot,
-Claude Desktop, Gemini CLI, Devin CLI, Windsurf, Zed, Antigravity CLI, OpenCode,
-and generic HTTP MCP clients. These clients do not all consume this plugin
+Claude Desktop, Gemini CLI, Devin CLI, Grok Build, Windsurf, Zed, Antigravity
+CLI, OpenCode, and generic HTTP MCP clients. These clients do not all consume this plugin
 automatically; install or copy the skill where your client supports skills, or
 use the client-specific setup snippets in the skill as a reference.
 
@@ -253,6 +317,7 @@ npx skills add SigNoz/agent-skills --skill signoz-writing-clickhouse-queries    
 ├── .agents/plugins/marketplace.json        # Codex marketplace
 ├── .claude-plugin/marketplace.json         # Claude Code marketplace
 ├── .cursor-plugin/marketplace.json         # Cursor marketplace
+├── .grok-plugin/marketplace.json           # Grok Build marketplace
 ├── .devin-plugin/plugin.json               # Devin CLI plugin manifest
 ├── gemini-extension.json                   # Gemini CLI extension manifest
 ├── plugin.json                             # Antigravity plugin manifest (native, repo root)
@@ -262,9 +327,11 @@ npx skills add SigNoz/agent-skills --skill signoz-writing-clickhouse-queries    
 │   ├── .codex-plugin/plugin.json           # Codex plugin manifest
 │   ├── .claude-plugin/plugin.json          # Claude Code plugin manifest
 │   ├── .cursor-plugin/plugin.json          # Cursor plugin manifest
+│   ├── .grok-plugin/plugin.json            # Grok Build plugin manifest
 │   ├── .signoz_claude_mcp.json             # Claude Code MCP config
 │   ├── .mcp.json                           # Codex MCP config
 │   ├── .signoz_cursor_mcp.json             # Cursor MCP config
+│   ├── .signoz_grok_mcp.json               # Grok Build MCP config (env-interpolated)
 │   ├── hooks/                              # Auto-allow hooks
 │   └── skills/
 │       ├── signoz-mcp-setup/

--- a/plugins/signoz/.grok-plugin/plugin.json
+++ b/plugins/signoz/.grok-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "signoz",
+  "version": "2026.08.06",
+  "description": "Official SigNoz plugin for MCP setup, docs, queries, dashboards, and alerts",
+  "author": {
+    "name": "SigNoz",
+    "url": "https://signoz.io"
+  },
+  "homepage": "https://signoz.io",
+  "repository": "https://github.com/SigNoz/agent-skills",
+  "license": "MIT",
+  "keywords": [
+    "signoz",
+    "opentelemetry",
+    "observability",
+    "mcp",
+    "clickhouse",
+    "tracing",
+    "logging"
+  ],
+  "mcpServers": "./.signoz_grok_mcp.json",
+  "skills": "./skills/",
+  "hooks": "./hooks/hooks.json"
+}

--- a/plugins/signoz/.signoz_grok_mcp.json
+++ b/plugins/signoz/.signoz_grok_mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "signoz": {
+      "type": "http",
+      "url": "${SIGNOZ_MCP_URL:-https://mcp.us.signoz.cloud/mcp}"
+    }
+  }
+}

--- a/plugins/signoz/skills/signoz-mcp-setup/SKILL.md
+++ b/plugins/signoz/skills/signoz-mcp-setup/SKILL.md
@@ -2,8 +2,8 @@
 name: signoz-mcp-setup
 description: >
   Initialize or repair SigNoz MCP server configuration for Claude Code, Codex,
-  Cursor, VS Code/GitHub Copilot, Claude Desktop, Gemini CLI, Devin CLI,
-  Windsurf, Zed, Antigravity CLI, OpenCode, or another MCP client. Use this skill before any
+  Cursor, VS Code/GitHub Copilot, Claude Desktop, Gemini CLI, Devin CLI, Grok
+  Build, Windsurf, Zed, Antigravity CLI, OpenCode, or another MCP client. Use this skill before any
   SigNoz docs, query, dashboard, alert, or view workflow when
   `signoz_*` tools are unavailable, or when the user says "setup SigNoz
   MCP", "configure SigNoz plugin", "wrong region", "change SigNoz region",
@@ -44,6 +44,9 @@ on disk):
 
 - Claude Code, Codex, or Cursor plugin install: use the bundled plugin
   registration files.
+- Grok Build: use the Grok Build CLI recipe in `client-configs.md`. It ships a
+  bundled registration file, but its endpoint is configured through
+  `[mcp_servers.signoz]`, not by editing that file.
 - VS Code / GitHub Copilot, Claude Desktop, Gemini CLI, Devin CLI, Windsurf,
   Zed, Antigravity CLI, or OpenCode: use the matching native client recipe in
   `client-configs.md`.
@@ -63,6 +66,9 @@ tools (`signoz_search_docs` or `signoz_fetch_doc`) for this check.
 
 - For a Claude Code, Codex, or Cursor bundled plugin install, the reference
   flow's registration-file fallback applies.
+- For Grok Build, read `[mcp_servers.signoz]` from Grok's config scopes (or run
+  `grok mcp list`) instead. Its bundled `.signoz_grok_mcp.json` ships a working
+  default and is overridden by config, so it never reports the live state.
 - For every other client — including Devin CLI — do not read or search for
   `.signoz_claude_mcp.json`, `.mcp.json`, or `.signoz_cursor_mcp.json`. Those
   are bundled files for a different client's plugin distribution and are
@@ -174,6 +180,22 @@ This writes the user-level `[mcp_servers.signoz]` entry in Codex config and
 survives plugin cache updates. If editing TOML directly, preserve unrelated
 config and only set `url` for `mcp_servers.signoz`.
 
+For Grok Build, do not edit the bundled `.signoz_grok_mcp.json`. Write the
+resolved endpoint to Grok's own config, which replaces the plugin-provided
+`signoz` server and survives plugin updates:
+
+```sh
+grok mcp add signoz -t http <resolved-mcp-url> -s user
+```
+
+Use `-s project` instead when the user wants the endpoint committed with the
+repo in `./.grok/config.toml`. Re-running the command updates the existing
+entry rather than adding a second server. If `signoz` is already defined in
+more than one scope, update the highest-precedence one
+(`./.grok/config.toml` > `<repo-root>/.grok/config.toml` >
+`~/.grok/config.toml`) — editing a lower one would be silently shadowed. See
+the Grok Build CLI recipe in `client-configs.md`.
+
 For native client setup, use `client-configs.md`:
 
 - Edit an existing native client config only when the user named that client or
@@ -221,6 +243,11 @@ client-specific authentication step:
   connectors originate from Anthropic's cloud. Restart Claude Desktop after a
   local stdio change so it reloads `claude_desktop_config.json`; that file is
   only for command-based registration, not a hosted URL.
+- **Grok Build** — run `/mcps` (or press Ctrl+L and open the MCP Servers tab),
+  press `r` to reload after the config change, then select `signoz` and press
+  `i` to complete the OAuth flow in the browser. Self-hosted endpoints need no
+  OAuth unless the server runs with `OAUTH_ENABLED=true`. Diagnose with
+  `grok mcp doctor signoz`.
 - **Gemini CLI** — restart Gemini CLI if needed, then run `/mcp auth signoz`.
 - **Devin CLI** — start a new session so the updated `.devin/config.json` is
   picked up. For SigNoz Cloud, run `devin mcp login signoz` to complete OAuth.

--- a/plugins/signoz/skills/signoz-mcp-setup/references/client-configs.md
+++ b/plugins/signoz/skills/signoz-mcp-setup/references/client-configs.md
@@ -464,6 +464,39 @@ SIGNOZ_API_KEY = "<your-api-key>"
 LOG_LEVEL = "info"
 ```
 
+### Grok Build CLI stdio
+
+CLI (stdio is the default transport, so `-t` is not needed; everything after
+`--` is the server command):
+
+```sh
+grok mcp add signoz \
+  -e SIGNOZ_URL="<your-signoz-url>" \
+  -e SIGNOZ_API_KEY="<your-api-key>" \
+  -e LOG_LEVEL=info \
+  -s user \
+  -- "<path-to-binary>/signoz-mcp-server"
+```
+
+TOML:
+
+```toml
+[mcp_servers.signoz]
+command = "<path-to-binary>/signoz-mcp-server"
+args = []
+env = { SIGNOZ_URL = "<your-signoz-url>", SIGNOZ_API_KEY = "<your-api-key>", LOG_LEVEL = "info" }
+```
+
+Grok expands `${VAR}` and `${VAR:-default}` in `command`, `args`, and `env`
+values as well as `url`, so prefer a reference over a literal key:
+
+```sh
+grok mcp add signoz -e SIGNOZ_API_KEY='${SIGNOZ_API_KEY}' -s user -- "<path-to-binary>/signoz-mcp-server"
+```
+
+Keep the server name `signoz` here too — the stdio entry replaces the bundled
+HTTP registration of the same name rather than running alongside it.
+
 ### Zed
 
 Edit Zed settings.

--- a/plugins/signoz/skills/signoz-mcp-setup/references/client-configs.md
+++ b/plugins/signoz/skills/signoz-mcp-setup/references/client-configs.md
@@ -174,6 +174,61 @@ is copied into a versioned plugin cache, but `codex mcp add` writes the
 user-level Codex config. Verify the effective server with
 `codex mcp get signoz` or `codex mcp list`.
 
+### Grok Build CLI
+
+Grok ships the plugin's bundled `.signoz_grok_mcp.json`, which registers
+`signoz` against the `us` SigNoz Cloud endpoint by default and expands a
+`SIGNOZ_MCP_URL` environment override when one is set. **Do not edit that
+bundled file.** Write the endpoint to Grok's own config instead: a
+`[mcp_servers.signoz]` entry replaces the plugin-provided server of the same
+name, and unlike the bundled file it survives plugin updates.
+
+CLI (preferred):
+
+```sh
+grok mcp add signoz -t http https://mcp.us.signoz.cloud/mcp -s user
+```
+
+Use `-s user` for `~/.grok/config.toml` (per-machine, the sane default for a
+personal CLI) and `-s project` for `./.grok/config.toml` (team-shared,
+committed with the repo). Re-running the command updates the existing entry in
+place instead of adding a second server.
+
+TOML equivalent:
+
+```toml
+[mcp_servers.signoz]
+url = "https://mcp.us.signoz.cloud/mcp"
+enabled = true
+```
+
+Precedence for `[mcp_servers]`, highest first: `./.grok/config.toml` >
+`<repo-root>/.grok/config.toml` > `~/.grok/config.toml` > plugin-provided
+servers. Same-name entries replace lower-priority ones, so exactly one `signoz`
+server stays live. Check each scope for an existing `signoz` entry before
+writing a new one, and edit the highest-precedence file that already defines it.
+
+Writing the config entry is also what **de-duplicates** Grok's compatibility
+sources. Grok reads `~/.claude.json`, `~/.cursor/mcp.json`, and `.mcp.json`
+alongside its own config, and a compat-sourced server does not replace the
+plugin's — both load. A user who already has SigNoz configured in Claude Code or
+Cursor therefore ends up with two live `signoz` servers pointing at different
+endpoints (for example a self-hosted `http://localhost:8000/mcp` from
+`~/.claude.json` and the plugin's Cloud default), which `grok mcp doctor` reports
+as two separate servers. A `[mcp_servers.signoz]` entry outranks both and
+collapses them to one. If the user reports duplicate or unexpectedly-routed
+SigNoz tools in Grok, check `grok mcp doctor` for a second `signoz` and write the
+config entry.
+
+For a one-off or CI run, skip config entirely and export the environment
+override that the bundled registration reads:
+
+```sh
+export SIGNOZ_MCP_URL=https://mcp.eu.signoz.cloud/mcp
+```
+
+Verify with `grok mcp list` and diagnose with `grok mcp doctor signoz`.
+
 ### Gemini CLI
 
 CLI:
@@ -466,6 +521,13 @@ Edit `opencode.json` or `opencode.jsonc`.
 - Codex (self-hosted HTTP): no OAuth step unless the server runs with
   `OAUTH_ENABLED=true`; skip `codex mcp login` and verify the already-authenticated
   `signoz` server with `/mcp`.
+- Grok Build CLI (SigNoz Cloud): run `/mcps` (or press Ctrl+L and open the MCP
+  Servers tab), select `signoz`, and press `i` to start the OAuth flow. Press
+  `r` to reload the list after a config change. Tokens are cached in
+  `~/.grok/mcp_credentials.json`.
+- Grok Build CLI (self-hosted HTTP): no OAuth step unless the server runs with
+  `OAUTH_ENABLED=true`; press `r` in `/mcps` and verify the `signoz` server is
+  connected.
 - Gemini CLI: run `/mcp auth signoz`.
 - Devin CLI (SigNoz Cloud): start a new session, then run
   `devin mcp login signoz` to complete OAuth.

--- a/plugins/signoz/skills/signoz-mcp-setup/references/mcp-settings.md
+++ b/plugins/signoz/skills/signoz-mcp-setup/references/mcp-settings.md
@@ -29,6 +29,10 @@ Silently determine `signoz-server-state`, **only after the client is known**
 3. If the call fails, returns no tools, or cannot be attempted:
    - **Claude Code, Codex, or Cursor bundled plugin install** — read the
      plugin registration files below.
+   - **Grok Build** — read `[mcp_servers.signoz]` from `./.grok/config.toml`,
+     `<repo-root>/.grok/config.toml`, then `~/.grok/config.toml`, or run
+     `grok mcp list`. Grok ships a bundled registration too, but its endpoint
+     comes from config, so the bundled file says nothing about the live state.
    - **Any other client** — do not read or file-search for the bundled
      registration files below. They belong to a different client's plugin
      distribution and can exist on disk for unrelated reasons — most
@@ -54,6 +58,12 @@ a file search finds them:
 - `.signoz_claude_mcp.json` for Claude Code
 - `.mcp.json` for Codex
 - `.signoz_cursor_mcp.json` for Cursor
+
+The plugin also ships `.signoz_grok_mcp.json` for Grok Build, but Grok is **not**
+a bundled-file-editing client: it resolves the endpoint from
+`[mcp_servers.signoz]` in its own config, which replaces the plugin-provided
+server of the same name. Never edit `.signoz_grok_mcp.json` — use the Grok Build
+CLI recipe in `client-configs.md` instead.
 
 This reference file lives at `skills/signoz-mcp-setup/references/mcp-settings.md`,
 so the plugin root is two directories up from `skills/signoz-mcp-setup/`. That
@@ -87,9 +97,15 @@ The URL should use a concrete endpoint in all bundled registration files:
 ```
 
 Replace the entire `url` value with the resolved MCP endpoint. Do not keep
-`${SIGNOZ_MCP_URL:-...}` in bundled plugin MCP files; Codex treats it as a
-literal URL, and Cursor documents interpolation syntax that does not include
-shell-style defaults.
+`${SIGNOZ_MCP_URL:-...}` in these three bundled plugin MCP files; Codex treats
+it as a literal URL, and Cursor documents interpolation syntax that does not
+include shell-style defaults.
+
+Grok Build is the one exception, which is why its registration is a separate
+file: Grok expands `${VAR}` and `${VAR:-default}` in MCP `url`, `command`,
+`args`, `env`, and `headers` at load time, so `.signoz_grok_mcp.json`
+deliberately keeps `${SIGNOZ_MCP_URL:-https://mcp.us.signoz.cloud/mcp}`. Leave
+it intact and configure Grok through `[mcp_servers.signoz]`.
 
 If either bundled file contains any legacy `SIGNOZ_MCP_URL` wrapper, replace
 the full value with the concrete resolved URL.


### PR DESCRIPTION
## What

Adds first-class [Grok Build](https://docs.x.ai/build/overview) support to the SigNoz plugin, alongside Claude Code, Codex, Cursor, Gemini CLI, Devin CLI, and Antigravity CLI.

## Why

Grok Build reads Claude Code's plugin format, so `grok plugin marketplace add SigNoz/agent-skills` already resolved our Claude-format catalog and installed all 13 skills and the hooks. But the MCP server came up broken.

Claude's manifest points at `.signoz_claude_mcp.json`, whose `${user_config.SIGNOZ_MCP_URL}` placeholder is Claude-only syntax. Grok cannot expand it, so it registered a dead server keyed `mcp`:

```
mcp (http: ${user_config.SIGNOZ_MCP_URL})
  ✗ handshake failed (Client error: builder error / RelativeUrlWithoutBase)
```

Grok also has no install-time config prompt, so neither Claude Code's `userConfig` nor Cursor's `variables` gives users a way to pick a region.

## How

**Grok-native manifest** (Grok reads `.grok-plugin/plugin.json` in preference to `.claude-plugin/plugin.json`, verified against `grok 1.0.4`):

- `plugins/signoz/.grok-plugin/plugin.json`
- `plugins/signoz/.signoz_grok_mcp.json` — registers `signoz` at `${SIGNOZ_MCP_URL:-https://mcp.us.signoz.cloud/mcp}`

Grok expands `${VAR}` and `${VAR:-default}` in MCP `url`, `command`, `args`, `env`, and `headers` at load time. That is why this registration is a separate file from the Codex and Cursor ones, which must carry a concrete URL: Grok keeps the interpolation, so `us` works with zero configuration and `SIGNOZ_MCP_URL` covers CI.

**Marketplace catalog** — `.grok-plugin/marketplace.json`. Grok resolved the Claude-format catalog via compatibility, but this makes the listing first-class and is the schema the [xAI marketplace](https://github.com/xai-org/plugin-marketplace) expects for a future upstream submission.

**Region / self-hosted selection** — `grok mcp add signoz -t http <url> -s user|project`, or `/signoz-mcp-setup <region>`. This is more durable than the Claude and Cursor paths, which edit a file inside the plugin that resets on update; a config entry survives updates.

## On the server key

The key stays `signoz` deliberately. Grok's `[mcp_servers]` config **replaces** a plugin-provided server of the same name, so the collision is what makes `grok mcp add signoz` an override instead of a duplicate. A unique key such as `signoz-grok` would leave two live servers and double every tool.

The shared key also de-duplicates Grok's compatibility sources. Grok reads `~/.claude.json`, `~/.cursor/mcp.json`, and `.mcp.json` alongside its own config, and a compat-sourced `signoz` loads *next to* the plugin's rather than replacing it:

```
# no config entry — two live servers, different endpoints
signoz -> http://localhost:8000/mcp         [ claudeJson ]
signoz -> https://mcp.us.signoz.cloud/mcp   [ plugin ]

# with [mcp_servers.signoz] — collapses to one
signoz -> https://mcp.us.signoz.cloud/mcp   [ configToml ]
```

`grok mcp doctor` dials both and reports `2 failing`, so these are genuinely two servers, not a display artifact. The README and skill reference both call this out.

## Verified against `grok 1.0.4`

| Check | Result |
|---|---|
| `grok plugin validate ./plugins/signoz` | valid — 13 skills, hooks, MCP servers |
| Marketplace catalog resolves | `signoz`, 13 skills, hooks, MCP |
| Plugin default, no config | `https://mcp.us.signoz.cloud/mcp` |
| `SIGNOZ_MCP_URL` override | `https://mcp.in.signoz.cloud/mcp` |
| With `[mcp_servers.signoz]` | exactly one server, config wins |
| `.grok-plugin` vs `.claude-plugin` precedence | Grok manifest wins |
| `grok inspect` | 13/13 skills, hooks registered |

`grok mcp doctor signoz` ends at `OAuth authorization required`, which is the expected state until the user completes `/mcps` → `i`.

## Docs

- `README.md` — new **Grok Build** install section, matching the structure of the existing client sections
- `signoz-mcp-setup` — Grok recipe in `client-configs.md`, state-check and interpolation rules in `mcp-settings.md`, client identification and finish steps in `SKILL.md`
- `CONTRIBUTING.md` — manifest sync rules and the rationale for the `signoz` server key

## Note on the workflow change

`.github/workflows/auto-version-bump.yml` adds `.grok-plugin/plugin.json` to the CalVer bump, so Grok users receive updates. Without it that manifest silently pins to `2026.08.06` forever. Happy to split it into a separate PR if fork PRs touching workflows are awkward here.

## Follow-ups, not in this PR

- Submit to the [xAI plugin marketplace](https://github.com/xai-org/plugin-marketplace). It needs a pinned 40-char commit SHA, so it has to wait until this merges. Adds a SHA-bump step to our release process.
- Add Grok Build to the public docs at signoz.io/docs/ai/signoz-mcp-server (separate repo).
- `hooks/hooks.json` matches on `WebFetch`, Claude Code's tool name. The hook file loads in Grok, but I did not confirm Grok's fetch tool shares that name, so the auto-allow may not fire there.
