### PR TITLE
docs: remove AI-slop phrasing from skills, codify writing style

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,26 +24,42 @@ npx skills add https://github.com/anthropics/skills --skill skill-creator
 
 ### Conventions
 
-- **Skill naming.** Domain action skills use gerund form prefixed with `signoz-`, lowercase with hyphens — e.g. `signoz-creating-alerts`, `signoz-modifying-dashboards`, `signoz-investigating-alerts`. Setup/maintenance skills may use precise object-action names such as `signoz-mcp-setup`; avoid broad command names like `signoz-setup`. Both Anthropic's best-practices doc and the SigNoz Skills/MCP spec recommend gerund form for action skills. The `name` in SKILL.md frontmatter must exactly match the directory name.
+- **Skill naming.** Domain action skills use gerund form prefixed with `signoz-`, lowercase with hyphens, e.g. `signoz-creating-alerts`, `signoz-modifying-dashboards`, `signoz-investigating-alerts`. Setup/maintenance skills may use precise object-action names such as `signoz-mcp-setup`; avoid broad command names like `signoz-setup`. Both Anthropic's best-practices doc and the SigNoz Skills/MCP spec recommend gerund form for action skills. The `name` in SKILL.md frontmatter must exactly match the directory name.
 - **Descriptions.** Imperative, pushy, and third-person. State both what the skill does and when to trigger it, with explicit user-phrase examples and an "even if they don't say X explicitly" clause. Aim well under the 1024-char limit.
-- **"Do NOT use" lists.** Only mention sibling skills that are genuinely similar or competing — i.e. ones a user could plausibly invoke instead. Don't enumerate every other skill in the plugin; rotting cross-references erode trust faster than any clarity they add.
-- **MCP tool references.** Use the bare tool name (e.g. `` `signoz_get_alert` ``) in skill bodies. Every SigNoz tool is `signoz_`-prefixed, so the names are self-namespacing and resolve unambiguously even when other MCP servers are loaded. Bare names also stay correct regardless of the registration key — the Claude Code plugin keys the server `mcp`, so a `signoz:` qualifier no longer matches the live `mcp__plugin_signoz_mcp__*` namespace.
+- **"Do NOT use" lists.** Only mention sibling skills that are genuinely similar or competing, i.e. ones a user could plausibly invoke instead. Don't enumerate every other skill in the plugin; rotting cross-references erode trust faster than any clarity they add.
+- **MCP tool references.** Use the bare tool name (e.g. `` `signoz_get_alert` ``) in skill bodies. Every SigNoz tool is `signoz_`-prefixed, so the names are self-namespacing and resolve unambiguously even when other MCP servers are loaded. Bare names also stay correct regardless of the registration key: the Claude Code plugin keys the server `mcp`, so a `signoz:` qualifier no longer matches the live `mcp__plugin_signoz_mcp__*` namespace.
 - **MCP vs skill split.** MCP is the API; skills are the playbook. Tool definitions, input schemas, schema validation, searchable corpora, live tenant data, and release-sensitive reference data belong in MCP tools/resources. Workflows, conventions, decision rules, interpretation hints, pitfalls, and curated examples belong in skills.
-- **Schema reference.** The MCP server is the source of truth for tool input schemas, alert/dashboard JSON shape, and validation rules. Read the `signoz://*` resources rather than transcribing schema into a skill — duplicated schema rots out of sync.
+- **Schema reference.** The MCP server is the source of truth for tool input schemas, alert/dashboard JSON shape, and validation rules. Read the `signoz://*` resources rather than transcribing schema into a skill; duplicated schema rots out of sync.
 - **Reference files.** Move material >300 lines into `references/`, `scripts/`, or `assets/`. Any reference file longer than 100 lines must start with a `## Contents` table-of-contents.
-- **SKILL.md length.** Keep the body under 500 lines. Use progressive disclosure — link to specific reference files with a clear "read this when X" pointer rather than burying detail inline.
-- **Plugin manifests.** Keep `plugins/signoz/.codex-plugin/plugin.json`, `plugins/signoz/.cursor-plugin/plugin.json`, and `plugins/signoz/.grok-plugin/plugin.json` in sync with the Claude manifest when adding or removing skills. **Grok Build** reads `.grok-plugin/plugin.json` in preference to `.claude-plugin/plugin.json`, which is exactly why it exists: Claude's manifest points at `.signoz_claude_mcp.json`, whose `${user_config.SIGNOZ_MCP_URL}` placeholder is Claude-only syntax that Grok cannot expand (it fails the handshake with `RelativeUrlWithoutBase`). The Grok manifest points at `.signoz_grok_mcp.json` instead, which uses `${SIGNOZ_MCP_URL:-https://mcp.us.signoz.cloud/mcp}` — Grok expands `${VAR}` and `${VAR:-default}` in MCP `url`, `command`, `args`, `env`, and `headers` at load time. Keep the Grok server key as `signoz`: Grok's `[mcp_servers]` config **replaces** a plugin-provided server of the same name, so the shared key is what makes `grok mcp add signoz` an override instead of a duplicate. Do not give it a unique key like `signoz-grok` — that would leave two live servers and duplicate every tool. The shared key matters for de-duplication too: Grok scans `~/.claude.json`, `~/.cursor/mcp.json`, and `.mcp.json` as compatibility sources, so a user with SigNoz already configured in Claude Code or Cursor gets a second `signoz` from there, and only a same-named `[mcp_servers.signoz]` entry outranks both it and the plugin. The **Antigravity** plugin is native to the **repo root**: `plugin.json` (marker) + `mcp_config.json` (MCP registration, remote key `serverUrl`) + the root `skills` symlink. This lets `agy plugin install https://github.com/SigNoz/agent-skills` stage the repo root as a native Antigravity plugin. Antigravity's `plugin.json` schema is strict (`name` + `description` only, `additionalProperties: false`), so it intentionally carries **no `version`** and is not part of the CalVer bump. Do not point the root `mcp_config.json` at `${...}` interpolation — Antigravity does not resolve it (unlike `gemini-extension.json`, which keeps its `${SIGNOZ_MCP_URL}` prompt for Gemini CLI).
+- **SKILL.md length.** Keep the body under 500 lines. Use progressive disclosure: link to specific reference files with a clear "read this when X" pointer rather than burying detail inline.
+- **Plugin manifests.** Keep `plugins/signoz/.codex-plugin/plugin.json`, `plugins/signoz/.cursor-plugin/plugin.json`, and `plugins/signoz/.grok-plugin/plugin.json` in sync with the Claude manifest when adding or removing skills. **Grok Build** reads `.grok-plugin/plugin.json` in preference to `.claude-plugin/plugin.json`, which is exactly why it exists: Claude's manifest points at `.signoz_claude_mcp.json`, whose `${user_config.SIGNOZ_MCP_URL}` placeholder is Claude-only syntax that Grok cannot expand (it fails the handshake with `RelativeUrlWithoutBase`). The Grok manifest points at `.signoz_grok_mcp.json` instead, which uses `${SIGNOZ_MCP_URL:-https://mcp.us.signoz.cloud/mcp}`; Grok expands `${VAR}` and `${VAR:-default}` in MCP `url`, `command`, `args`, `env`, and `headers` at load time. Keep the Grok server key as `signoz`: Grok's `[mcp_servers]` config **replaces** a plugin-provided server of the same name, so the shared key is what makes `grok mcp add signoz` an override instead of a duplicate. Do not give it a unique key like `signoz-grok`; that would leave two live servers and duplicate every tool. The shared key matters for de-duplication too: Grok scans `~/.claude.json`, `~/.cursor/mcp.json`, and `.mcp.json` as compatibility sources, so a user with SigNoz already configured in Claude Code or Cursor gets a second `signoz` from there, and only a same-named `[mcp_servers.signoz]` entry outranks both it and the plugin. The **Antigravity** plugin is native to the **repo root**: `plugin.json` (marker) + `mcp_config.json` (MCP registration, remote key `serverUrl`) + the root `skills` symlink. This lets `agy plugin install https://github.com/SigNoz/agent-skills` stage the repo root as a native Antigravity plugin. Antigravity's `plugin.json` schema is strict (`name` + `description` only, `additionalProperties: false`), so it intentionally carries **no `version`** and is not part of the CalVer bump. Do not point the root `mcp_config.json` at `${...}` interpolation; Antigravity does not resolve it (unlike `gemini-extension.json`, which keeps its `${SIGNOZ_MCP_URL}` prompt for Gemini CLI).
+
+### Writing style
+
+Skill bodies are instructions an agent executes, not prose that persuades a reader. Keep them plain, concrete, and testable. Model-drafted text tends to arrive with a recognizable set of tics; strip them before opening the PR.
+
+- **No em dashes.** Use a colon for a label gloss (`` `spec.variables`: dashboard-level filters ``), a semicolon or period between independent clauses, parentheses for an aside, or a comma for brief apposition. The skill tree is em-dash-free; keep it that way.
+- **Banned words.** delve, foster, leverage, utilize, facilitate, empower, streamline, robust, seamless, cutting-edge, paradigm shift, game changer, transformative, elevate, embark, supercharge, harness, ever-evolving, meticulous, intricate, paramount, realm, tapestry, beacon, multifaceted. Say the plain thing instead: "use", "cut", "reliable".
+- **Cut empty phrases.** it's worth noting, it's important to note, at the end of the day, when it comes to, at its core, in today's world, the reality is, in order to, going forward. Delete them and state the instruction.
+- **No AI-slop rhetoric.** Skip binary contrasts ("it's not X, it's Y"), faux-insight setups ("what most people miss"), colon reveals ("the detail that makes it work: ..."), importance puffery ("plays a vital role"), weasel attribution ("experts agree"), rhetorical questions, and summary-recap endings. Make the claim directly.
+- **No punchy fragments or aphorisms.** A rule the agent must follow has to be stated as a rule. "No chips beat wrong chips" became "Offering no follow-ups is better than offering wrong ones"; "They detonate the bill" became "They multiply the metric bill". Sentence fragments and mic-drop kickers read as filler and are easy to misapply.
+- **No superficial `-ing` analysis.** Drop trailing "highlighting X", "underscoring Y", "showcasing Z" clauses. State the mechanism or the consequence.
+- **Be concrete.** Name the tool, field, threshold, or number. "Verify the key with `signoz_get_field_keys`" beats "ensure attribute correctness".
+- **Active voice, direct verbs.** "The server rejects a partial body", not "a partial body is rejected". "decide", not "make a decision".
+- **Formatting follows content.** No emoji in headings, no bold sprinkled mid-sentence for emphasis, no bullet list where two sentences read better, no header over a two-sentence section.
+
+Reviewers should treat any of the above in a diff as a change request. `grep -n '—'` over changed files is the fastest single check.
 
 ### Further reading
 
 These guides and internal specs shape the conventions above. When in doubt, follow them:
 
-- Anthropic — [Skill authoring best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices)
-- agentskills.io — [Best practices for skill creators](https://agentskills.io/skill-creation/best-practices)
-- agentskills.io — [Evaluating skill output quality](https://agentskills.io/skill-creation/evaluating-skills)
-- agentskills.io — [Optimizing skill descriptions](https://agentskills.io/skill-creation/optimizing-descriptions)
+- Anthropic: [Skill authoring best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices)
+- agentskills.io: [Best practices for skill creators](https://agentskills.io/skill-creation/best-practices)
+- agentskills.io: [Evaluating skill output quality](https://agentskills.io/skill-creation/evaluating-skills)
+- agentskills.io: [Optimizing skill descriptions](https://agentskills.io/skill-creation/optimizing-descriptions)
 - Agent Skills [specification](https://agentskills.io/specification)
-- SigNoz internal — [Skills & MCP Spec](https://www.notion.so/signoz/Skills-MCP-Spec-352fcc6bcd1980c89215deec882df42e#200b80ec35cb4012a246da1ccdc9d580)
+- SigNoz internal: [Skills & MCP Spec](https://www.notion.so/signoz/Skills-MCP-Spec-352fcc6bcd1980c89215deec882df42e#200b80ec35cb4012a246da1ccdc9d580)
 
 ## Plugin Versioning (CalVer)
 
@@ -62,13 +78,14 @@ A GitHub Actions workflow (`.github/workflows/auto-version-bump.yml`) opens or u
 
 Repository maintainers must enable **Settings → Actions → General → Allow GitHub Actions to create and approve pull requests** so the workflow's `GITHUB_TOKEN` can open the follow-up PR.
 
-**You do not need to manually bump versions** — after your PR is merged to `main`, the workflow opens or refreshes a follow-up version-bump PR.
+**You do not need to manually bump versions**: after your PR is merged to `main`, the workflow opens or refreshes a follow-up version-bump PR.
 
 ## Pull Request Checklist
 
 - [ ] Skill follows the [Agent Skills specification](https://agentskills.io/specification)
 - [ ] `name` in SKILL.md frontmatter matches the directory name
 - [ ] `README.md` updated if a new skill was added
+- [ ] Writing style respected: no em dashes, banned words, or AI-slop patterns (see **Writing style**)
 - [ ] **Plugin versions left unchanged** for the follow-up auto-bump PR
 - [ ] Changes tested locally with the relevant tool (Claude Code, Codex, Cursor, or Grok Build)
 

--- a/plugins/signoz/skills/signoz-creating-alerts/SKILL.md
+++ b/plugins/signoz/skills/signoz-creating-alerts/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: signoz-creating-alerts
 description: >
-  Create a new SigNoz alert rule from a natural-language intent — threshold,
+  Create a new SigNoz alert rule from a natural-language intent: threshold,
   anomaly, log-volume, error-rate, latency, or absent-data alerts across
   metrics, logs, traces, and exceptions. Make sure to use this skill whenever
   the user says "alert me when…", "notify me if…", "set up monitoring for…",
@@ -57,9 +57,9 @@ and ask through the host's supported clarification UI.
 
 What to include in the question:
 
-- **What is missing** — name it concretely (e.g. "which resource-attribute
+- **What is missing**: name it concretely (e.g. "which resource-attribute
   filter to use").
-- **Candidate lists** from discovery — concrete values per attribute, e.g.:
+- **Candidate lists** from discovery, with concrete values per attribute, e.g.:
   `service.name` → `frontend`, `checkout`, `payments`;
   `host.name` → `prod-api-1`, `prod-db-1`.
 - **Free-form input** so the user can name an unsurfaced value.
@@ -72,13 +72,13 @@ In autonomous mode, escalate or use upstream context; never call
 ### Step 1: Parse intent and check what's missing
 
 Extract from the user's request:
-1. **What to monitor** — signal type (metrics / logs / traces / exceptions)
+1. **What to monitor**: signal type (metrics / logs / traces / exceptions)
    and the specific condition (CPU, error rate, p99 latency, log count, ...).
-2. **Resource scope** — which service, host, namespace, or environment.
-3. **Threshold** — numeric value and comparison ("above 80%", "below 100/s").
-4. **Severity** — implicit from urgency words ("page" → critical, default
+2. **Resource scope**: which service, host, namespace, or environment.
+3. **Threshold**: numeric value and comparison ("above 80%", "below 100/s").
+4. **Severity**: implicit from urgency words ("page" → critical, default
    warning otherwise).
-5. **Routing** — explicit direct-channel name(s), or an explicit request to use a confirmed existing org notification policy.
+5. **Routing**: explicit direct-channel name(s), or an explicit request to use a confirmed existing org notification policy.
 
 Map signal phrasing to alert type:
 
@@ -114,17 +114,17 @@ inputs* above). Do not pick one.
 
 Once the scope is resolved (either provided by the user or discovered in
 Step 2), check for existing alerts before probing data or authoring a
-new config — both are wasted work if the user wants to update an
+new config; both are wasted work if the user wants to update an
 existing rule instead.
 
-Call `signoz_list_alert_rules` and **paginate through every page** —
+Call `signoz_list_alert_rules` and **paginate through every page**:
 `pagination.hasMore` is true until you have walked the full list. This lists
 *configured* alert rules (the durable state); do not use `signoz_list_alerts`,
 which returns currently triggered/active alert instances and will silently
 miss rules that are configured but not firing right now. Check for existing
 rules that match the user's intent (same signal + same scope + similar
 threshold). If a likely duplicate exists, surface it and ask whether to
-create a new one anyway, modify the existing one (out of scope here — use
+create a new one anyway, modify the existing one (out of scope here; use
 `signoz_update_alert`), or cancel.
 
 ### Step 4: Probe data existence for the chosen filter (fail fast)
@@ -132,8 +132,8 @@ create a new one anyway, modify the existing one (out of scope here — use
 Before authoring any alert config, confirm the **specific combination** the
 alert will watch (metric × service × any other filter) actually emits data.
 The most common silent failure is "metric exists in the catalog *and* the
-service exists in the catalog, but the service doesn't emit that metric"
-— each piece checks out in isolation, the alert saves successfully, and it
+service exists in the catalog, but the service doesn't emit that metric":
+each piece checks out in isolation, the alert saves successfully, and it
 silently never fires.
 
 Run a single probe over the last 1 hour using the same filter the alert
@@ -166,7 +166,7 @@ Inspect the result:
   - Service emits the metric but not in the expected time range → widen
     the probe window once (e.g. last 24h) before declaring no-data.
 
-**Exception — log-based crash / panic / OOMKilled / FATAL alerts.** These
+**Exception: log-based crash / panic / OOMKilled / FATAL alerts.** These
 intentionally have zero matches in a healthy system. The probe will
 return empty by design. Do not stop; instead, surface the zero-match
 result and ask the user to confirm before save. Treat this exception
@@ -197,11 +197,11 @@ For most user intents, the config is one of a small number of patterns:
 | Single-metric threshold | "alert when CPU > 80%", "p99 latency > 2s" |
 | Log volume threshold | "more than N error logs/min" |
 | Trace-based count or p-tile | "p99 span duration > 2s on checkout" |
-| Error-rate formula (A/B*100) — see "Common query shapes" below | "error rate > 5%" |
+| Error-rate formula (A/B*100); see "Common query shapes" below | "error rate > 5%" |
 | Anomaly detection (Z-score) | "alert me on anomalous traffic" |
 | Combined threshold + absence (only after approval) | "alert if data stops arriving" |
-| ClickHouse SQL alert — author SQL using the schema in `signoz://alert/examples` | non-trivial joins, custom aggregations the builder cannot express |
-| PromQL alert — delegate to `signoz-generating-queries` for the query, then return here | when user already has PromQL |
+| ClickHouse SQL alert; author SQL using the schema in `signoz://alert/examples` | non-trivial joins, custom aggregations the builder cannot express |
+| PromQL alert; delegate to `signoz-generating-queries` for the query, then return here | when user already has PromQL |
 
 **Threshold `op` and `matchType` values.** Prefer readable words; symbols and
 legacy numeric codes are accepted but discouraged. Valid `op` words are
@@ -218,14 +218,14 @@ Use `above` for anomaly rules: their absolute score covers spikes and drops.
 |  |  | last value breaches | `"last"` |
 
 **Defaults the skill applies (and surfaces in the preview):**
-- `evalWindow: 5m0s`, `frequency: 1m0s` — change only if the intent implies
+- `evalWindow: 5m0s`, `frequency: 1m0s`; change only if the intent implies
   a slower or faster cadence.
-- `matchType: "on_average"` for CPU / memory / latency — smooths
+- `matchType: "on_average"` for CPU / memory / latency, which smooths
   transient spikes.
-- `matchType: "at_least_once"` for error counts / error rates —
+- `matchType: "at_least_once"` for error counts / error rates, which
   catches any breach.
 
-**Severity defaults — derive intrinsic urgency, not just wording.** An explicit
+**Severity defaults: derive intrinsic urgency, not just wording.** An explicit
 cue overrides this table ("just FYI" → demote; "page me" → promote).
 
 | Alert intent | Default severity |
@@ -243,15 +243,15 @@ When the user's intent is ambiguous on severity (no urgency cue, no
 clearly-critical condition), default to `warning` and surface the choice
 in the preview so they can adjust.
 
-**Attribute names** — use exact keys returned by `signoz_get_field_keys`; when
+**Attribute names**: use exact keys returned by `signoz_get_field_keys`; when
 available they are usually OTel names such as `service.name`, not `service`.
 
-**Annotation templates** — include moving values; on-call sees the notification,
+**Annotation templates**: include moving values; on-call sees the notification,
 not the config:
 
-- `summary` — single-line headline. Include the resource scope and the
+- `summary`: single-line headline. Include the resource scope and the
   numeric value: `"checkoutservice error rate {{$value}}% above 3%"`.
-- `description` — longer message. Include `{{$value}}`, `{{$threshold}}`,
+- `description`: longer message. Include `{{$value}}`, `{{$threshold}}`,
   the groupBy values (e.g. `{{$labels.service_name}}`), and a sentence on
   what to do or where to look. For count-based alerts include the count
   explicitly: `"{{$value}} crash log lines in the last 5 minutes from
@@ -261,7 +261,7 @@ Use `{{$value}}` for the breaching value, `{{$threshold}}` for the target,
 and `{{$labels.<key>}}` for groupBy values (note SigNoz substitutes the
 dotted attribute name with underscores: `service.name` → `service_name`).
 
-#### Common query shapes — conventions
+#### Common query shapes: conventions
 
 Read `signoz://alert/examples` for the authoritative JSON patterns: error rate,
 p99 latency, log volume, combined threshold + absence, anomaly, PromQL, and
@@ -270,7 +270,7 @@ ClickHouse SQL. The conventions that don't live in the schema:
 - **Error-rate formula:** set `disabled: true` on the component
   queries A and B so only the formula F1 renders in the alert chart
   and notification. The raw counts are intermediate, not the alert
-  signal — forgetting this clutters the preview with three series and
+  signal, and forgetting this clutters the preview with three series and
   confuses the on-call engineer reading the notification.
 - **p99 latency:** the query emits nanoseconds, but express the threshold in
   the user's unit (for example `target: 2`, `targetUnit: "s"`); SigNoz converts
@@ -280,7 +280,7 @@ ClickHouse SQL. The conventions that don't live in the schema:
   size (for example, `60` for “per minute”). Do not invent comparison operators
   inside a formula such as `A * (B >= N)`.
 - **Log volume spike:** prefer `groupBy: service.name` over a hard
-  filter when the user said "any service" — groupBy provides the
+  filter when the user said "any service"; groupBy provides the
   scoping AND keeps the notification useful per-service.
 
 ### Step 6: Dry-run the full query and validate the threshold
@@ -289,26 +289,26 @@ Step 4 confirmed data flows. Step 6 does two things:
 
 1. **Validate query shape.** Run the full builder spec (with
    `groupBy`, formulas, disabled component queries, and non-string
-   filters) — Step 4's bare `count()` probe doesn't exercise these.
+   filters). Step 4's bare `count()` probe doesn't exercise these.
    The create-alert schema accepts queries that error at evaluation
    (numeric `groupBy`, unquoted bool filter, mismatched aggregation).
    Any HTTP 5xx or "filter type mismatch" = fix the config before
    proceeding to (2). `disabled: true` on formula component queries
    (A, B in `A * 100 / B`) is the *recommended* pattern, not a failure
-   — see Step 5.
+   (see Step 5).
 2. **Calibrate the threshold.** Given the validated query, would the
    alert have fired a sensible number of times in the last hour?
 
 Run the full primary query (or formula) over the last hour:
 - `signoz_execute_builder_query` for **all** builder, formula,
-  and PromQL queries — set `compositeQuery.queries[].type` to
+  and PromQL queries: set `compositeQuery.queries[].type` to
   `builder_query` / `builder_formula` / `promql` as appropriate. Alert PromQL
   specs carry only `name` / `query` / `legend` / `disabled`; dry-run execution
   PromQL specs may also carry `step` / `stats`. Still omit builder-only
   `stepInterval`.
   Put the string in `spec.query`, read
   `signoz://promql/instructions` for the UTF-8 quoted-selector form
-  SigNoz requires (`{"metric.name.with.dots"}` — not the underscored
+  SigNoz requires (`{"metric.name.with.dots"}`, not the underscored
   or bare-dotted forms), and keep alert PromQL fully literal: no `$var`,
   `$__rate_interval`, or other dashboard variable is evaluated.
 - Alert specs omit time bounds, but this dry-run cannot: set outer-query
@@ -319,7 +319,7 @@ Run the full primary query (or formula) over the last hour:
 - `signoz_aggregate_logs` / `signoz_aggregate_traces`
   when those fit better.
 - `signoz_query_metrics` when the alert query targets a single
-  known metric by `metricName` — the tool auto-applies aggregation
+  known metric by `metricName`; the tool auto-applies aggregation
   defaults and accepts `filter`, `groupBy`, and `formula` alongside.
   PromQL is not supported here; use `signoz_execute_builder_query`
   for that.
@@ -342,7 +342,7 @@ the user completeness cannot otherwise be guaranteed.
 
 Compute how many evaluation points breached the proposed threshold.
 Surface in the preview as **"would have fired N times in the last 1h"**.
-A 1h window is too short to grade most alerts — only the upper extreme
+A 1h window is too short to grade most alerts; only the upper extreme
 is actionable:
    - **N is large (e.g. > 30)** → likely alert storm. Surface and
      recommend tightening or adding hysteresis (`recoveryTarget`).
@@ -353,11 +353,11 @@ is actionable:
      whether the threshold is right. One hour can't distinguish "tuned
      well" from "barely caught a transient".
 3. **Exceptions:**
-   - **Anomaly alerts** — execute the underlying metric query without the
+   - **Anomaly alerts**: execute the underlying metric query without the
      anomaly `functions` transform to verify its shape and data, then skip the
      breach count (Z-scores aren't directly comparable to raw values). Be
      explicit that this validates the base query, not anomaly scoring.
-   - **Log-based crash / panic / OOMKilled / FATAL alerts** — these
+   - **Log-based crash / panic / OOMKilled / FATAL alerts**: these
      intentionally have zero matches in a healthy system. Step 4 has
      already surfaced the zero-match result and obtained user confirmation;
      skip the breach count.
@@ -394,7 +394,7 @@ tracked config.
 Place the resolved channel according to the rule schema:
 
 - `threshold_rule` / `promql_rule` (v2alpha1): attach direct-routing channels
-  to each `condition.thresholds.spec[N].channels` array — typically warning →
+  to each `condition.thresholds.spec[N].channels` array, typically warning →
   Slack only, critical → Slack + PagerDuty.
 - `anomaly_rule` (v1): direct routing only; thresholds are forbidden, so put channel names in top-level `preferredChannels`.
 
@@ -422,7 +422,7 @@ inputs and follow these rules:
   intermediate prose. After the create call succeeds, refer to the
   channel by name; after a failure, ask the user to re-paste rather than
   echoing what they sent.
-- **If the user instead asks "how do I set up a Slack channel?"** — that
+- **If the user instead asks "how do I set up a Slack channel?"**: that
   is a docs question, not a create-channel request. Answer with the docs
   flow (the SigNoz UI's Notification Channels page) and do not solicit
   the secret in chat at all. Prefer the UI path when the user seems
@@ -430,8 +430,8 @@ inputs and follow these rules:
 
 ### Step 8: Preview the prepared config
 
-Emit a one-paragraph plain-language summary of what will be created —
-no raw JSON dump. The user-facing facts (what fires, on what scope, at
+Emit a one-paragraph plain-language summary of what will be created,
+with no raw JSON dump. The user-facing facts (what fires, on what scope, at
 what threshold, where it routes) are captured by the summary; clicking
 through the JSON does not catch query-shape errors (Step 6's dry-run
 does).
@@ -444,7 +444,7 @@ does).
 ### Step 9: Save and report
 
 1. Call `signoz_create_alert` with the config from Step 8.
-2. **Name collision** — if `signoz_create_alert` returns a duplicate-name
+2. **Name collision**: if `signoz_create_alert` returns a duplicate-name
    error, **do not** suffix-append or call `signoz_update_alert`. Stop and
    tell the user the existing alert blocked creation; offer to use a
    different name or modify the existing alert (which is out of scope for
@@ -465,7 +465,7 @@ does).
   `signoz_create_alert`; a never-firing alert creates false confidence.
 - **Threshold operators use canonical words** Prefer valid words, never
   `equals`. Numeric codes (`"1"`–`"7"`)
-  are accepted but discouraged — same goes for `matchType`
+  are accepted but discouraged, as with `matchType`
   (`"on_average"` / `"at_least_once"`, not `"3"` / `"1"`).
 - **Signal must match alertType** `signal: "logs"` requires
   `LOGS_BASED_ALERT`. Mismatches fail validation.
@@ -484,15 +484,15 @@ does).
 
 ## Examples
 
-Four canonical alert flows — multi-severity metric threshold,
-error-rate formula, log-volume groupBy, anomaly detection — live in
+Four canonical alert flows (multi-severity metric threshold,
+error-rate formula, log-volume groupBy, anomaly detection) live in
 [`references/examples.md`](references/examples.md).
 
 ## Additional resources
 
 - `signoz://alert/instructions` and `signoz://alert/examples` MCP resources
-  — full alert config JSON schema, threshold codes, filter expression
+  hold the full alert config JSON schema, threshold codes, filter expression
   syntax, and version-current pattern examples. Always preferred over any
   transcribed copy.
-- `signoz-generating-queries` skill — for authoring PromQL or testing queries
+- `signoz-generating-queries` skill: for authoring PromQL or testing queries
   before wrapping them in an alert.

--- a/plugins/signoz/skills/signoz-creating-alerts/references/examples.md
+++ b/plugins/signoz/skills/signoz-creating-alerts/references/examples.md
@@ -1,4 +1,4 @@
-# Examples — `signoz-creating-alerts`
+# Examples: `signoz-creating-alerts`
 
 Four canonical alert flows: simple metric threshold, error-rate formula,
 log-volume groupBy, and anomaly detection.
@@ -23,7 +23,7 @@ log-volume groupBy, and anomaly detection.
    `service.name = 'checkout'`.
 6. Dry-run via `signoz_execute_builder_query` over last 1h: returns data,
    would have fired 0 times (clean baseline).
-7. Emits a one-paragraph plain-language summary — no JSON dump.
+7. Emits a one-paragraph plain-language summary, no JSON dump.
 8. Calls `signoz_create_alert`. Reports created alert with ID, threshold
    summary, channel routing, and dry-run result.
 
@@ -47,7 +47,7 @@ log-volume groupBy, and anomaly detection.
    `pagination.hasMore=false`; the user picks `slack-payments`. If none fits,
    it offers `signoz_create_notification_channel` with user-provided config.
 6. Dry-run on last 1h: payments error rate hovered around 0.3%, would have
-   fired 0 times. Clean — not too tight.
+   fired 0 times. Clean, not too tight.
 7. Preview, save, report.
 
 ## Log-volume threshold with groupBy
@@ -70,7 +70,7 @@ log-volume groupBy, and anomaly detection.
    `signoz_list_notification_channels` result, or calls it through
    `pagination.hasMore=false`; the user picks a Slack channel. If none fits,
    it offers `signoz_create_notification_channel` with user-provided config.
-5. Dry-run: returned per-service counts, max in last 1h was 87 — would
+5. Dry-run: returned per-service counts, max in last 1h was 87, which would
    have fired 0 times. Within reasonable headroom.
 6. Preview, save, report.
 

--- a/plugins/signoz/skills/signoz-creating-dashboards/SKILL.md
+++ b/plugins/signoz/skills/signoz-creating-dashboards/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: signoz-creating-dashboards
 description: >
-  Create a new SigNoz dashboard from a natural-language intent — import a
+  Create a new SigNoz dashboard from a natural-language intent: import a
   curated template (PostgreSQL, Redis, JVM, k8s, hostmetrics, APM, LLM,
   etc.) when one fits, or build a custom dashboard from scratch with
   metric / trace / log panels. Make sure to use this skill whenever the
   user says "create a dashboard for…", "set up monitoring for…",
   "build me a dashboard…", "I need observability for…", "import a
   dashboard template", or asks to track / visualize a service, database,
-  cluster, or AI/LLM platform — even if they don't explicitly say
+  cluster, or AI/LLM platform, even if they don't explicitly say
   "dashboard". Also use it when someone wants to "monitor", "watch", or
   "see metrics for" a technology and the natural answer is a dashboard.
 argument-hint: <natural-language dashboard intent>
@@ -31,7 +31,7 @@ This skill calls SigNoz MCP server tools (`signoz_create_dashboard`,
 `signoz_aggregate_logs`, `signoz_aggregate_traces`, etc.).
 Before running the workflow, confirm the `signoz_*` tools are
 available. If they are not, the SigNoz MCP server is not installed or
-configured — run `signoz-mcp-setup` first to initialize or repair the MCP
+configured; run `signoz-mcp-setup` first to initialize or repair the MCP
 connection. Do not fall back to raw HTTP calls or fabricate dashboard JSON
 without the MCP tools.
 
@@ -53,7 +53,7 @@ Do NOT use when the user wants to:
 
 Dashboard creation is a write operation. Guessing here clutters the
 shared workspace with empty or wrongly-scoped dashboards someone else has
-to clean up. The skill enforces a soft input contract — most fields have
+to clean up. The skill enforces a soft input contract; most fields have
 sensible defaults, but a few cannot be guessed:
 
 | Input | Required | Source if missing |
@@ -68,14 +68,14 @@ sensible defaults, but a few cannot be guessed:
 If a required input is missing and cannot be discovered, **stop before
 calling any write tool** and ask the user. The host application decides
 how the question is surfaced (a structured clarification tool, inline
-`<assistant_question>` tags, an interactive prompt, etc.) — follow the
+`<assistant_question>` tags, an interactive prompt, etc.); follow the
 host's UI rendering rules.
 
 What to include in the question:
 
-- **What is missing** — name the input concretely (e.g. "no service or
+- **What is missing**: name the input concretely (e.g. "no service or
   cluster specified for the custom build").
-- **Candidate lists** populated from your discovery calls — concrete
+- **Candidate lists** populated from your discovery calls: concrete
   values per attribute the user can pick from. Example shape:
   `service.name` → `frontend`, `checkout`, `payments`, `inventory`;
   `k8s.cluster.name` → `prod-us-east-1`, `staging`.
@@ -106,14 +106,14 @@ integer or string `limit` / `offset` values.
 **Match by relevance** Compare each existing
 dashboard's lowercased `spec.display.name`, `.description`, and `tags` against the
 user's technology/domain. Surface only matches a human would recognize
-as the same thing — a "redis" dashboard does not match a "postgresql"
+as the same thing: a "redis" dashboard does not match a "postgresql"
 request just because both have a `database` tag. Collect each match's
 `spec.display.name`, `id`, and `createdAt` for the next step.
 
-### Step 2: Ask the user — modify or create
+### Step 2: Ask the user (modify or create)
 
 Present exactly two options (no template-import as a separate top-level
-choice — that's an internal decision in Step 3b):
+choice; that's an internal decision in Step 3b):
 
 - **Duplicates found:** "There are already these similar dashboards:
   [list with name, id, created-at]. Want me to (a) modify one of
@@ -130,35 +130,35 @@ Wait for the user's choice. "modify" → Step 3a. "create new" / confirm
 
 Hand off immediately to `signoz-modifying-dashboards` with the chosen
 dashboard id and the user's intent. Do not call
-`signoz_update_dashboard` or `signoz_patch_dashboard` from this skill —
+`signoz_update_dashboard` or `signoz_patch_dashboard` from this skill;
 modification is out of scope. (See "Scope boundary" in Guardrails.)
 
 #### Step 3b: Create a new dashboard
 
 Run the template lookup first. The user has already agreed to create
-new — the lookup decides *how* we build it.
+new; the lookup decides *how* we build it.
 
 Call `signoz_list_dashboard_templates` once with no arguments.
-The full catalog (~95 entries) returns in a single call — read it
+The full catalog (~95 entries) returns in a single call; read it
 in-context and pick the best match for the user's intent. When several
 entries plausibly fit, present the top 3–5 and let the user choose.
 
 Branch on the result:
-- **Single clear template match** — proceed to Step 3b-i (template
+- **Single clear template match**: proceed to Step 3b-i (template
   import). Briefly tell the user "I found a pre-built [title] template
   and will use it" so they know what's being created; do not block on
   yes/no.
-- **Multiple plausible matches** — present them and ask the user to
+- **Multiple plausible matches**: present them and ask the user to
   pick. Once picked, proceed to Step 3b-i.
-- **Template matches the technology but not the requested signals** —
+- **Template matches the technology but not the requested signals**:
   common for any specific ask ("Kafka, but I want consumer fetch rate by
   client"). Not "no template": import it, then hand the extra panels to
   `signoz-modifying-dashboards` with the new id. Building from scratch
   discards the curated baseline for no gain.
-- **No template** — proceed to Step 3b-ii (custom build). That means no
+- **No template**: proceed to Step 3b-ii (custom build). That means no
   catalog entry for the technology, not an entry that looks imperfect or
   aimed at a different metric family. Template bodies are not readable
-  before import, so a suspected mismatch is only a hypothesis — and the
+  before import, so a suspected mismatch is only a hypothesis, and the
   Step 3b-i.1 probe sits *inside* the import path, so it cannot justify
   leaving that path. Probe first, then decide.
 
@@ -169,7 +169,7 @@ Branch on the result:
 > `signoz_import_dashboard`. Do not shell out, fetch raw GitHub
 > URLs, or invent other tool names.
 > `signoz_import_dashboard` takes the template `path` from the
-> catalog entry and creates the dashboard in one call — you do not need
+> catalog entry and creates the dashboard in one call, so you do not need
 > to fetch the JSON yourself or call `signoz_create_dashboard`
 > afterwards.
 
@@ -178,26 +178,26 @@ Branch on the result:
 Before calling `signoz_import_dashboard`, confirm the template's
 signals are actually being ingested. The most common silent failure for
 template imports is "the template imports cleanly but every panel reads
-'No data' because the technology isn't being scraped" — the user only
+'No data' because the technology isn't being scraped": the user only
 discovers it after clicking through to a useless dashboard.
 
 Since we don't fetch the template body up front, base the probe on the
 catalog entry's `category`, `title`, and `keywords` plus the user's
-stated technology. Pick up to ~5 representative signals and check them
-— keep the total small:
+stated technology. Pick up to ~5 representative signals and check
+them; keep the total small:
 
 - **Metric-based templates** (most infra/runtime templates): call
   `signoz_list_metrics` with `searchText` set to the technology
   prefix (e.g. `searchText="postgresql"`). Empty result → metric family
   is not being ingested. *Early out:* if this returns empty, declare
-  "None present" and skip the rest of the metric probes — they will all
+  "None present" and skip the rest of the metric probes; they will all
   return zero. Use `timeRange` for a relative window, or pass
   `start`/`end` (unix-ms strings) when you need an exact window instead
   of the server default.
 - **Trace-based templates** (APM-style): call
   `signoz_aggregate_traces` with `aggregation=count`,
   `timeRange=1h`. No filter is needed for the "is anything flowing"
-  probe — adding `filter="service.name EXISTS"` is fragile and
+  probe; adding `filter="service.name EXISTS"` is fragile and
   unnecessary. Zero count → no traces flowing.
 - **Log-based templates**: call `signoz_aggregate_logs` with
   `aggregation=count`, `timeRange=1h`, no filter. Zero count → no logs.
@@ -254,15 +254,15 @@ explicitly rejected the suggested template, or
 
 Ask the user (skip questions whose answer is already clear from intent):
 
-1. **Signals** — metrics, traces, logs, or a combination.
-2. **Specific signals** — which metrics, which span attributes, which
+1. **Signals**: metrics, traces, logs, or a combination.
+2. **Specific signals**: which metrics, which span attributes, which
    log severities matter most.
-3. **Resource scope** — which service(s), namespace(s), cluster(s), or
+3. **Resource scope**: which service(s), namespace(s), cluster(s), or
    environment(s).
-4. **Variables** — what should be a dropdown vs. a hard-coded filter
+4. **Variables**: what should be a dropdown vs. a hard-coded filter
    (typical: `service.name`, `deployment.environment.name`,
    `k8s.cluster.name`).
-5. **Sections** — group panels into Overview / Latency / Errors /
+5. **Sections**: group panels into Overview / Latency / Errors /
    Saturation, or another structure that fits the domain.
 
 If the user is non-specific ("just make me something useful for X"),
@@ -274,18 +274,18 @@ The MCP guideline applies: **always prefer resource-attribute filters**.
 Before authoring panels, confirm the names you'll use exist and emit
 data:
 
-1. **Metrics** — call `signoz_list_metrics` with `searchText`
+1. **Metrics**: call `signoz_list_metrics` with `searchText`
    tied to the technology (e.g. `searchText="postgresql"`) to get the
-   *exact* OTel metric names. Catalog presence ≠ data flowing — for
+   *exact* OTel metric names. Catalog presence ≠ data flowing; for
    any metric you intend to use, follow up with `signoz_query_metrics`
    on a representative window to confirm it actually has datapoints.
-2. **Resource attributes** — call `signoz_get_field_keys` with
+2. **Resource attributes**: call `signoz_get_field_keys` with
    `fieldContext=resource` for the relevant signal to enumerate
    available attributes; call `signoz_get_field_values` on the
    ones you'll use as variables to confirm concrete values exist. Note
    that the live data may use older OTel semconv (e.g.
-   `deployment.environment` rather than `deployment.environment.name`)
-   — always trust the discovered key over the one in the defaults
+   `deployment.environment` rather than `deployment.environment.name`);
+   always trust the discovered key over the one in the defaults
    table.
 
 If **none** of the discovered signals return data, tell the user the
@@ -296,7 +296,7 @@ or stop. Wait for the user's choice before building.
 ##### Step 3b-ii.3: Read the dashboard MCP resources
 
 These are the source of truth for the JSON schema, panel types, query
-builder shape, and layout rules — do not transcribe schema text into
+builder shape, and layout rules; do not transcribe schema text into
 this skill, it will rot out of sync with the server. Read the core
 resources before authoring panel JSON.
 
@@ -307,16 +307,16 @@ resources before authoring panel JSON.
 > an existing dashboard of the same signal type (metrics / traces /
 > logs) and read its `spec.panels` map for worked panel shapes.
 
-- `signoz://dashboard/instructions` — title, tags, description,
+- `signoz://dashboard/instructions`: title, tags, description,
   layout, variables.
-- `signoz://dashboard/widgets-instructions` — 7 panel types and layout
+- `signoz://dashboard/widgets-instructions`: 7 panel types and layout
   rules.
-- `signoz://dashboard/widgets-examples` — complete panel configs with
-  all required fields (the most important resource — every panel must
+- `signoz://dashboard/widgets-examples`: complete panel configs with
+  all required fields (the most important resource; every panel must
   include `kind`, `spec.display`, `spec.plugin`, and exactly one query).
-- `signoz://dashboard/examples` — whole create payloads with panels,
+- `signoz://dashboard/examples`: whole create payloads with panels,
   layouts, and variables assembled.
-- `signoz://dashboard/query-builder-example` — query builder reference.
+- `signoz://dashboard/query-builder-example`: query builder reference.
 
 Add signal-specific resources as needed:
 
@@ -329,7 +329,7 @@ Add signal-specific resources as needed:
 - Metrics (ClickHouse): `signoz://dashboard/clickhouse-schema-for-metrics`
   + `signoz://dashboard/clickhouse-metrics-example`.
 - Metrics (Query Builder aggregation rules):
-  `signoz://metrics-aggregation-guide` — required for picking valid
+  `signoz://metrics-aggregation-guide`: required for picking valid
   `timeAggregation` / `spaceAggregation` per metric type.
 - Traces (Query Builder): `signoz://traces/query-builder-guide`.
 - Logs (Query Builder): `signoz://logs/query-builder-guide`.
@@ -353,7 +353,7 @@ PromQL range selector inside a Builder query.
 Use SigNoz kinds and JSON types exactly. `signoz/TimeSeriesPanel` means time series
 (never Grafana `timeseries`); variables are `ListVariable` / `TextVariable` carrying a
 `signoz/DynamicVariable`, `signoz/CustomVariable`, or `signoz/QueryVariable` plugin.
-The envelope is `schemaVersion: "v6"` plus `spec`, with no top-level `name` on create —
+The envelope is `schemaVersion: "v6"` plus `spec`, with no top-level `name` on create;
 the server derives that immutable machine label from `spec.display.name`. Tags are
 `{key, value}` objects; defer full shapes to the resources.
 
@@ -370,9 +370,9 @@ through `content.$ref`. During import or rebuild, drop any grid item whose
 | Section structure (infra/runtime) | Overview / Saturation / Errors / Latency | domain-specific |
 | Headline panels (services) | request rate, error rate, p50/p95/p99 latency, throughput | omit those that don't apply |
 | Headline panels (infra) | resource utilization (CPU, mem), saturation, error/restart counts, throughput | tailor to the technology |
-| Counter render unit (rate vs. count) | per-second rate | per-interval **increase** count over a wider window (24h–7d) for any low-volume / bursty / human-paced counter — requests, **error counts**, restarts, OOM kills — where `/sec` renders as tiny decimals (e.g. `0.03/s`); gauges (CPU/mem/queue depth) are already absolute and unaffected; note `increase` rescales its y-axis with the selected range, so prefer it deliberately, not by reflex |
-| Variables (services) | `service.name`, `deployment.environment` (or `deployment.environment.name` — verify which exists via `signoz_get_field_keys`) | add `k8s.cluster.name` / `k8s.namespace.name` when k8s-flavored |
-| Variables (k8s/infra) | `k8s.cluster.name`, `k8s.namespace.name` (or `host.name` for hostmetrics) | drop `service.name` — it is rarely populated on infra signals |
+| Counter render unit (rate vs. count) | per-second rate | per-interval **increase** count over a wider window (24h–7d) for any low-volume / bursty / human-paced counter (requests, **error counts**, restarts, OOM kills) where `/sec` renders as tiny decimals (e.g. `0.03/s`); gauges (CPU/mem/queue depth) are already absolute and unaffected; note `increase` rescales its y-axis with the selected range, so prefer it deliberately, not by reflex |
+| Variables (services) | `service.name`, `deployment.environment` (or `deployment.environment.name`; verify which exists via `signoz_get_field_keys`) | add `k8s.cluster.name` / `k8s.namespace.name` when k8s-flavored |
+| Variables (k8s/infra) | `k8s.cluster.name`, `k8s.namespace.name` (or `host.name` for hostmetrics) | drop `service.name`; it is rarely populated on infra signals |
 | Layout | 2-column grid (`width: 6`), 12 columns wide; every item has `0 <= x < 12`, `1 <= width <= 12`, `x + width <= 12` | full-width (`x: 0, width: 12`) for tables and time-series with many series |
 | GroupBy on per-service panels | `service.name` resource attribute | drop when filtering to a single service |
 
@@ -383,7 +383,7 @@ coordinates are per-Grid, so adding to an earlier section leaves later
 sections untouched.
 
 **Title and description** The dashboard title (`spec.display.name`) should name the
-technology and the scope clearly: "PostgreSQL — prod-us-east-1", not
+technology and the scope clearly: "PostgreSQL - prod-us-east-1", not
 just "PostgreSQL". `spec.display.description` should answer "what is this for" in one
 sentence. Tags are `{key, value}`: technology + signal types + environment when known.
 
@@ -408,8 +408,8 @@ if formula-input cardinality can exceed 10000.
 
 Two rules `widgets-examples` does not call out, but
 `signoz_create_dashboard` enforces: **no `JSON.stringify` on
-arrays/objects** — `spec`, `panels`, `layouts`, `tags`, and `variables`
-are native JSON — and **one query per panel**, so a panel plotting two
+arrays/objects** (`spec`, `panels`, `layouts`, `tags`, and `variables`
+are native JSON) and **one query per panel**, so a panel plotting two
 series carries a single `signoz/CompositeQuery` envelope holding both.
 
 ##### Step 3b-ii.6: Dry-run before save (mandatory)
@@ -418,7 +418,7 @@ For every query-bearing panel, read the compact
 [`dashboard-to-query-builder-v5` reference](./references/dashboard-to-query-builder-v5.md).
 The panel already stores the execution spec, so lift it into the outer envelope
 and call `signoz_execute_builder_query` with that payload, never panel JSON.
-Dry-run over a short absolute Unix-ms window — usually the last 30-60 minutes,
+Dry-run over a short absolute Unix-ms window (usually the last 30-60 minutes),
 never the panel's display range by reflex; apply the reference's dry-run hygiene
 rules before widening or retrying after a timeout. Use representative variable
 values in the dry-run copy and keep `$var` in `signoz_create_dashboard`.
@@ -431,7 +431,7 @@ accepted absent telemetry.
 ##### Step 3b-ii.7: Preview, save, report
 
 1. **Preview** Emit a one-paragraph plain-language summary of what
-   will be created — no JSON dump. A 20–30 panel payload is hundreds
+   will be created; no JSON dump. A 20–30 panel payload is hundreds
    of lines the user cannot meaningfully review in chat. Call out any
    validation gap the user explicitly accepted.
 
@@ -459,7 +459,7 @@ accepted absent telemetry.
 - **Always paginate `signoz_list_dashboards`** Stopping at page
   1 misses duplicates and produces clutter.
 - **Duplicate check first** The user's only two upfront options are
-  "modify an existing one" or "create a new one" — never offer
+  "modify an existing one" or "create a new one"; never offer
   template-import as a separate top-level choice.
 - **Template-first on the create path** Once the user has chosen to
   create, always run `signoz_list_dashboard_templates` before any
@@ -479,7 +479,7 @@ accepted absent telemetry.
 - **Prefer OTel attribute names** `service.name` not `service`,
   `host.name` not `host`. Wrong names produce empty panels. Verify the
   exact key (`deployment.environment` vs `deployment.environment.name`,
-  for instance) against `signoz_get_field_keys` rather than guessing —
+  for instance) against `signoz_get_field_keys` rather than guessing;
   installs running classic OTel semconv emit the no-`.name` form.
 - **No metric guessing** For custom builds, verify metric names with
   `signoz_list_metrics` before authoring. Wrong names produce
@@ -492,11 +492,11 @@ accepted absent telemetry.
   plugin kinds from Step 3b-ii.4.
 - **Scope boundary** This skill creates dashboards. The moment the
   user asks to modify, edit, rearrange, or extend an existing dashboard
-  — including immediately after import — hand off to
+  (including immediately after import), hand off to
   `signoz-modifying-dashboards`. Do not call
   `signoz_update_dashboard` or `signoz_patch_dashboard` from this skill.
 
 ## Examples
 
-Four canonical flows — template happy path, template choice, duplicate
-found, custom build — live in [`references/examples.md`](references/examples.md).
+Four canonical flows (template happy path, template choice, duplicate
+found, custom build) live in [`references/examples.md`](references/examples.md).

--- a/plugins/signoz/skills/signoz-creating-dashboards/references/dashboard-to-query-builder-v5.md
+++ b/plugins/signoz/skills/signoz-creating-dashboards/references/dashboard-to-query-builder-v5.md
@@ -38,14 +38,14 @@ The query envelope's `kind` is the outer `requestType`, unchanged:
 graph/bar/histogram panels save `time_series`; table/pie/value save `scalar`;
 list saves `raw`; an existing trace panel saves `trace`. These are the only
 execution values; never invent `aggregate`, `table`, or `timeseries`. There is
-no trace panel plugin to author — use `signoz/ListPanel` with raw trace rows.
+no trace panel plugin to author; use `signoz/ListPanel` with raw trace rows.
 
 Put every dependency in one `compositeQuery.queries` array. A panel holds
 exactly one query envelope, and its plugin `kind` picks the execution `type`
 while `plugin.spec` becomes that entry's `spec`, unchanged:
 `signoz/BuilderQuery` -> `builder_query`; `signoz/Formula` ->
 `builder_formula`; `signoz/TraceOperator` -> `builder_trace_operator`.
-A `signoz/CompositeQuery` already holds `{type, spec}` members — lift its
+A `signoz/CompositeQuery` already holds `{type, spec}` members, so lift its
 `spec.queries` into `compositeQuery.queries` as-is.
 
 Bounds and ordering are part of the saved spec, so execute what the panel
@@ -65,7 +65,7 @@ stores rather than re-deriving it, and author them when you build the panel:
   payload. Raw and trace-request traces use timestamp desc; raw logs add id
   desc; aggregate logs/traces use the primary aggregation desc. A metrics
   `order` key is the composed `spaceAggregation(timeAggregation(metricName))`
-  expression — the bare metric name is rejected, while `__result` and groupBy
+  expression; the bare metric name is rejected, while `__result` and groupBy
   keys are accepted; a formula orders by `__result`.
 - Time-series top-N ranks groups over the whole window and can omit a
   short-lived local spike. Narrow filters or grouping if formula-input

--- a/plugins/signoz/skills/signoz-creating-dashboards/references/examples.md
+++ b/plugins/signoz/skills/signoz-creating-dashboards/references/examples.md
@@ -1,9 +1,9 @@
-# Examples — `signoz-creating-dashboards`
+# Examples: `signoz-creating-dashboards`
 
 Walkthroughs of the four canonical flows: template import with data,
 template import without data, duplicate-found choice, and custom build.
 
-## Template import — happy path
+## Template import: happy path
 
 **User:** "Create a dashboard for my PostgreSQL database"
 
@@ -19,18 +19,18 @@ template import without data, duplicate-found choice, and custom build.
    → returns `postgresql.connections.usage`, `postgresql.commits`, etc.
    Data flowing.
 5. Calls `signoz_import_dashboard path=postgresql/postgresql.json`.
-6. Reports: "Created 'PostgreSQL Overview' (id `…`) — 24 panels
+6. Reports: "Created 'PostgreSQL Overview' (id `…`) with 24 panels
    across Overview / Connections / Throughput / Replication. Variables:
    `postgresql.host.name`. Probe found data for all headline panels.
    Want me to adjust anything, or wire alerts for slow queries?"
 
-*Variant — no PG data ingested:* the probe in step 4 returns empty;
+*Variant, no PG data ingested:* the probe in step 4 returns empty;
 agent emits the verbatim no-data warning from Step 3b-i.1 and waits for
 the user to choose between "create anyway" and "stop".
 
 ## Template choice when several match
 
-**User:** "I need an APM dashboard — what do you have?"
+**User:** "I need an APM dashboard. What do you have?"
 
 **Agent:**
 1. `signoz_list_dashboards` (paginated) → no APM dashboard.
@@ -44,7 +44,7 @@ the user to choose between "create anyway" and "stop".
 6. Imports, reports panels and variables. Offers to wire latency
    alerts via `signoz-creating-alerts`.
 
-## Duplicate found — modify-or-create
+## Duplicate found: modify-or-create
 
 **User:** "Set up monitoring for Redis" (existing "Redis - Overview"
 dashboard found)
@@ -56,10 +56,10 @@ template. If (a), hands off to `signoz-modifying-dashboards` with the
 dashboard's id and the user's intent (no `signoz_get_dashboard` call
 from this skill).
 
-## Custom build — no template match
+## Custom build: no template match
 
 **User:** "Create a dashboard to track our payment processing pipeline"
-(custom build — no template match)
+(custom build, no template match)
 
 **Agent:**
 1. Duplicate check (none) and creation confirmation as above.
@@ -80,8 +80,8 @@ from this skill).
 6. Per-panel dry-run via `signoz_execute_builder_query` for
    **every** panel (envelope lift per Step 3b-ii.6, with
    `name` preserved on each `builder_query.spec` so formulas
-   resolve). Emits a one-paragraph plain-language summary — no JSON
-   dump — then calls `signoz_create_dashboard`. Reports the id,
+   resolve). Emits a one-paragraph plain-language summary, no JSON
+   dump, then calls `signoz_create_dashboard`. Reports the id,
    panel count and section breakdown, and which variables are
    wired. Offers to wire error-rate alerts via
    `signoz-creating-alerts`.

--- a/plugins/signoz/skills/signoz-explaining-alerts/SKILL.md
+++ b/plugins/signoz/skills/signoz-explaining-alerts/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: signoz-explaining-alerts
 description: >
-  Describe what an existing SigNoz alert rule does in plain language —
+  Describe what an existing SigNoz alert rule does in plain language:
   the signal it watches, the threshold and evaluation behavior, the
   notification routing, and a one-line fire-frequency summary so the user
   knows whether the alert has been active. Make sure to use this skill
   whenever the user asks "what does this alert do", "explain alert X",
   "walk me through this rule", "how does my [Y] alert work", "is this
   alert configured correctly", or otherwise asks for an interpretation
-  of an existing alert's configuration. Static explanation only — for
+  of an existing alert's configuration. Static explanation only; for
   diagnosing a specific firing incident, use `signoz-investigating-alerts`.
 argument-hint: <alert name or rule id>
 ---
@@ -19,7 +19,7 @@ Decode an existing SigNoz alert's configuration into a plain-language
 explanation. The skill is read-only and stays focused on the rule
 itself: what it watches, when it fires, where it notifies. A single
 line of fire-frequency data is included to ground the explanation, but
-this skill does **not** investigate any specific fire — that is
+this skill does **not** investigate any specific fire; that is
 `signoz-investigating-alerts`'s job.
 
 ## Prerequisites
@@ -51,12 +51,12 @@ Do NOT use when the user wants to:
 | Alert identifier (rule ID or name) | yes | `$ARGUMENTS`, recent context, or fuzzy match |
 
 If the input is missing or ambiguous, this skill is **best-effort** (not
-strict — read-only operations are cheap to recover from):
+strict; read-only operations are cheap to recover from):
 
 1. Call `signoz_list_alert_rules`, paginate through every page, and find
    the closest name match.
 2. State the interpretation in the response:
-   "Interpreting your request as alert 'High Error Rate — Checkout' (id 42).
+   "Interpreting your request as alert 'High Error Rate - Checkout' (id 42).
    If you meant a different one, tell me the name or id."
 3. Proceed with the explanation. The user can correct after.
 
@@ -67,7 +67,7 @@ strict — read-only operations are cheap to recover from):
 If the user provided a rule ID (UUID or legacy numeric ID), skip to Step 2.
 Otherwise:
 
-1. Call `signoz_list_alert_rules` and **paginate every page** —
+1. Call `signoz_list_alert_rules` and **paginate every page**:
    `pagination.hasMore` is true until the full list is walked.
 2. Match by name (case-insensitive substring). If multiple match,
    present the candidates and ask which one (interactive) or pick the
@@ -75,7 +75,7 @@ Otherwise:
 
 ### Step 2: Fetch the full configuration
 
-Call `signoz_get_alert` with the rule id. This is **mandatory** — the
+Call `signoz_get_alert` with the rule id. This is **mandatory**: the
 list response does not include the full condition / thresholds /
 notification settings, and explanations based on the name alone are
 guesses.
@@ -110,58 +110,58 @@ If the alert never fired in the window, say so explicitly:
 separately; disabled rules can still have earlier fires in the lookback.
 
 This single line grounds the explanation. Do **not** drill into specific
-fires here — that's `signoz-investigating-alerts`.
+fires here; that's `signoz-investigating-alerts`.
 
 ### Step 4: Build the explanation
 
 The single most useful thing for the user is a tight summary. Lead
 with a **TL;DR that directly answers the question they asked**, not a
 generic alert summary. The TL;DR is the only thing some users will
-read — burying their answer under a fixed template forces them to
+read; burying their answer under a fixed template forces them to
 scroll for what they wanted in the first place.
 
 Match the TL;DR shape to the user's question:
 
-- **"What does this alert do?" / "Explain X"** — describe what fires:
+- **"What does this alert do?" / "Explain X"**: describe what fires:
   > **TL;DR**: Fires when `<condition>` for `<scope>`, notifies
   > `<channel>`. `<fire-frequency line>`.
 
 - **"Is it configured correctly?" / "Audit this" / "Anything I should
-  change?"** — lead with the **verdict and the top 1–3 changes**, not
+  change?"**: lead with the **verdict and the top 1–3 changes**, not
   the description of what fires:
   > **TL;DR**: Mostly well-configured, but recommend: (1) add
-  > `alertOnAbsent` — currently a crashed service stays silent; (2)
+  > `alertOnAbsent` (currently a crashed service stays silent); (2)
   > fix annotation template `{{$topic}}` → `{{$labels.topic}}` (won't
   > interpolate); (3) split critical to PagerDuty (both tiers
   > currently route to Slack). `<fire-frequency line>`.
 
-- **"How does X work?" / "Explain the count guard"** — answer the
+- **"How does X work?" / "Explain the count guard"**: answer the
   mechanism in 1–2 sentences before any framing:
   > **TL;DR**: The count guard is a `having: count() > 50` clause on
-  > query A — any 1-minute bucket with ≤50 spans is dropped before
+  > query A: any 1-minute bucket with ≤50 spans is dropped before
   > evaluation, so low-traffic minutes can't fire the alert.
 
-- **"What's the threshold?" / focused config question** — state the
+- **"What's the threshold?" / focused config question**: state the
   exact thing they asked about:
   > **TL;DR**: Threshold is **3 standard deviations** (z-score), not
   > a raw rate value. Daily seasonality means the model compares
   > each hour against historical norms for that hour.
 
 Always include the fire-frequency line and `disabled` status if
-non-default — those ground every kind of TL;DR. But put the answer to
+non-default; those ground every kind of TL;DR. But put the answer to
 the user's specific question first.
 
 After the TL;DR, write the explanation in prose, organized into the
 four sections below. **Skip any section that has nothing meaningful to
-add** — empty severity labels, default notification settings, vanilla
+add**: empty severity labels, default notification settings, vanilla
 annotations don't deserve a header. Short and skimmable beats
 perfunctorily complete; the user is not reading a checklist.
 
-**1. What it watches** — one short paragraph. Combine signal type
+**1. What it watches**: one short paragraph. Combine signal type
 (metrics / logs / traces / exceptions), what the query measures, and
 scope. Translate the query to operational language; for formulas, name
 each sub-query (A, B, …) and state what F1 (or whichever
-`selectedQueryName` triggers) computes — e.g. "F1 = A × 100 / B → error
+`selectedQueryName` triggers) computes, e.g. "F1 = A × 100 / B → error
 percentage". Decode filter operators (`=` equals, `!=` not equals,
 `IN` / `NOT IN`, `LIKE` / `ILIKE`, `CONTAINS`, `REGEXP`, `EXISTS` /
 `NOT EXISTS`); enumerate `IN` / `NOT IN` value lists so the user can
@@ -170,13 +170,13 @@ verify them. Name each `groupBy` dimension and its practical effect
 
 For **anomaly rules** (`ruleType: anomaly_rule`), explicitly state that
 the threshold is in **standard deviations from the learned pattern, not
-the raw value** — this is the most common point of confusion. Include
+the raw value**; this is the most common point of confusion. Include
 `algorithm` (`standard`, which is z-score based), `seasonality` (hourly /
 daily / weekly), and how
 lower/higher targets shift sensitivity (lower → more noise, higher →
 only extreme deviations).
 
-**2. When it fires** — one paragraph covering threshold + timing.
+**2. When it fires**: one paragraph covering threshold + timing.
 Decode the threshold spec into plain English using these mappings:
 
 - `op` codes: `1` above, `2` below, `3` equal, `4` not equal, `5`
@@ -195,7 +195,7 @@ Describe timing as "checks every `<frequency>` over the last
 `<evalWindow>`", and mention that with `at_least_once` a single-point
 breach triggers, while `all_the_times` requires the full window.
 
-**3. Where it notifies** — decode effective routing, not just fields in
+**3. Where it notifies**: decode effective routing, not just fields in
 isolation. If `notificationSettings.usePolicy` is true, say that org policy
 matches the rule/static/dynamic labels and that threshold channels are ignored.
 Otherwise, a v2 `threshold_rule` or `promql_rule` routes only through each
@@ -209,21 +209,21 @@ result if needed. Also explain `notificationSettings.groupBy` (bundling) and
 `renotify` (interval + states). Skip this section only when routing is already
 unambiguous in the TL;DR.
 
-**4. Notable concerns** — flag *only* what's non-default and worth the
+**4. Notable concerns**: flag *only* what's non-default and worth the
 user's attention. Don't list every absent field; focus on the
-high-leverage ones:
+high-impact ones:
 
 - **`alertOnAbsent` missing** when the signal is critical: silent data
   loss (crashed service, broken instrumentation) won't trigger the
   alert. Always call this out for production-tier rules.
 - **`alertOnAbsent: true` but `nodata` not in `renotify.alertStates`**:
-  the absent-data fire pages once and then goes silent — easy to miss.
+  the absent-data fire pages once and then goes silent (easy to miss).
 - **Template variable bugs**: `{{$topic}}` won't interpolate; the
   correct form is `{{$labels.topic}}`. Dots in label keys become
   underscores (`service.name` → `{{$labels.service_name}}`).
-- **Multiple severity tiers but `labels.severity` missing on the rule**
-  — breaks label-based routing policies. Common gap.
-- **All tiers route to the same channel** — defeats the point of
+- **Multiple severity tiers but `labels.severity` missing on the rule**:
+  breaks label-based routing policies. Common gap.
+- **All tiers route to the same channel**: defeats the point of
   graduated thresholds.
 - **High-cardinality `groupBy`** (e.g. `pod.name` × `partition`) →
   notification-storm risk during cluster-wide events.
@@ -231,9 +231,9 @@ high-leverage ones:
   description says "for over 5 minutes" but `matchType=at_least_once`
   fires on first breach within the window).
 - **Alert name doesn't match the filter target** (e.g. name says
-  "checkout" but filter targets `payments`) — call this out.
+  "checkout" but filter targets `payments`); call this out.
 
-If none of these apply, omit the section. Better silent than padded.
+If none of these apply, omit the section rather than pad it.
 
 If the user asked only "what does this alert do", stop here. The audit
 (Step 5) is for "is it configured correctly" / "audit this" /
@@ -246,26 +246,26 @@ Only assess when asked or when the request implies it (audit, review,
 "is this configured correctly"). Keep assessment grounded in what's
 actually in the config:
 
-- **Threshold calibration** — appropriate for the signal? Consider
+- **Threshold calibration**: appropriate for the signal? Consider
   service criticality and traffic.
-- **matchType fit** — `at_least_once` is sensitive (catches transients);
+- **matchType fit**: `at_least_once` is sensitive (catches transients);
   `all_the_times` is conservative; `on_average` smooths noise.
-- **Window vs frequency** — short window + `at_least_once` can be noisy.
+- **Window vs frequency**: short window + `at_least_once` can be noisy.
   Long window can delay detection.
-- **Multi-severity** — alerts with both warning and critical thresholds
+- **Multi-severity**: alerts with both warning and critical thresholds
   enable graduated response. Single-severity alerts miss this.
-- **Notification routing** — critical → high-urgency channels (PagerDuty);
+- **Notification routing**: critical → high-urgency channels (PagerDuty);
   warning → low-urgency (Slack).
-- **Missing runbook / description** — if `annotations` are empty or
+- **Missing runbook / description**: if `annotations` are empty or
   default, suggest adding context.
-- **Absent-data monitoring** — for critical signals, recommend
+- **Absent-data monitoring**: for critical signals, recommend
   `alertOnAbsent: true` if it isn't set.
-- **GroupBy cardinality** — high-cardinality groupBy fields can produce
+- **GroupBy cardinality**: high-cardinality groupBy fields can produce
   many independent alert series; flag potential notification storms.
-- **Filter completeness** — for `IN` / `NOT IN` filters with explicit
+- **Filter completeness**: for `IN` / `NOT IN` filters with explicit
   value lists, flag values that look out of place or missing values
   that seem expected.
-- **Fire frequency vs threshold** — if Step 3 shows the alert fires
+- **Fire frequency vs threshold**: if Step 3 shows the alert fires
   many times a day (>10/day in the 7d window), the threshold is likely
   too tight; if it never fires and the user is asking because they
   expected it to, the threshold may be too loose or the query may be
@@ -274,14 +274,14 @@ actually in the config:
 ### Step 6: Offer next steps
 
 Surface up to 3 follow-up intents based on what the explanation
-revealed — things like investigating a recent fire, running the
+revealed: things like investigating a recent fire, running the
 underlying query to see current values, adjusting a threshold, or
 creating a related alert for a coverage gap. Use your judgment; do
 not pad to 3.
 
 Skip follow-ups entirely when the user is purely inspecting ("what
-does this alert do?") and signals no further intent. No chips beat
-wrong chips.
+does this alert do?") and signals no further intent. Offering no
+follow-ups is better than offering wrong ones.
 
 ## Guardrails
 
@@ -294,7 +294,7 @@ wrong chips.
   expressions, and query JSON into operational language. Show raw JSON
   only if the user asks.
 - **Decode every sub-query.** For formula alerts, explain each builder
-  query and the formula. Don't gloss over a formula as "error rate" —
+  query and the formula. Don't gloss over a formula as "error rate";
   show the user what A, B, and F1 each compute.
 - **Anchor to the actual config.** Don't speculate based on the alert
   name. If the name says "checkout" but the filter targets `payments`,
@@ -316,8 +316,8 @@ wrong chips.
 **User:** "Explain my checkout error rate alert"
 
 **Agent:**
-1. `signoz_list_alert_rules` (paginated) → finds "High Error Rate —
-   Checkout" id 42.
+1. `signoz_list_alert_rules` (paginated) → finds
+   "High Error Rate - Checkout" id 42.
 2. `signoz_get_alert id=42` → traces formula (A errored spans / B
    total spans × 100), single critical threshold at 5%, `op=1`,
    `matchType=1`, channel `pagerduty-oncall`.
@@ -329,16 +329,16 @@ wrong chips.
    > spans) exceeds 5% at any point in the last 5 min, pages
    > `pagerduty-oncall`. Fired 3 times in the last 7d (last 2h ago).
    >
-   > **What it watches** — traces from `service.name = 'checkout'`.
+   > **What it watches**: traces from `service.name = 'checkout'`.
    > Query A counts spans with `has_error = true`, query B counts all
    > spans, F1 = A × 100 / B is the error percentage; the alert
    > triggers on F1.
    >
-   > **When it fires** — `op=above`, `matchType=at_least_once`, target
-   > 5%. Checks every 1 min over the last 5 min — a single elevated
+   > **When it fires**: `op=above`, `matchType=at_least_once`, target
+   > 5%. Checks every 1 min over the last 5 min; a single elevated
    > minute fires it.
    >
-   > **Notable** — no `recoveryTarget` (could flap near 5%); no
+   > **Notable**: no `recoveryTarget` (could flap near 5%); no
    > `alertOnAbsent` (a checkout outage that drops traffic to zero
    > won't trigger this rule).
 
@@ -346,7 +346,7 @@ wrong chips.
 
 ---
 
-**User:** "Explain alert rule 17 — is it well configured?"
+**User:** "Explain alert rule 17 - is it well configured?"
 
 **Agent:**
 1. `signoz_get_alert id=17` → metrics, `system.cpu.utilization`,
@@ -354,26 +354,26 @@ wrong chips.
    filter `deployment.environment.name = 'production'`, groupBy
    `host.name`.
 2. `signoz_get_alert_history id=17` → has not fired in last 7d.
-3. The user asked "is it well configured?" — the TL;DR leads with the
+3. The user asked "is it well configured?"; the TL;DR leads with the
    **verdict**, not a generic description. Then explanation + full
    audit:
 
    > **TL;DR**: Mostly well-configured (dual-threshold + `on_average`
    > is the right call for CPU), but two gaps to fix: (1) no
-   > `alertOnAbsent` — a crashed agent silently stops reporting and
-   > this rule won't catch it; (2) annotations are default — a
-   > runbook URL would help on-call. Has not fired in the last 7d
+   > `alertOnAbsent` (a crashed agent silently stops reporting and
+   > this rule won't catch it); (2) annotations are default (a
+   > runbook URL would help on-call). Has not fired in the last 7d
    > (could mean production is healthy or thresholds too loose).
    >
-   > **What it watches** — `system.cpu.utilization` on
+   > **What it watches**: `system.cpu.utilization` on
    > `deployment.environment.name = 'production'`, grouped by
    > `host.name` (fires per host).
    >
-   > **When it fires** — `op=above`, `matchType=on_average`, two tiers
+   > **When it fires**: `op=above`, `matchType=on_average`, two tiers
    > (warning 80%, critical 90%) over a 5-min window. Short spikes
-   > don't fire — smoothing is correct for CPU.
+   > don't fire; smoothing is correct for CPU.
    >
-   > **Notable concerns** — same as TL;DR fixes above; nothing else
+   > **Notable concerns**: same as TL;DR fixes above; nothing else
    > non-default.
 
 4. Offers next steps.
@@ -393,13 +393,13 @@ wrong chips.
    > than **3 standard deviations** (not raw latency, not a fixed value)
    > from its learned daily pattern. Fired once in the last 7d.
    >
-   > **What it watches** — `http.server.request.duration` for
+   > **What it watches**: `http.server.request.duration` for
    > `service.name = 'api-gateway'`, evaluated as a Z-score anomaly
-   > with **daily seasonality** — the model learns the typical pattern
+   > with **daily seasonality**: the model learns the typical pattern
    > for each hour of day, so peak-hour latency won't false-trigger if
    > it matches the historical norm for that hour.
    >
-   > **When it fires** — when |Z-score| > 3, i.e. the value is more
+   > **When it fires**: when |Z-score| > 3, i.e. the value is more
    > than 3 standard deviations away from the expected pattern. Lower
    > target → more sensitive (more noise); higher → only extreme
    > deviations. The threshold is **not** in seconds or milliseconds.

--- a/plugins/signoz/skills/signoz-explaining-dashboards/SKILL.md
+++ b/plugins/signoz/skills/signoz-explaining-dashboards/SKILL.md
@@ -2,12 +2,12 @@
 name: signoz-explaining-dashboards
 description: >
   Explain what an existing SigNoz dashboard shows in plain operational
-  language — the panels, queries, variables, and what to watch for on
+  language: the panels, queries, variables, and what to watch for on
   each. Make sure to use this skill whenever the user asks "explain this
   dashboard", "what does my [X] dashboard show", "walk me through the
   panels", "what should I watch for on this dashboard", or "help me
   understand this dashboard", or otherwise asks for an interpretation of
-  a dashboard's contents — even if they don't say "explain" explicitly.
+  a dashboard's contents, even if they don't say "explain" explicitly.
   Also use it when someone is onboarding to a service and wants to
   understand what its existing observability looks like.
 ---
@@ -19,7 +19,7 @@ description: >
 This skill calls SigNoz MCP server tools (`signoz_get_dashboard`,
 `signoz_list_dashboards`). Before running the workflow, confirm the
 `signoz_*` tools are available. If they are not, the SigNoz MCP server
-is not installed or configured — run `signoz-mcp-setup` first to initialize or
+is not installed or configured; run `signoz-mcp-setup` first to initialize or
 repair the MCP connection. Do not guess at a dashboard's contents from its
 title alone.
 
@@ -40,7 +40,7 @@ Do NOT use when:
 
 Use a supplied id or a dashboard resource that includes its id directly.
 For any name-only request, call `signoz_list_dashboards` and resolve the name to
-an id, matching on `spec.display.name`. **Cover the whole listing** — narrow with
+an id, matching on `spec.display.name`. **Cover the whole listing**: narrow with
 the `filter` argument, re-run unfiltered when it comes back empty, and page by
 raising `offset` by `limit` until you have covered `total`. Never pass a
 dashboard name to `signoz_get_dashboard` or conclude it is missing from the
@@ -51,37 +51,37 @@ explain.
 
 ### Step 2: Fetch the full dashboard configuration
 
-Call `signoz_get_dashboard` with the dashboard id. This is **mandatory** — you
+Call `signoz_get_dashboard` with the dashboard id. This is **mandatory**; you
 need the complete JSON to explain the dashboard accurately. Never guess based on
 the title alone.
 
 Examine the response to understand:
-- `spec.display.name`, `.description`, `tags` — the dashboard identity and author-provided context
-- `spec.variables` — dashboard-level filters (dropdowns the user can change)
-- `spec.panels` — a map keyed by panel id: the panels, their plugin kinds, titles, and queries
-- `spec.layouts` — Grid entries placing panels in the 12-column grid via `content.$ref`
-- each Grid's `spec.display.title` — the section a panel belongs to
+- `spec.display.name`, `.description`, `tags`: the dashboard identity and author-provided context
+- `spec.variables`: dashboard-level filters (dropdowns the user can change)
+- `spec.panels` (a map keyed by panel id): the panels, their plugin kinds, titles, and queries
+- `spec.layouts`: Grid entries placing panels in the 12-column grid via `content.$ref`
+- each Grid's `spec.display.title`: the section a panel belongs to
 
 ### Step 3: Build the explanation
 
 Structure your explanation in this order:
 
-**1. Overview** — One paragraph summarizing the dashboard's purpose, what it
+**1. Overview**: one paragraph summarizing the dashboard's purpose, what it
 monitors, and what data sources it draws from (metrics, traces, logs). Mention
 the `tags` if they provide useful context.
 
-**2. Variables and filters** — Explain each variable:
-- Name (`spec.name`, the `$handle` queries reference) and what it filters — for a
+**2. Variables and filters**: explain each variable:
+- Name (`spec.name`, the `$handle` queries reference) and what it filters; for a
   `signoz/DynamicVariable` that is `plugin.spec.name` on `plugin.spec.signal`
 - Kind: `signoz/DynamicVariable` (auto-populated from telemetry),
   `signoz/QueryVariable` (query-driven dropdown), `signoz/CustomVariable`
   (configured choices), or a `TextVariable` (free-form input)
 - Whether it supports multi-select (`allowMultiple`) and an "ALL" option
-- Note if any panels do NOT reference a variable in their `filter.expression` —
+- Note if any panels do NOT reference a variable in their `filter.expression`:
   changing that variable dropdown would not affect those panels, which can be
   confusing
 
-**3. Panel-by-panel walkthrough** — Group panels by Grid section: walk
+**3. Panel-by-panel walkthrough**. Group panels by Grid section: walk
 `spec.layouts` in order, using each Grid's `spec.display.title` as the section
 header and following its `spec.items` (by `y` then `x`) to the panels they
 `$ref`. For a single untitled Grid, walk panels in position order and organize
@@ -90,16 +90,16 @@ by logical theme. For each panel:
   `signoz/TimeSeriesPanel`, `signoz/NumberPanel` (single value),
   `signoz/TablePanel`, `signoz/BarChartPanel`, `signoz/PieChartPanel`,
   `signoz/HistogramPanel`, `signoz/ListPanel` (raw rows)
-- **What it shows** — interpret the panel's one query in plain language. For
+- **What it shows**: interpret the panel's one query in plain language. For
   `signoz/BuilderQuery`, explain the signal, aggregation, `filter.expression`,
   and `groupBy`. For a `signoz/CompositeQuery`, explain each member and how the
   formula combines them. For ClickHouse SQL or PromQL, translate the query
   intent into plain English.
-- **What to watch for** — describe what healthy looks like and what patterns
+- **What to watch for**: describe what healthy looks like and what patterns
   indicate trouble. Be specific: "sustained usage above 80% means..." not just
   "watch if it's high". Anchor advice to the actual metric being queried, not
   generic domain knowledge.
-- **Unit** — mention `plugin.spec.formatting.unit` so the user knows how to read the values
+- **Unit**: mention `plugin.spec.formatting.unit` so the user knows how to read the values
 
 For panels with complex queries:
 - **Formulas** (inside a composite): explain each member (A, B, ...) separately,
@@ -107,7 +107,7 @@ For panels with complex queries:
 - **Functions** (rate, derivative, clampMin/Max, timeShift): explain the transform
   in plain terms (e.g., "rate converts the raw counter into a per-second value")
 
-**4. Dashboard health observations** — After the walkthrough, note any structural
+**4. Dashboard health observations**. After the walkthrough, note any structural
 issues you spotted:
 - Panels with no query, or a composite whose members are all disabled
 - Panels in `spec.panels` that no grid item references (they never render)
@@ -119,22 +119,22 @@ issues you spotted:
 - Very wide step intervals that could hide spikes
 - Panels with high-cardinality groupBy that may produce unreadable charts
 
-**5. Coverage gaps** — Based on what the dashboard actually monitors, note
+**5. Coverage gaps**. Based on what the dashboard actually monitors, note
 significant observability areas that are absent. Only mention gaps that are
-directly related to the technology or domain the dashboard covers — do not
+directly related to the technology or domain the dashboard covers; do not
 speculate about unrelated areas. Frame as suggestions: "You may want to consider
 adding panels for X to cover Y."
 
 ### Step 4: Offer next steps
 
 Surface up to 3 follow-up intents based on what the explanation
-surfaced — things like running a specific panel's underlying query,
+surfaced, such as running a specific panel's underlying query,
 filling a coverage gap, or wiring an alert for an actionable threshold
 the user has not yet alerted on. Use your judgment; do not pad to 3.
 
 Skip follow-ups when the user was clearly just onboarding to the
-dashboard ("what is this?") and showed no further intent. No chips
-beat wrong chips.
+dashboard ("what is this?") and showed no further intent. Offering no
+follow-ups is better than offering wrong ones.
 
 ## Guardrails
 
@@ -153,7 +153,7 @@ beat wrong chips.
 - **Paginate dashboard listing**: When searching for a dashboard by name, always
   paginate through all pages of `signoz_list_dashboards` before concluding a
   dashboard does not exist.
-- **All query types**: Handle builder, ClickHouse SQL, and PromQL queries — each
+- **All query types**: Handle builder, ClickHouse SQL, and PromQL queries; each
   requires a different interpretation approach. For builder queries, read the
   aggregations, filter expression, and groupBy. For raw SQL/PromQL, parse the
   query string and explain the intent.
@@ -165,20 +165,20 @@ beat wrong chips.
 **User:** "Explain my PostgreSQL dashboard"
 
 **Agent:**
-1. Calls `signoz_list_dashboards` (paginates all pages) — finds "PostgreSQL
+1. Calls `signoz_list_dashboards` (paginates all pages): finds "PostgreSQL
    Overview" dashboard with id `abc-123`.
-2. Calls `signoz_get_dashboard` with id `abc-123` — gets full configuration.
+2. Calls `signoz_get_dashboard` with id `abc-123`: gets full configuration.
 3. Provides structured explanation:
    - **Overview**: "This dashboard monitors PostgreSQL database health across
      connections, query performance, buffer cache efficiency, and replication. It
      uses metrics from the OpenTelemetry PostgreSQL receiver."
-   - **Variables**: "Two variables — `host_name` (dynamic, filters by
+   - **Variables**: "Two variables: `host_name` (dynamic, filters by
      `host.name`) and `database` (dynamic, filters by `postgresql.database.name`).
      Both support multi-select."
    - **Panels by section**: Walks each Grid section, explaining every panel's
      metric, aggregation, and what to watch for.
    - **Health observations**: "The 'Connection Count' panel has no threshold
-     configured — consider adding a line at 80% of your max_connections."
+     configured; consider adding a line at 80% of your max_connections."
    - **Coverage gaps**: "No panels for vacuum/autovacuum health or lock contention.
      Consider adding these if you manage write-heavy workloads."
 4. Offers: "Want me to run any panel queries to check for data, or add the
@@ -191,7 +191,7 @@ provided via @mention or auto-context)
 
 **Agent:**
 1. Extracts the dashboard id from the provided context.
-2. Calls `signoz_get_dashboard` — gets full configuration.
+2. Calls `signoz_get_dashboard`: gets full configuration.
 3. Provides a focused panel-by-panel walkthrough grouped by Grid section,
    explaining what each panel shows and what to watch for.
 4. Skips the health/gaps sections unless something notable stands out, since the
@@ -199,7 +199,7 @@ provided via @mention or auto-context)
 
 ---
 
-**User:** "Help me understand this LLM monitoring dashboard — I'm new to it"
+**User:** "Help me understand this LLM monitoring dashboard. I'm new to it"
 
 **Agent:**
 1. Identifies the dashboard, fetches full config.

--- a/plugins/signoz/skills/signoz-generating-queries/SKILL.md
+++ b/plugins/signoz/skills/signoz-generating-queries/SKILL.md
@@ -2,13 +2,13 @@
 name: signoz-generating-queries
 description: >
   Generate, write, or run an ad-hoc query against SigNoz observability
-  data — metrics, logs, or traces — without wrapping it in
+  data (metrics, logs, or traces) without wrapping it in
   a dashboard panel or alert. Make sure to use this skill whenever the
   user asks "show me error rates", "query logs for timeout errors",
   "what's the p99 latency for the cart service", "how many requests hit
   the payment endpoint", "find slow traces", "errors in the last hour",
   or otherwise asks an exploratory question that needs live observability
-  data — even if they don't say "query" or "search" explicitly.
+  data, even if they don't say "query" or "search" explicitly.
 ---
 
 # Query Generate
@@ -35,9 +35,9 @@ Use this skill when the user asks to:
 
 Do NOT use when:
 - User wants raw ClickHouse SQL for a dashboard panel (custom joins, window
-  functions, regex over log bodies) — that's a separate dashboard-panel SQL
+  functions, regex over log bodies); that's a separate dashboard-panel SQL
   workflow, not this skill.
-- User needs the Exceptions Explorer as an exception-specific signal — the
+- User needs the Exceptions Explorer as an exception-specific signal: the
   current MCP contract has no exception query tool. Explain that limitation and
   offer an equivalent error-trace or error-log query only if it answers their
   underlying question.
@@ -55,7 +55,7 @@ Map the user's intent to the right signal:
 | Find specific log entries, error messages, stack traces | **logs** | Text search, pattern matching, severity filtering. |
 | Find specific traces, slow requests, error spans | **traces** | Per-request detail, span attributes, duration filtering. |
 | Infrastructure metrics (CPU, memory, disk, network) | **metrics** | Always metrics for resource utilization. |
-| Ingestion volume (bytes or count), cost, or billing usage | **metrics** with `source=meter` (Cost Meter) | `signoz.meter.*` ingestion metrics (logs/spans/datapoints by count **and** bytes) live only in the meter store; bytes are unavailable on the raw signals. Dollar **cost is not a metric** — derive it from volume × per-unit price (see Step 2). groupBy/filter work like a normal metric, but only over the limited attribute set the meter retains (not arbitrary log/trace fields). For a *count* sliced by an attribute the meter doesn't carry, aggregate logs/traces directly instead. |
+| Ingestion volume (bytes or count), cost, or billing usage | **metrics** with `source=meter` (Cost Meter) | `signoz.meter.*` ingestion metrics (logs/spans/datapoints by count **and** bytes) live only in the meter store; bytes are unavailable on the raw signals. Dollar **cost is not a metric**; derive it from volume × per-unit price (see Step 2). groupBy/filter work like a normal metric, but only over the limited attribute set the meter retains (not arbitrary log/trace fields). For a *count* sliced by an attribute the meter doesn't carry, aggregate logs/traces directly instead. |
 | "How many X per Y" (count/rate grouped by dimension) | **traces** or **logs** (aggregate) | Use `signoz_aggregate_traces` or `signoz_aggregate_logs` for grouped counts. |
 
 Traces have no unqualified full-text search; use `CONTAINS` against a discovered
@@ -63,19 +63,19 @@ structured trace field. `searchText`-style body search is logs-only.
 
 If the signal is genuinely ambiguous, ask the user before proceeding. The
 host application decides how the question is surfaced (e.g. a structured
-clarification tool or an inline `<assistant_question>` tag) — follow the
+clarification tool or an inline `<assistant_question>` tag); follow the
 host's UI rendering rules.
 
 ### Step 2: Discover available data
 
-**Always discover before querying.** Use only names returned by tools — never
+**Always discover before querying.** Use only names returned by tools, never
 guess from training knowledge.
 
 Run discovery calls in parallel where possible:
 
 - **For metrics**: Call `signoz_list_metrics` with a `searchText` substring
   matching the user's intent (e.g., `searchText: "http"`, `searchText: "latency"`).
-  The response includes metric type, temporality, and isMonotonic — pass these to
+  The response includes metric type, temporality, and isMonotonic; pass these to
   `signoz_query_metrics` to avoid extra lookups. Before filtering or grouping,
   discover labels with `signoz_get_field_keys(signal: "metrics", metricName:
   <discovered-name>)`; metric labels are not trace/log attributes (`db.system`,
@@ -87,21 +87,21 @@ Run discovery calls in parallel where possible:
   |---|---|
   | gauge | `latest`, `sum`, `avg`, `min`, `max`, `count`, `count_distinct` |
   | monotonic counter/sum | `rate`, `increase` |
-  | non-monotonic sum | `avg`, `sum`, `min`, `max`, `count`, `count_distinct` — never `latest` or `rate` |
+  | non-monotonic sum | `avg`, `sum`, `min`, `max`, `count`, `count_distinct`; never `latest` or `rate` |
   | histogram / exponential histogram | omit; aggregation is automatic |
 - **For Cost Meter** (ingestion volume, cost, billing): pass `source=meter` to
-  `signoz_list_metrics` to discover the metrics (`signoz.meter.*`) — they're
+  `signoz_list_metrics` to discover the metrics (`signoz.meter.*`); they're
   invisible in the default store and the set evolves, so don't hardcode it.
   groupBy/filters/aggregations then work like any metric, with three caveats:
   *bytes exist only here* (count is also available via direct
   `signoz_aggregate_logs`/`_traces`); the meter retains only a *limited
-  attribute set* — discover groupable keys via `signoz_get_field_keys(signal:
+  attribute set*, so discover groupable keys via `signoz_get_field_keys(signal:
   "metrics", source: "meter")`, and fall back to a direct count (no bytes) to
-  slice by an attribute it lacks; and **dollar cost is not a meter metric** —
+  slice by an attribute it lacks; and **dollar cost is not a meter metric**:
   the store holds only volume, so don't `searchText: "cost"` expecting a hit.
   For a cost question, query the volume metric (bytes for logs/traces, count
   for metric datapoints) and multiply by the per-unit price from Settings →
-  Billing — ask the user for the price if you don't have it.
+  Billing; ask the user for the price if you don't have it.
 - **For traces**: Call `signoz_list_services` to confirm the service name exists,
   following `pagination.nextOffset` while `pagination.hasMore` is true before
   declaring it missing.
@@ -114,7 +114,7 @@ Run discovery calls in parallel where possible:
 
 Field keys are signal-specific: `service.name` may be absent on logs, while
 `body` is logs-only. Never carry a key across signals. Skip key discovery only
-when live output in this conversation returned it for the same signal — never
+when live output in this conversation returned it for the same signal, never
 for user text or memory. Use returned dot notation verbatim, not camelCase
 guesses such as `traceID` or `hostname`. Never assume tenant keys (`org.id`,
 `orgId`, `organization_id`, etc.); discover the actual key per signal. Call
@@ -180,19 +180,19 @@ not apply to PromQL or ClickHouse SQL envelopes.
 
 ### Step 4: Execute the query
 
-- Always include `searchContext` with the user's original question — it improves
+- Always include `searchContext` with the user's original question; it improves
   result relevance.
 - Respect the requested range; otherwise use 1h. Search/aggregate log and trace
-  tools accept relative `timeRange` strings (`"1h"`, `"24h"`; default `1h`) —
+  tools accept relative `timeRange` strings (`"1h"`, `"24h"`; default `1h`);
   prefer them. Valid Unix-ms `start`/`end` override `timeRange`; malformed explicit
   timestamps return validation guidance pointing to `timeRange`.
   `signoz_execute_builder_query` has no relative option: its outer `query` requires
   absolute `start` and `end` as JSON integer Unix-ms or fails with
   `missing start or end timestamp`.
 - Use shortcut parameters (`service`, `severity`, `operation`, `error`) when they
-  match the user's filters — they are simpler and less error-prone than building
+  match the user's filters; they are simpler and less error-prone than building
   `filter` expressions.
-- Combine shortcut params with `filter` for additional constraints — they
+- Combine shortcut params with `filter` for additional constraints; they
   are ANDed together.
 - For `signoz_query_metrics`, pass `metricType`, `temporality`, and `isMonotonic`
   from the `signoz_list_metrics` response to avoid an extra auto-fetch round trip.
@@ -219,9 +219,9 @@ not apply to PromQL or ClickHouse SQL envelopes.
   group count if truncated by `limit`.
 - For search results, summarize patterns rather than listing every entry.
 
-**No data returned — apply three-way distinction:**
+**No data returned. Apply the three-way distinction:**
 1. **Healthy zero**: The query ran successfully but the count is zero. Say so:
-   "No errors found for checkout-service in the last hour — error count is zero."
+   "No errors found for checkout-service in the last hour; error count is zero."
 2. **No data in range**: The field/metric exists but no data points fall in the
    time window. Suggest expanding: "No data in the last hour. Try a wider range?"
 3. **Missing instrumentation**: The metric, field, or service doesn't exist in
@@ -249,7 +249,7 @@ not apply to PromQL or ClickHouse SQL envelopes.
   one precise query answers the question. Use parallel discovery calls, but be
   precise for execution.
 - **Respect MCP server rules**: The MCP server enforces rules about resource
-  attribute filters, filter operators, and redundant queries. Follow them —
+  attribute filters, filter operators, and redundant queries. Follow them,
   especially preferring resource attributes in filters for faster queries.
 - **No raw ClickHouse SQL**: Always use the Query Builder tools. Never construct
   raw SQL.
@@ -268,8 +268,8 @@ not apply to PromQL or ClickHouse SQL envelopes.
   that exact query object, or skip the chip. Use the appropriate `signal`
   field (`metrics`, `logs`, or `traces`). This signals to the SigNoz UI that
   the user wants to apply the query to an explorer page. Only emit
-  `apply_filter` when the user's primary intent is to obtain a runnable query
-  — not when the user is asking a one-shot data question that the analysis text
+  `apply_filter` when the user's primary intent is to obtain a runnable query,
+  not when the user is asking a one-shot data question that the analysis text
   already answers. For a Cost Meter query keep `signal: metrics` and ensure the
   copied query spec carries `source: meter`.
 
@@ -357,8 +357,8 @@ not apply to PromQL or ClickHouse SQL envelopes.
 **Agent:**
 1. Calls `signoz_aggregate_traces(aggregation: "count", error: "true",
    service: "frontend", requestType: "time_series", timeRange: "6h")`.
-2. Presents: "Error count for frontend over the last 6 hours. Spike at 11:30 UTC
-   — error count jumped from ~5/min to ~45/min, returning to baseline by 12:15."
+2. Presents: "Error count for frontend over the last 6 hours. Spike at 11:30 UTC:
+   error count jumped from ~5/min to ~45/min, returning to baseline by 12:15."
 3. Offers: "Want me to check what error types appeared during the spike?"
 
 ---

--- a/plugins/signoz/skills/signoz-investigating-alerts/SKILL.md
+++ b/plugins/signoz/skills/signoz-investigating-alerts/SKILL.md
@@ -3,12 +3,12 @@ name: signoz-investigating-alerts
 description: >
   Diagnose why a SigNoz alert fired by correlating the alert's own signal
   with neighbor signals (error rate, latency, throughput, CPU/memory),
-  traces, and logs around the fire window — and rank likely causes.
+  traces, and logs around the fire window, and rank likely causes.
   Make sure to use this skill whenever the user asks "why did this alert
   fire", "what caused alert X", "investigate this alert", "RCA for the
   alert that paged me", "what's wrong with [service]" in the context of
   a recent fire, or otherwise asks for a root-cause analysis of a
-  firing or recently-fired alert. Read-only — does not modify any
+  firing or recently-fired alert. Read-only; does not modify any
   alert or notification.
 argument-hint: <alert name or rule id> [time window]
 ---
@@ -18,7 +18,7 @@ argument-hint: <alert name or rule id> [time window]
 Diagnose why a SigNoz alert fired. The skill correlates the alert's own
 signal with neighbor signals around the fire window, and surfaces a
 ranked list of likely causes with supporting evidence. It is the
-companion to `signoz-explaining-alerts` — explain decodes the rule
+companion to `signoz-explaining-alerts`: explain decodes the rule
 statically; investigate diagnoses a specific incident.
 
 ## Prerequisites
@@ -28,7 +28,7 @@ This skill calls SigNoz MCP server tools heavily (`signoz_get_alert`,
 `signoz_query_metrics`, `signoz_search_traces`, `signoz_search_logs`,
 `signoz_get_trace_details`, etc.). Before running the workflow,
 confirm the `signoz_*` tools are available. If they are not, the
-SigNoz MCP server is not installed or configured — run `signoz-mcp-setup` first
+SigNoz MCP server is not installed or configured; run `signoz-mcp-setup` first
 to initialize or repair the MCP connection. The investigation depends on
 correlating multiple MCP queries; without the server there is no way to ground
 the analysis.
@@ -58,7 +58,7 @@ Do NOT use when the user wants to:
 
 If the alert name is fuzzy, this skill is **best-effort** (read-only):
 1. Call `signoz_list_alert_rules`, paginate, fuzzy-match the name.
-2. State the interpretation: "Investigating fire of 'High Error Rate —
+2. State the interpretation: "Investigating fire of 'High Error Rate -
    Checkout' (id 42) at 14:32 UTC. If you meant a different alert or
    fire, tell me."
 3. Proceed.
@@ -81,7 +81,7 @@ alerts.
 
 1. Resolve the alert id via `signoz_list_alert_rules` (paginated) if
    not given.
-2. Call `signoz_get_alert` for the full rule config — needed to know
+2. Call `signoz_get_alert` for the full rule config, needed to know
    what query, threshold, and resource scope the alert evaluated.
 3. First call `signoz_get_alert_history` with `timeRange: "7d"` and
    `order: "desc"`; omit `state` so the timeline includes firing and inactive
@@ -110,7 +110,7 @@ alerts.
      - `recurring` → fires at regular intervals (cron-like, e.g., every hour).
    - Never infer flapping from different fingerprints. The pattern guides tiers 2/3.
 
-### Step 2: Tier 1 — what fired and how hard
+### Step 2: Tier 1 (what fired and how hard)
 
 This tier always runs. It establishes the fire is real (vs. transient
 threshold tickle or flap) and quantifies the magnitude.
@@ -132,11 +132,11 @@ threshold tickle or flap) and quantifies the magnitude.
    - **Pre-fire baseline**: average value in the 30m before fire start.
 3. **Early-stop gate**: if the breach magnitude is < 10% over the
    threshold AND the fire duration is < 1 evaluation window, classify
-   as "marginal fire" — the alert may be too sensitive. Skip tiers 2
+   as "marginal fire"; the alert may be too sensitive. Skip tiers 2
    and 3 and go to Step 5 with a single hypothesis: "threshold may be
    too tight, recommend tuning."
 
-### Step 3: Tier 2 — neighbor signals vs baseline
+### Step 3: Tier 2 (neighbor signals vs baseline)
 
 Run only if Tier 1 confirms a real breach. Pull related signals for the
 same resource scope as the alert and compare the fire window to a
@@ -164,13 +164,13 @@ baseline window.
    - Rank by absolute delta.
 
 4. **Early-stop gate**: if no neighbor signal shows ≥ 25% deviation
-   from baseline, classify as "isolated fire — the alert's own signal
+   from baseline, classify as "isolated fire: the alert's own signal
    moved but nothing else did." This is unusual and worth surfacing.
    Skip Tier 3 and go to Step 5 with hypotheses focused on the alert's
    own query (likely causes: data source change, instrumentation
    change, downstream silent failure that only shows in this metric).
 
-### Step 4: Tier 3 — traces and logs at the fire window
+### Step 4: Tier 3 (traces and logs at the fire window)
 
 Run only if Tier 2 found correlated neighbor anomalies. Drill into
 specific failing operations.
@@ -201,17 +201,16 @@ fire-window and baseline-window calls cleanly.
 
 ### Step 5: Build the structured output
 
-Use this exact section order. Lead with a TL;DR — engineers under
-pressure scan the top first and stop reading once they have what
-they need. Compression plus proof: every claim cites the MCP query
-that produced it; no generic "check logs / verify connectivity"
-filler.
+Use this exact section order. Lead with a TL;DR, because engineers
+under pressure scan the top first and stop reading once they have what
+they need. Every claim cites the MCP query that produced it, with no
+generic "check logs / verify connectivity" filler.
 
-**1. TL;DR** — one or two sentences, no more. Leading hypothesis,
+**1. TL;DR**: one or two sentences, no more. Leading hypothesis,
 overall confidence, blast radius, and the single most useful next
 action. Example:
 > "checkoutservice error rate hit 12.4% (threshold 5%) for 8m at
-> 14:32 UTC — most likely cause is payments-api timing out
+> 14:32 UTC; most likely cause is payments-api timing out
 > (high confidence). Open trace `7af3a09b…` to see the failing call."
 
 If no hypothesis reaches medium confidence, the leading line is
@@ -220,34 +219,34 @@ dressed up as the answer.
 
 **2. What fired**
 The alert (id, name), the fire window (absolute UTC + relative),
-peak magnitude ("error rate hit 12.4% vs. 5% threshold — 148% over"),
+peak magnitude ("error rate hit 12.4% vs. 5% threshold, 148% over"),
 fire duration, and the fire pattern (`one-off` / `sustained` /
 `flapping` / `recurring` / `marginal`).
 
 **3. Investigation trail**
 A scannable list of what was checked, with ✅ for confirmed signals
 and ❌ for ruled out, each followed by a one-line finding. The point
-is that the reader can see what work the AI did and what it found —
-this is where trust is earned. Example:
-- ✅ Tier 1 — peak error rate 12.4%, fire was real (not marginal).
-- ✅ Tier 2 — payments error rate +8900%, p99 +1180%; downstream
+is that the reader can see what work the AI did and what it found.
+Example:
+- ✅ Tier 1: peak error rate 12.4%, fire was real (not marginal).
+- ✅ Tier 2: payments error rate +8900%, p99 +1180%; downstream
   cascade.
-- ❌ CPU / memory pressure — flat through the fire window.
-- ✅ Tier 3 — 30 error traces all hit payments-api, same message.
+- ❌ CPU / memory pressure: flat through the fire window.
+- ✅ Tier 3: 30 error traces all hit payments-api, same message.
 
 **4. Likely causes** (ranked, max 3)
 Each cause has three parts:
-- **Hypothesis** — one sentence, specific. Bad: "service is unhealthy".
+- **Hypothesis**: one sentence, specific. Bad: "service is unhealthy".
   Good: "checkout is timing out on calls to payments-api".
-- **Evidence** — the supporting numbers from tiers 1/2/3, with the
+- **Evidence**: the supporting numbers from tiers 1/2/3, with the
   underlying query inline so the user can re-run it. State the
   neighbor signal, the delta vs baseline, the trace/log pattern that
   supports it.
-- **Confidence** — `high` requires ≥2 of: temporal precedence,
+- **Confidence**: `high` requires ≥2 of: temporal precedence,
   topology / dependency edge, shared service or entity, correlated
   metric/log/trace evidence, recent deploy or config change.
   `medium` is one tier's evidence with at least one of those
-  signals. `low` is a single signal moved with no corroboration —
+  signals. `low` is a single signal moved with no corroboration;
   in that case label it a "co-occurring signal," not a cause.
 
 If only Tier 1 ran (marginal fire / no neighbor anomalies), output
@@ -257,7 +256,7 @@ limitation.
 **5. Ruled out**
 Short but explicit. List candidates the evidence eliminated and the
 one-line reason why. Skip the section if there's nothing meaningful
-to rule out — but if you considered something and dropped it, say so
+to rule out, but if you considered something and dropped it, say so
 here so the user doesn't waste time re-checking it.
 
 **6. Suggested next steps**
@@ -265,32 +264,32 @@ Action items the user can take. Be concrete and use SigNoz-native
 handles so the user can act immediately:
 - Specific trace, dashboard, or alert to open
   (e.g., "open trace `7af3a09b…` in the SigNoz UI").
-- Specific query to run with `signoz-generating-queries` — paste
+- Specific query to run with `signoz-generating-queries`: paste
   the exact filter and time window.
-- "Tune this alert" if the fire was marginal — name the field
+- "Tune this alert" if the fire was marginal: name the field
   (`matchType`, `target`, `recoveryTarget`) and the change to make
   via `signoz_update_alert`.
 - "Open an incident" or "page the owning team" if the cause is
   cross-service.
 
 Do not pad with generic advice ("verify connectivity", "check
-dashboards") — that's noise during an active incident.
+dashboards"); that's noise during an active incident.
 
 **Mirroring as navigation chips.** Mirror up to 3 of these "Suggested
-next steps" as host follow-up intents — the most actionable,
+next steps" as host follow-up intents: the most actionable,
 alert-scoped ones. Keep the rest in the report prose so the user has
 the full picture. The chip surface is capped; the prose is not.
 
 ## Out of scope (v1)
 
-- **Deployment / config-change correlation** — SigNoz MCP does not
+- **Deployment / config-change correlation**: SigNoz MCP does not
   expose a deployments tool; do not fabricate one. If the user
   mentions a recent deploy, surface it as context but don't claim it
   caused the fire without the signal evidence.
-- **Cross-service blast-radius walking** — investigating downstream
+- **Cross-service blast-radius walking**: investigating downstream
   callers of the alert's service. Out of scope to keep context
   bounded.
-- **Long-horizon historical baselines** — Tier 2 compares to one
+- **Long-horizon historical baselines**: Tier 2 compares to one
   prior-day window, not to weekly/monthly seasonality. If the user
   says "is this normal for a Friday afternoon", suggest an anomaly
   alert (`signoz-creating-alerts` with `anomaly_rule`).
@@ -304,7 +303,7 @@ the full picture. The chip surface is capped; the prose is not.
   evidence is missing, lower confidence and say so.
 - **Show the supporting query** with each hypothesis so the user can
   reproduce and dig deeper.
-- **Compression plus proof.** TL;DR is one or two sentences max; the
+- **Keep it short and evidence-backed.** TL;DR is one or two sentences max; the
   full report is a triage card, not a postmortem. Engineers under
   pressure should be able to skim the top and act. Every section
   earns its place by adding evidence the user couldn't already see
@@ -314,18 +313,18 @@ the full picture. The chip surface is capped; the prose is not.
   moved before symptom), topology / dependency edge, shared service
   or entity, correlated metric/log/trace evidence, or a recent
   deploy/config change. A single time-aligned anomaly is a
-  "co-occurring signal," not a cause — say so explicitly.
+  "co-occurring signal," not a cause; say so explicitly.
 - **Don't restate the alert or recommend the obvious.** "Check
-  logs", "verify connectivity", "investigate dashboards" — the
+  logs", "verify connectivity", "investigate dashboards": the
   reader of this output already knows they need to. Replace generic
   suggestions with specific queries, traces, or filters they can run
   immediately.
 - **No fabricated identifiers.** Trace IDs, span names, alert rule
-  IDs, channel names, deploy IDs — every identifier in the output
+  IDs, channel names, deploy IDs: every identifier in the output
   must come from a real MCP response. Don't invent placeholders that
   look plausible.
-- **Honest uncertainty wins.** If no hypothesis reaches medium
-  confidence, the answer is "No clear root cause found — here's
+- **Report uncertainty honestly.** If no hypothesis reaches medium
+  confidence, the answer is "No clear root cause found; here's
   what we checked and what's ruled out." Do not promote a
   low-confidence guess to the leading hypothesis just to sound
   useful. False positives waste active incident time more than false
@@ -348,11 +347,11 @@ the full picture. The chip surface is capped; the prose is not.
 **User:** "Why did the checkout error rate alert fire?"
 
 **Agent:**
-1. Resolves alert: "High Error Rate — Checkout" (id 42).
+1. Resolves alert: "High Error Rate - Checkout" (id 42).
 2. `signoz_get_alert_history` → most recent fire 2h ago at 14:32 UTC,
    sustained for 8m, single fire (not flapping).
 3. **Tier 1**: re-runs error-rate formula over `[14:02, 15:02]`. Peak
-   error rate 12.4% (vs 5% threshold — 148% over). Pre-fire baseline
+   error rate 12.4% (vs 5% threshold, 148% over). Pre-fire baseline
    0.3%. Real fire, not marginal.
 4. **Tier 2**: pulls neighbor signals for `service.name = checkout`:
    - p99 latency: 4.1s vs 320ms baseline (+1180%).
@@ -360,7 +359,7 @@ the full picture. The chip surface is capped; the prose is not.
    - Downstream `payments` error rate: 18% vs 0.2% baseline (+8900%).
    - CPU/memory: flat (no resource pressure).
 5. **Tier 3**: traces for `service.name = checkout, has_error = true`
-   in the fire window — top operation `POST /checkout/submit`, top
+   in the fire window: top operation `POST /checkout/submit`, top
    error message "context deadline exceeded calling payments-api".
    30 traces, all hitting the same downstream URL. Logs show
    matching "payments client timeout" lines, 142 occurrences.
@@ -368,18 +367,18 @@ the full picture. The chip surface is capped; the prose is not.
 
    > **TL;DR**: checkoutservice error rate hit 12.4% (threshold 5%)
    > for 8m at 14:32 UTC. Most likely cause: payments-api timing out
-   > (high confidence — converging trace + log + neighbor evidence).
+   > (high confidence; converging trace + log + neighbor evidence).
    > Open trace `7af3a09b…` to see the failing call.
 
    - **What fired**: alert 42 fired 2h ago at 14:32 UTC, sustained
      8m. Error rate peaked at 12.4% (148% over threshold).
    - **Investigation trail**:
-     - ✅ Tier 1 — peak 12.4% vs 5% threshold, pre-fire baseline 0.3%.
+     - ✅ Tier 1: peak 12.4% vs 5% threshold, pre-fire baseline 0.3%.
        Real fire.
-     - ✅ Tier 2 — payments error rate +8900%, p99 latency +1180%,
+     - ✅ Tier 2: payments error rate +8900%, p99 latency +1180%,
        throughput −42%.
-     - ❌ CPU / memory pressure on checkout — flat.
-     - ✅ Tier 3 — 30 error traces all hit payments-api with
+     - ❌ CPU / memory pressure on checkout: flat.
+     - ✅ Tier 3: 30 error traces all hit payments-api with
        `context deadline exceeded`; 142 matching timeout logs.
    - **Likely causes** (high confidence): payments service errors
      cascading into checkout. Evidence converges across topology
@@ -401,14 +400,14 @@ the full picture. The chip surface is capped; the prose is not.
 **Agent:**
 1. Resolves alert (id 88, host.name = prod-api-3).
 2. History: 7 fires in last 1h, alternating fire/resolve every 8-12
-   minutes — flapping pattern.
+   minutes: a flapping pattern.
 3. **Tier 1**: peak 84% (threshold 80%, only 5% over). Each fire
-   lasted 2-4 minutes. Marginal — the value hovered near threshold.
+   lasted 2-4 minutes. Marginal: the value hovered near threshold.
    `matchType = at_least_once` made each blip trigger.
 4. Early-stop kicks in. Skip tiers 2/3.
 5. **Output**:
 
-   > **TL;DR**: alert 88 has been flapping on `prod-api-3` — 7 fires
+   > **TL;DR**: alert 88 has been flapping on `prod-api-3`: 7 fires
    > in the last 1h, each 2–4m, all within 5% of the 80% threshold.
    > No clear root cause; this is threshold tuning, not an incident.
    > Switch `matchType` to `on_average` or add hysteresis to stop
@@ -418,13 +417,13 @@ the full picture. The chip surface is capped; the prose is not.
      `flapping`. 7 fires in the last 1h, each 2–4m. Peak 84% (5%
      over the 80% threshold).
    - **Investigation trail**:
-     - ✅ Tier 1 — every fire was within 5% of threshold; duration
-       short; baseline already at 70–75%. Marginal fire — early-stop
+     - ✅ Tier 1: every fire was within 5% of threshold; duration
+       short; baseline already at 70–75%. Marginal fire; early-stop
        triggered, Tier 2/3 skipped.
    - **Likely causes** (low / co-occurring signal only): threshold
      tuned too tight or `matchType` is too sensitive. Evidence:
      every fire was within 5% of threshold; baseline already runs
-     at 70–75%. Not promoted to a "cause" — single signal, no
+     at 70–75%. Not promoted to a "cause": single signal, no
      corroboration.
    - **Ruled out**: real CPU saturation incident (peaks too small
      and short-lived; baseline already near threshold).
@@ -438,7 +437,7 @@ the full picture. The chip surface is capped; the prose is not.
 
 **Agent:**
 1. Resolves alert: "Error Log Volume Spike" (id 14, no service
-   filter — groupBy `service.name`).
+   filter; groupBy `service.name`).
 2. History: fired at 03:12 UTC, sustained 22m, broke down by service
    in the alert annotations: `service.name = inventory` was the
    firing series.
@@ -464,12 +463,12 @@ the full picture. The chip surface is capped; the prose is not.
    - **What fired**: alert 14 fired at 03:12 UTC for service
      `inventory`, sustained 22m, 240% over threshold.
    - **Investigation trail**:
-     - ✅ Tier 1 — peak 3,400 errors/min vs 1,000/min threshold;
+     - ✅ Tier 1: peak 3,400 errors/min vs 1,000/min threshold;
        pre-fire baseline 12/min. Real fire.
-     - ✅ Tier 2 — request error rate +600%; CPU/memory collapsed
+     - ✅ Tier 2: request error rate +600%; CPU/memory collapsed
        (−80%/−60%); 4 pod restarts in window.
-     - ❌ p99 latency — only +30%, not a latency-driven incident.
-     - ✅ Tier 3 — top log message "OOMKilled restarting" (1,200
+     - ❌ p99 latency: only +30%, not a latency-driven incident.
+     - ✅ Tier 3: top log message "OOMKilled restarting" (1,200
        occurrences); top trace error: graceful-shutdown exceptions.
    - **Likely causes** (high confidence): inventory pods OOM-killed
      and restarted 4 times during the window. Evidence converges
@@ -487,13 +486,13 @@ the full picture. The chip surface is capped; the prose is not.
 
 ## Additional resources
 
-- `references/neighbor-signals.md` — lookup table mapping resource type
+- `references/neighbor-signals.md`: lookup table mapping resource type
   (service / host / k8s) to the neighbor signals to pull in Tier 2.
-- `references/baseline-comparison.md` — query templates that pair
+- `references/baseline-comparison.md`: query templates that pair
   fire-window and baseline-window calls cleanly, including how to
   format `signoz_execute_builder_query` for both.
-- `signoz-explaining-alerts` skill — to decode the rule before
+- `signoz-explaining-alerts` skill: to decode the rule before
   investigating, if the user is unfamiliar with what the alert
   monitors.
-- `signoz-generating-queries` skill — for ad-hoc follow-up queries on the same
+- `signoz-generating-queries` skill: for ad-hoc follow-up queries on the same
   resource scope.

--- a/plugins/signoz/skills/signoz-investigating-alerts/references/baseline-comparison.md
+++ b/plugins/signoz/skills/signoz-investigating-alerts/references/baseline-comparison.md
@@ -32,7 +32,7 @@ relative description ("24h before fire").
 
 ## Builder query template (`signoz_execute_builder_query`)
 
-For each neighbor signal, run the same builder query twice — once per
+For each neighbor signal, run the same builder query twice, once per
 window. The only thing that changes is `start` / `end`.
 
 This is a complete tool-argument example for trace p99 latency. Replace the
@@ -107,7 +107,7 @@ delta_pct = (fire_value - baseline_value) / max(baseline_value, epsilon) * 100
   a stable reference.
 - Use `epsilon = max(baseline_value * 0.01, signal-specific floor)` to
   avoid divide-by-zero on metrics that idle at 0 (e.g., error rate).
-- Clamp `delta_pct` for display at ±10000% — beyond that the absolute
+- Clamp `delta_pct` for display at ±10000%; beyond that the absolute
   values matter more than the ratio.
 
 ## Surfacing the comparison
@@ -116,12 +116,12 @@ In the Tier 2 output for each signal, present:
 
 ```
 - p99 latency: 4.1s vs 320ms baseline (+1180%)
-  query: signoz_execute_builder_query — p99(duration_nano) on
+  query: signoz_execute_builder_query, p99(duration_nano) on
          service.name = checkout, fire window 14:32-14:40 UTC vs
          baseline 14:32-14:40 UTC (24h prior)
 ```
 
-The agent should embed these in the "Likely causes — Evidence"
+The agent should embed these in the "Likely causes - Evidence"
 sections of the final structured output. The query line lets the user
 re-run the comparison without rebuilding the parameters.
 
@@ -133,7 +133,7 @@ Skip baseline comparison and call out the limitation if:
   (`signoz_get_alert_history` shows a fire in the baseline window).
   In that case use a 7-day median or the user's confirmed
   known-healthy window.
-- The service was deployed within 24h before the baseline window —
+- The service was deployed within 24h before the baseline window;
   the baseline reflects pre-deploy behavior. Note this and either
   use a median or explicitly state "no good baseline available".
 - The alert is `anomaly_rule` (Z-score). The rule already encodes a
@@ -143,7 +143,7 @@ Skip baseline comparison and call out the limitation if:
 
 ## Logs / traces drill-down (Tier 3)
 
-Tier 3 does not require a baseline — the question is "what happened",
+Tier 3 does not require a baseline: the question is "what happened",
 not "what changed". Run a single fire-window query for each:
 
 - `signoz_search_traces` with the resource filter + `has_error = true`.

--- a/plugins/signoz/skills/signoz-investigating-alerts/references/neighbor-signals.md
+++ b/plugins/signoz/skills/signoz-investigating-alerts/references/neighbor-signals.md
@@ -6,7 +6,7 @@ comparison). Pull every signal in the row; rank by absolute deviation
 from baseline.
 
 The MCP server's "always prefer resource attributes" guideline applies
-to all of these queries — use the same resource-attribute filter as
+to all of these queries: use the same resource-attribute filter as
 the alert itself.
 
 ## Service-level scope (`service.name = X`)
@@ -33,7 +33,7 @@ infrastructure-level.
 
 | Signal | Source | Aggregation | Why it matters |
 |---|---|---|---|
-| CPU utilization | metrics | `system.cpu.utilization` time-avg space-avg | Already may be the alert metric — pull anyway to see how peak relates to threshold. |
+| CPU utilization | metrics | `system.cpu.utilization` time-avg space-avg | Already may be the alert metric; pull anyway to see how peak relates to threshold. |
 | Memory pressure | metrics | `system.memory.utilization` or free pages | OOM and swap activity. |
 | Disk I/O wait | metrics | `system.disk.io_time` or iowait equivalent | Disk saturation often masquerades as CPU pressure. |
 | Network I/O | metrics | `system.network.io` | Network saturation or NIC errors. |
@@ -46,7 +46,7 @@ The alert is scoped to a k8s namespace, deployment, or pod set.
 
 | Signal | Source | Aggregation | Why it matters |
 |---|---|---|---|
-| Pod restart count | metrics | restarts in fire window vs baseline | Crash loops dominate every other signal — surface first. |
+| Pod restart count | metrics | restarts in fire window vs baseline | Crash loops dominate every other signal; surface first. |
 | CPU vs requests/limits | metrics | `container.cpu.utilization` divided by limit | Throttling shows up here even when raw CPU% looks healthy. |
 | Memory vs limit | metrics | `container.memory.usage / container.memory.limit` | OOMKilled is the most common k8s failure. |
 | Node pressure | metrics | `kube_node_status_condition` for pressure conditions | Node-level resource exhaustion bleeds into all pods scheduled there. |
@@ -72,7 +72,7 @@ Tier 2 against that service's row from the table above.
    filter.** If the alert filters on both `k8s.namespace.name` and
    `service.name`, prefer the k8s row plus `service.name` cross-cuts.
 2. **Skip a signal if the data is not available.** Don't fabricate
-   queries against metrics that don't exist — call `signoz_list_metrics`
+   queries against metrics that don't exist; call `signoz_list_metrics`
    to verify metric names before querying.
 3. **Cap signal pulls at 6 queries per tier** to keep context bounded.
    Pick the most informative for the alert's signal type.

--- a/plugins/signoz/skills/signoz-managing-views/SKILL.md
+++ b/plugins/signoz/skills/signoz-managing-views/SKILL.md
@@ -6,7 +6,7 @@ description: >
   view", "save this filter", "bookmark this search", "list my saved views",
   "show me views for traces/logs/metrics/meter", "rename the X view", "update my
   saved view to also filter Y", "delete the X view", or any request to manage
-  Explorer saved views — even if they don't say "view" explicitly. Also use
+  Explorer saved views, even if they don't say "view" explicitly. Also use
   when someone wants to share a recurring Explorer query with their team and
   asks how to "save" or "bookmark" it.
 argument-hint: <view name, sourcePage (traces/logs/metrics/meter), and filter intent>
@@ -16,13 +16,13 @@ argument-hint: <view name, sourcePage (traces/logs/metrics/meter), and filter in
 
 Create, read, update, and delete SigNoz **saved Explorer views** via the
 SigNoz MCP server. A saved view is a reusable snapshot of an Explorer query
-on the Logs, Traces, Metrics, or Cost Meter page — name + filters + panel
+on the Logs, Traces, Metrics, or Cost Meter page: name + filters + panel
 type, scoped to one `sourcePage`. They are not dashboards and not alerts.
 
 This skill covers the full CRUD surface in one place because the operations
 share the same schema, the same identity model (UUID per view), and the same
 prerequisite resources. The only operation with real blast radius is delete,
-and update has a sharp edge (full-body replace) — both get explicit guards
+and update has a sharp edge (full-body replace); both get explicit guards
 below.
 
 ## Prerequisites
@@ -43,7 +43,7 @@ Use this skill when the user wants to:
 - **Create** a saved view from a current or described Explorer query.
 - **List / find** existing views (by `sourcePage`, name, or category).
 - **Inspect** a single view's filter or panel type.
-- **Update** a view — rename, recategorize, or change its filter,
+- **Update** a view: rename, recategorize, or change its filter,
   panel type, or aggregations.
 - **Delete** a view that is no longer useful.
 
@@ -57,19 +57,19 @@ Do NOT use when the user wants to:
 ## Schema reference
 
 **Read both resources BEFORE composing any create or update payload.** Do not
-hand-compose a `compositeQuery` from memory — the correct schema is not the
+hand-compose a `compositeQuery` from memory. The correct schema is not the
 legacy `builder.queryData` format; it is the v5 spec described in these
 resources. Sending a legacy payload causes a silent HTTP 400.
 
 Read both MCP resources by URI using your client's resource-read mechanism:
 
-- `signoz://view/instructions` — SavedView field reference, `sourcePage`
+- `signoz://view/instructions`: SavedView field reference, `sourcePage`
   rules, the GET-then-PUT update flow, the minimal create body.
-- `signoz://view/examples` — round-tripped payloads (traces list, logs list,
+- `signoz://view/examples`: round-tripped payloads (traces list, logs list,
   metrics graph, and a Cost Meter graph) you can adapt verbatim.
 
 The server returns HTTP 400 on legacy v3/v4 fields (`builder`, `promql`,
-`unit`, top-level `id`, `queryFormulas`, `queryTraceOperator`) — the failure
+`unit`, top-level `id`, `queryFormulas`, `queryTraceOperator`); the failure
 mode is silent for the user, so reading the resources first is mandatory, not
 optional.
 
@@ -77,21 +77,21 @@ optional.
 
 ### Create a view
 
-1. **Resolve `sourcePage`** — must be exactly one of `traces`, `logs`,
+1. **Resolve `sourcePage`**: must be exactly one of `traces`, `logs`,
    `metrics`, `meter`. If the user's intent is ambiguous ("save this query"),
    ask which Explorer they mean. It cannot be inferred from filter strings
-   alone. Use `meter` for **Cost Meter** (usage / billing) views — it is a
+   alone. Use `meter` for **Cost Meter** (usage / billing) views; it is a
    distinct Explorer page from `metrics`, even though the query runs on the
    metrics signal (see Step 4).
 2. **Read the schema resources.** Read both `signoz://view/instructions`
    and `signoz://view/examples` using your client's resource-read mechanism
    before composing any payload. Do not skip this step even if you think
-   you know the schema — the legacy `builder.queryData` format is rejected
+   you know the schema; the legacy `builder.queryData` format is rejected
    with HTTP 400.
-3. **Build the query using `signoz-generating-queries` — mandatory.** Use
+3. **Build the query using `signoz-generating-queries`, mandatory.** Use
    the `Skill` tool to invoke `signoz-generating-queries`. The sub-skill
    handles field discovery, type checking, and live-data validation in one
-   pass — adapting an example payload from `signoz://view/examples` or
+   pass; adapting an example payload from `signoz://view/examples` or
    running a bare `signoz_search_traces` call skips the field-type
    checks and service-name resolution that catch silent 400s before they
    become permanent bad views. Skipping it means a malformed filter becomes
@@ -126,7 +126,7 @@ optional.
 4. **Enforce the signal rule** in every `builder_query` spec.
    - For `traces` / `logs` / `metrics`: `signal == sourcePage`. A
      `sourcePage:"traces"` view with `signal:"logs"` is a server-side error.
-   - For `meter` (Cost Meter): `signal:"metrics"` **and** `source:"meter"` —
+   - For `meter` (Cost Meter): `signal:"metrics"` **and** `source:"meter"`:
      a Cost Meter view is queried on the metrics signal against the meter
      store. Omitting `source:"meter"` silently queries the default metrics
      store; setting `source:"meter"` on a non-`meter` sourcePage is rejected.
@@ -138,7 +138,7 @@ optional.
    - `sourcePage=metrics` → `signoz_query_metrics` with the
      `metricName` from `spec.aggregations[0].metricName` plus the same
      filter, `timeRange=1h`, `requestType=scalar`. Repeat per metric
-     query if the view has multiple. The tool requires `metricName` —
+     query if the view has multiple. The tool requires `metricName`;
      a filter-only probe is not supported.
    - `sourcePage=meter` → `signoz_query_metrics` with the `metricName`
      from `spec.aggregations[0].metricName`, **`source=meter`**, the same
@@ -149,20 +149,20 @@ optional.
    query *it* authored, not whatever you persist after edits or lifts.
    Empty → save anyway / revise / abort. Autonomous mode without
    authorization to persist empty views: abort and escalate.
-6. **Preview before writing — this step is not optional.** Before calling
+6. **Preview before writing; this step is not optional.** Before calling
    `signoz_create_view`, show the user a summary: name, sourcePage,
    panelType, the full filter expression, and the Step 5 probe result
-   ("sample fetch: N rows in last 1h" — for a `meter` view the probe window
+   ("sample fetch: N rows in last 1h"; for a `meter` view the probe window
    is 24h, so report it as such). For a human in the loop, wait
    for confirmation. For an autonomous agent, log the preview and proceed.
 7. Call `signoz_create_view`. The server populates `id`,
-   `createdAt/By`, `updatedAt/By` — never send those.
+   `createdAt/By`, `updatedAt/By`; never send those.
 
 ### List or find views
 
 `signoz_list_views` requires a `sourcePage`. If the user did not
 specify one and is searching by name, call it once per page (traces,
-logs, metrics, meter) and merge — do not guess. Use the `name` and `category`
+logs, metrics, meter) and merge; do not guess. Use the `name` and `category`
 parameters for server-side partial-match filtering when the user gives a
 substring; do not fetch everything and grep client-side.
 
@@ -170,12 +170,12 @@ The response paginates. **Always check `pagination.hasMore`** before
 concluding a view does not exist. Default page size is 50; pass `offset =
 pagination.nextOffset` to continue. A view is only confirmed missing for a
 given `sourcePage` once you have walked pages until `hasMore = false`. As
-long as `hasMore = true`, keep paginating — there is no page-count cap.
+long as `hasMore = true`, keep paginating; there is no page-count cap.
 
 ### Get a single view
 
 Use `signoz_get_view` with the UUID. The returned `data` object is
-the canonical SavedView shape — it is what you pass back to
+the canonical SavedView shape; it is what you pass back to
 `signoz_update_view`. Treat that data as the source of truth, not
 whatever the user described from memory.
 
@@ -187,13 +187,13 @@ upstream). Sending a partial body wipes the unspecified fields. The flow:
 1. `signoz_get_view` with the view's `id` → returns
    `{ "status": "success", "data": { ...SavedView... } }`.
 2. Take the `data` object. Strip server-populated fields (`id`,
-   `createdAt`, `createdBy`, `updatedAt`, `updatedBy`) — the MCP server
+   `createdAt`, `createdBy`, `updatedAt`, `updatedBy`); the MCP server
    strips them for you, but omitting them up front makes the diff
    readable.
 3. **If the update changes `compositeQuery`** (new filter, different panel
    type, different aggregation), invoke `signoz-generating-queries` to
    build and validate the new query before proceeding. Do not hand-edit
-   `compositeQuery` from the user's description — the same Step 4 signal
+   `compositeQuery` from the user's description; the same Step 4 signal
    rule applies (including the `meter` case: `signal:"metrics"` +
    `source:"meter"`), and `panelType` changes often imply a `stepInterval`
    change too. For a `meter` view, tell `signoz-generating-queries` it is a
@@ -205,7 +205,7 @@ upstream). Sending a partial body wipes the unspecified fields. The flow:
    `requestType`, `formatOptions`, and `variables`. For pure metadata tweaks (rename,
    recategorize), skip this step and do not touch `compositeQuery`.
 4. Modify only the field(s) the user asked to change.
-5. **Mandatory pre-save sample fetch — when `compositeQuery` changed.**
+5. **Mandatory pre-save sample fetch, when `compositeQuery` changed.**
    Run the 1-row probe from the Create flow's Step 5 against the new
    filter. Empty → save anyway / revise / abort. Skip only for pure
    metadata tweaks (rename, recategorize).
@@ -221,7 +221,7 @@ upstream). Sending a partial body wipes the unspecified fields. The flow:
 ### Delete a view
 
 Deletion is destructive and immediately removes the view from the shared
-list — any team member who had the view bookmarked will see it disappear.
+list; any team member who had the view bookmarked will see it disappear.
 Depending on the host application, the user may be offered a one-click
 restore action shortly after the delete (the SigNoz Assistant captures a
 snapshot and exposes a `restore` action), but treat that as a recovery
@@ -231,16 +231,16 @@ dropping a row from a shared table:
 1. **List to locate.** Call `signoz_list_views` to find the view
    by name. If `sourcePage` is unknown, search all four pages (traces,
    logs, metrics, meter).
-2. **Get to confirm — mandatory.** Call `signoz_get_view` with the
+2. **Get to confirm, mandatory.** Call `signoz_get_view` with the
    UUID from step 1. Do NOT skip this step even when you got the UUID from
    a list result that looks correct. List results are paginated and a name
-   match is not a UUID guarantee — `signoz_get_view` is the confirmation
+   match is not a UUID guarantee; `signoz_get_view` is the confirmation
    that the UUID maps to the view the user named.
    Never call `signoz_delete_view` on a UUID without a prior
    `signoz_get_view` confirming the matching name and `sourcePage`.
 3. **Show and ask.** Present the resolved view's name, `sourcePage`, and
    category, and explicitly ask for confirmation. Do **not** auto-confirm
-   based on the original prompt, even an emphatic one — destructive
+   based on the original prompt, even an emphatic one; destructive
    operations get a fresh confirmation against the resolved target.
 4. Call `signoz_delete_view`. Report success with the deleted
    view's name (not just the UUID), so the user can recognize it.
@@ -257,7 +257,7 @@ call.
   destination signal using the exact filter from the about-to-save
   payload. Skipping is equivalent to skipping get-before-delete. The
   Step 3 `signoz-generating-queries` delegation is necessary but not
-  sufficient — it validates the query *it* authored, not the filter
+  sufficient; it validates the query *it* authored, not the filter
   you persist after edits.
 
   *Cross-signal-lift footgun:* field keys are signal-scoped. An
@@ -267,7 +267,7 @@ call.
   from a sibling dashboard panel, alert rule, or view that targets a
   different signal is the most common source of empty saved views.
   `signoz_get_field_keys signal=<destination signal>` is necessary but
-  not sufficient — sparse emission still produces zero-result views.
+  not sufficient; sparse emission still produces zero-result views.
   Only the sample fetch confirms. The destination signal equals `sourcePage`
   for traces/logs/metrics; for a `meter` view it is `signal=metrics` with
   `source=meter` (never `signal=meter`).
@@ -298,14 +298,14 @@ call.
 
 | Mistake | Fix |
 |---------|-----|
-| Hand-composing `compositeQuery` from examples or memory (even after reading `signoz://view/examples`) | Use the `Skill` tool to invoke `signoz-generating-queries` — reading examples and validating with `signoz_search_traces` is not a substitute |
+| Hand-composing `compositeQuery` from examples or memory (even after reading `signoz://view/examples`) | Use the `Skill` tool to invoke `signoz-generating-queries`; reading examples and validating with `signoz_search_traces` is not a substitute |
 | Copying the full executable query envelope into the saved `compositeQuery` | Copy only `query.compositeQuery.queries`, then construct the saved shape `{queryType:"builder", panelType, queries}`; exclude `schemaVersion`, `start`, `end`, `requestType`, `formatOptions`, and `variables` |
-| Lifting an attribute name from a metric, alert rule, or sibling view and using it in a `sourcePage=traces` / `=logs` view filter without re-verifying on the destination signal | Field keys are signal-scoped; an attribute on metrics may not exist on traces or logs. Always re-check via `signoz_get_field_keys signal=<destination signal>` (for a `meter` view, `signal=metrics source=meter` — never `signal=meter`) **and** run the mandatory pre-save sample fetch — the key check is necessary but not sufficient |
+| Lifting an attribute name from a metric, alert rule, or sibling view and using it in a `sourcePage=traces` / `=logs` view filter without re-verifying on the destination signal | Field keys are signal-scoped; an attribute on metrics may not exist on traces or logs. Always re-check via `signoz_get_field_keys signal=<destination signal>` (for a `meter` view, `signal=metrics source=meter`, never `signal=meter`) **and** run the mandatory pre-save sample fetch; the key check is necessary but not sufficient |
 | Skipping the pre-save sample fetch because `signoz-generating-queries` already validated the query | The sub-skill validates the query *it* authored; the filter you persist may have been edited or lifted since then. The Step 5 sample fetch is mandatory regardless |
 | Skipping `signoz_get_view` before delete (relying on list UUID alone) | Always call `signoz_get_view` to confirm name+sourcePage before `signoz_delete_view` |
 | Sending legacy fields: `builder`, `promql`, `unit`, top-level `id`, `queryFormulas` | Read schema resources; server returns HTTP 400 silently |
 | `signal` ≠ `sourcePage` in builder query | For traces/logs/metrics, every `builder_query.signal` must equal the view's `sourcePage`. For a `meter` view, use `signal:"metrics"` + `source:"meter"` (not `signal:"meter"`) |
-| Filing a Cost Meter view under `sourcePage:"metrics"` (with `source:"meter"`) | Cost Meter views go under `sourcePage:"meter"` — otherwise they're invisible in the Meter Explorer and mis-filed under Metrics. The server rejects `source:"meter"` on a non-`meter` page |
+| Filing a Cost Meter view under `sourcePage:"metrics"` (with `source:"meter"`) | Cost Meter views go under `sourcePage:"meter"`; otherwise they're invisible in the Meter Explorer and mis-filed under Metrics. The server rejects `source:"meter"` on a non-`meter` page |
 | Partial update body (omitting unchanged fields) | GET full body first → modify only changed fields → PUT entire body |
 | Declaring "no such view" after only page 1 | Check `pagination.hasMore`; continue with `offset = pagination.nextOffset` |
 | Using PromQL or raw ClickHouse in a view | Only `queryType: "builder"` is supported; offer a dashboard panel instead |
@@ -318,7 +318,7 @@ After any write (create / update / delete), include in your reply:
 - The `sourcePage`.
 - A direct link **only** if the MCP response or SigNoz frontend provides a
   canonical URL, or the user explicitly asks for one. Do not fabricate
-  frontend routes — saved-view paths differ per signal and change over
+  frontend routes; saved-view paths differ per signal and change over
   time. When in doubt, omit the link and report the UUID + `sourcePage`.
 - For updates, what changed (one-line diff).
 - For deletes, an explicit "deleted" confirmation with the name.
@@ -326,7 +326,7 @@ After any write (create / update / delete), include in your reply:
 ## Follow-up suggestions
 
 After a view operation, you may surface up to 3 follow-up intents that
-match what just happened. The host application renders them — follow
+match what just happened. The host application renders them; follow
 the host's UI rendering rules for the exact mechanism. Use your
 judgment about what's natural for the user's context; do not pad to 3.
 
@@ -336,19 +336,19 @@ Two anti-rules that override your judgment:
   find, do not offer chips that propose a write (e.g. "Update this
   view", "Delete this view"). That contradicts the read-only stop rule
   in *Reporting back* below. Chips that re-run the view's underlying
-  query are fine — those stay on the read path. If the user's next
+  query are fine; those stay on the read path. If the user's next
   message names an update or delete, route from there.
 - **Do not duplicate host-injected actions.** If the host offers a
   restore action after a delete (the SigNoz Assistant does), do not
-  also surface restore as a follow-up — it would render twice.
+  also surface restore as a follow-up; it would render twice.
 
 When the user is purely exploring ("just listing my views", "what's
 in here?") and signals no further intent, skip follow-ups entirely.
-No chips beat wrong chips.
+Offering no follow-ups is better than offering wrong ones.
 
 Describe follow-ups by *user intent*, not by tool or skill name. The
 label the user clicks should read like the user's next prompt.
 
-Read-only operations (list, get) should report concisely — name, id,
-sourcePage, filter expression, panel type — and stop. Don't narrate
+Read-only operations (list, get) should report concisely (name, id,
+sourcePage, filter expression, panel type) and stop. Don't narrate
 the schema back to the user.

--- a/plugins/signoz/skills/signoz-mcp-setup/SKILL.md
+++ b/plugins/signoz/skills/signoz-mcp-setup/SKILL.md
@@ -34,7 +34,7 @@ stdio/local-binary setup is requested.
 
 ### Step 1: Identify the client
 
-Determine this before checking state — it decides where state is allowed to be
+Determine this before checking state: it decides where state is allowed to be
 checked from.
 
 Use the client named in `$ARGUMENTS` or the user's latest message. If no
@@ -69,7 +69,7 @@ tools (`signoz_search_docs` or `signoz_fetch_doc`) for this check.
 - For Grok Build, read `[mcp_servers.signoz]` from Grok's config scopes (or run
   `grok mcp list`) instead. Its bundled `.signoz_grok_mcp.json` ships a working
   default and is overridden by config, so it never reports the live state.
-- For every other client — including Devin CLI — do not read or search for
+- For every other client, including Devin CLI, do not read or search for
   `.signoz_claude_mcp.json`, `.mcp.json`, or `.signoz_cursor_mcp.json`. Those
   are bundled files for a different client's plugin distribution and are
   irrelevant here even if a file-search tool happens to find them (for
@@ -80,10 +80,10 @@ tools (`signoz_search_docs` or `signoz_fetch_doc`) for this check.
 
 State outcomes:
 
-- **working** — `signoz_list_services` succeeded; continue with the user's
+- **working**: `signoz_list_services` succeeded; continue with the user's
   original SigNoz request.
-- **not-setup** — run Step 3.
-- **configured-but-not-working** — if the user provided a new region or MCP URL,
+- **not-setup**: run Step 3.
+- **configured-but-not-working**: if the user provided a new region or MCP URL,
   run Step 3. Otherwise tell them the SigNoz MCP server is configured but not
   connected, then ask for the SigNoz Cloud region or MCP URL to repair it. If
   they believe the endpoint is already correct, tell them to complete the
@@ -193,7 +193,7 @@ repo in `./.grok/config.toml`. Re-running the command updates the existing
 entry rather than adding a second server. If `signoz` is already defined in
 more than one scope, update the highest-precedence one
 (`./.grok/config.toml` > `<repo-root>/.grok/config.toml` >
-`~/.grok/config.toml`) — editing a lower one would be silently shadowed. See
+`~/.grok/config.toml`); editing a lower one would be silently shadowed. See
 the Grok Build CLI recipe in `client-configs.md`.
 
 For native client setup, use `client-configs.md`:
@@ -208,7 +208,7 @@ For native client setup, use `client-configs.md`:
   user can run locally.
 - Preserve unrelated MCP servers and existing client settings.
 - Keep the server name `signoz` in native client configs (the bundled Claude
-  Code plugin file is the only one that uses the `mcp` key — do not rename it).
+  Code plugin file is the only one that uses the `mcp` key; do not rename it).
 
 ### Auth and role diagnosis
 
@@ -226,40 +226,40 @@ paste elevated keys into chat or tracked config.
 Tell the user that the SigNoz MCP endpoint has been configured, then give the
 client-specific authentication step:
 
-- **Cursor** — reload the window, then authenticate the `signoz` MCP server in
+- **Cursor**: reload the window, then authenticate the `signoz` MCP server in
   Tools & MCP if prompted.
-- **VS Code / GitHub Copilot** — open Copilot Chat in Agent mode, approve the
+- **VS Code / GitHub Copilot**: open Copilot Chat in Agent mode, approve the
   `signoz` server if prompted, then complete the authentication flow.
-- **Codex** — restart Codex if the server does not appear. For SigNoz Cloud,
+- **Codex**: restart Codex if the server does not appear. For SigNoz Cloud,
   run `codex mcp login signoz` to complete OAuth, then verify with `/mcp`. For a
   self-hosted HTTP endpoint (no OAuth unless the server runs with
   `OAUTH_ENABLED=true`), skip the login step and just verify with `/mcp` that the
   already-authenticated `signoz` server is connected.
-- **Claude Code** — restart Claude Code if the server does not appear, then run
+- **Claude Code**: restart Claude Code if the server does not appear, then run
   `/mcp`, select `signoz`, and complete authentication.
-- **Claude Desktop** — for SigNoz Cloud or publicly reachable self-hosted HTTP,
+- **Claude Desktop**: for SigNoz Cloud or publicly reachable self-hosted HTTP,
   reconnect the custom connector and complete authentication when prompted.
   Private-network or localhost endpoints need local stdio because remote
   connectors originate from Anthropic's cloud. Restart Claude Desktop after a
   local stdio change so it reloads `claude_desktop_config.json`; that file is
   only for command-based registration, not a hosted URL.
-- **Grok Build** — run `/mcps` (or press Ctrl+L and open the MCP Servers tab),
+- **Grok Build**: run `/mcps` (or press Ctrl+L and open the MCP Servers tab),
   press `r` to reload after the config change, then select `signoz` and press
   `i` to complete the OAuth flow in the browser. Self-hosted endpoints need no
   OAuth unless the server runs with `OAUTH_ENABLED=true`. Diagnose with
   `grok mcp doctor signoz`.
-- **Gemini CLI** — restart Gemini CLI if needed, then run `/mcp auth signoz`.
-- **Devin CLI** — start a new session so the updated `.devin/config.json` is
+- **Gemini CLI**: restart Gemini CLI if needed, then run `/mcp auth signoz`.
+- **Devin CLI**: start a new session so the updated `.devin/config.json` is
   picked up. For SigNoz Cloud, run `devin mcp login signoz` to complete OAuth.
   For a self-hosted or header-based endpoint, no OAuth step is expected.
-- **Windsurf** — reload Windsurf and complete authentication when prompted.
-- **Zed** — reload Zed after config changes; self-hosted stdio mode reads the
+- **Windsurf**: reload Windsurf and complete authentication when prompted.
+- **Zed**: reload Zed after config changes; self-hosted stdio mode reads the
   configured environment from the context server entry.
-- **Antigravity CLI** — type `/mcp`, select the `signoz` server, and choose
+- **Antigravity CLI**: type `/mcp`, select the `signoz` server, and choose
   **Authenticate** to start the OAuth flow (complete it in the browser). Self-hosted
   endpoints need no OAuth unless the server runs with `OAUTH_ENABLED=true`. If
   authentication is stuck, clear cached dynamic auth providers and retry.
-- **OpenCode** — run `opencode mcp auth signoz` if authentication does not
+- **OpenCode**: run `opencode mcp auth signoz` if authentication does not
   start automatically, then verify with `opencode mcp list`.
 
 Keep the response short. Do not expose registration file paths, placeholder

--- a/plugins/signoz/skills/signoz-mcp-setup/references/client-configs.md
+++ b/plugins/signoz/skills/signoz-mcp-setup/references/client-configs.md
@@ -30,13 +30,13 @@ SigNoz MCP Server docs and adds OpenCode's native config shape.
   the user requested. If they did not choose:
   1. **Check every scope the client supports for an existing `signoz` (or
      equivalently-purposed) entry first.** If one exists anywhere, edit that
-     same file in place — do not pick a different scope for the new value.
+     same file in place; do not pick a different scope for the new value.
      This matters most for CLI clients like Devin CLI, Codex, and Claude Code
      that support multiple config layers (user/global, project, project-local):
      re-deriving the scope from scratch on every repair can silently create a
      second, shadowing or shadowed entry in a different file, or make the
      skill go looking for a project file in whatever directory the current
-     session happens to be in — even an unrelated project that has nothing to
+     session happens to be in, even an unrelated project that has nothing to
      do with the endpoint being configured.
   2. Only when no existing entry is found in any scope, choose a scope: prefer
      user/global for secrets and for CLI tools in general (they are
@@ -211,7 +211,7 @@ writing a new one, and edit the highest-precedence file that already defines it.
 Writing the config entry is also what **de-duplicates** Grok's compatibility
 sources. Grok reads `~/.claude.json`, `~/.cursor/mcp.json`, and `.mcp.json`
 alongside its own config, and a compat-sourced server does not replace the
-plugin's — both load. A user who already has SigNoz configured in Claude Code or
+plugin's; both load. A user who already has SigNoz configured in Claude Code or
 Cursor therefore ends up with two live `signoz` servers pointing at different
 endpoints (for example a self-hosted `http://localhost:8000/mcp` from
 `~/.claude.json` and the plugin's Cloud default), which `grok mcp doctor` reports
@@ -254,17 +254,17 @@ Or edit `~/.gemini/settings.json`:
 Devin merges MCP servers by name across scopes, with later-checked scopes
 overriding earlier ones: user/global is overridden by project, which is
 overridden by project-local. Check these three files in **precedence
-order — highest first** — for an existing `signoz` entry, since that is the
+order (highest first)** for an existing `signoz` entry, since that is the
 one actually in effect:
 
-1. `.devin/config.local.json` in the current project root — gitignored,
+1. `.devin/config.local.json` in the current project root: gitignored,
    project-local. Highest precedence.
-2. `.devin/config.json` in the current project root — team-shared, committed.
-3. `~/.config/devin/config.json` (`%APPDATA%\devin\config.json` on Windows) —
+2. `.devin/config.json` in the current project root: team-shared, committed.
+3. `~/.config/devin/config.json` (`%APPDATA%\devin\config.json` on Windows):
    user/global, applies to every project. Lowest precedence.
 
 Edit the **first (highest-precedence) file that already has a `signoz`
-entry** — editing a lower-precedence file while a higher one still defines
+entry**: editing a lower-precedence file while a higher one still defines
 `signoz` would be silently shadowed and the active endpoint would not change.
 If more than one scope defines `signoz`, tell the user which scope is
 currently winning and ask whether to update that one or remove the
@@ -303,7 +303,7 @@ Edit `~/.codeium/windsurf/mcp_config.json`.
 
 ### Antigravity CLI
 
-Remote servers must use the `serverUrl` key — Antigravity does not support
+Remote servers must use the `serverUrl` key; Antigravity does not support
 the legacy `url` or `httpUrl` fields.
 
 If the SigNoz plugin is installed (`agy plugin install https://github.com/SigNoz/agent-skills`),
@@ -494,7 +494,7 @@ values as well as `url`, so prefer a reference over a literal key:
 grok mcp add signoz -e SIGNOZ_API_KEY='${SIGNOZ_API_KEY}' -s user -- "<path-to-binary>/signoz-mcp-server"
 ```
 
-Keep the server name `signoz` here too — the stdio entry replaces the bundled
+Keep the server name `signoz` here too: the stdio entry replaces the bundled
 HTTP registration of the same name rather than running alongside it.
 
 ### Zed

--- a/plugins/signoz/skills/signoz-mcp-setup/references/mcp-settings.md
+++ b/plugins/signoz/skills/signoz-mcp-setup/references/mcp-settings.md
@@ -18,7 +18,7 @@ Antigravity CLI, or OpenCode, read
 ## State Check
 
 Silently determine `signoz-server-state`, **only after the client is known**
-(see `SKILL.md` Step 1 — identify the client before checking state):
+(see `SKILL.md` Step 1: identify the client before checking state):
 
 1. If `signoz_*` MCP tools are available, call
    `signoz_list_services(timeRange: "1h", limit: 1)`. Do not use
@@ -27,15 +27,15 @@ Silently determine `signoz-server-state`, **only after the client is known**
 2. If the call succeeds, including with an empty service list, state is
    **working**.
 3. If the call fails, returns no tools, or cannot be attempted:
-   - **Claude Code, Codex, or Cursor bundled plugin install** — read the
+   - **Claude Code, Codex, or Cursor bundled plugin install**: read the
      plugin registration files below.
-   - **Grok Build** — read `[mcp_servers.signoz]` from `./.grok/config.toml`,
+   - **Grok Build**: read `[mcp_servers.signoz]` from `./.grok/config.toml`,
      `<repo-root>/.grok/config.toml`, then `~/.grok/config.toml`, or run
      `grok mcp list`. Grok ships a bundled registration too, but its endpoint
      comes from config, so the bundled file says nothing about the live state.
-   - **Any other client** — do not read or file-search for the bundled
+   - **Any other client**: do not read or file-search for the bundled
      registration files below. They belong to a different client's plugin
-     distribution and can exist on disk for unrelated reasons — most
+     distribution and can exist on disk for unrelated reasons, most
      notably, if this skill is running from a local checkout of the
      `agent-skills` source repo itself (e.g. a Devin CLI local-path plugin
      install), the bundled files genuinely exist a few directories up
@@ -52,7 +52,7 @@ only the plain outcome: working, not set up, or configured but not connected.
 ## Registration Files
 
 These bundled registration files exist only for the Claude Code, Codex, and
-Cursor plugin installs — never read or edit them for any other client, even if
+Cursor plugin installs; never read or edit them for any other client, even if
 a file search finds them:
 
 - `.signoz_claude_mcp.json` for Claude Code
@@ -62,21 +62,21 @@ a file search finds them:
 The plugin also ships `.signoz_grok_mcp.json` for Grok Build, but Grok is **not**
 a bundled-file-editing client: it resolves the endpoint from
 `[mcp_servers.signoz]` in its own config, which replaces the plugin-provided
-server of the same name. Never edit `.signoz_grok_mcp.json` — use the Grok Build
+server of the same name. Never edit `.signoz_grok_mcp.json`: use the Grok Build
 CLI recipe in `client-configs.md` instead.
 
 This reference file lives at `skills/signoz-mcp-setup/references/mcp-settings.md`,
 so the plugin root is two directories up from `skills/signoz-mcp-setup/`. That
 relative path also happens to resolve inside the `agent-skills` source repo
 itself (this plugin's own monorepo), which ships all three files side by side
-for their respective bundled installs — resolving to a real file there does
+for their respective bundled installs; resolving to a real file there does
 not mean it is the active client's configuration.
 
 Update every registration file that exists **for the identified client only**.
 Replace only the `url` value and preserve each file's existing server key and
 `type`: the Claude Code file (`.signoz_claude_mcp.json`) ships the server key
 `mcp`, while the Codex and Cursor files ship `signoz`. Do not create duplicate
-MCP server entries, and do not rename the existing server — renaming the
+MCP server entries, and do not rename the existing server: renaming the
 Claude Code key changes the tool namespace (`plugin:signoz:mcp`) and forces
 re-authentication.
 
@@ -150,22 +150,22 @@ SigNoz Cloud hosted MCP URLs use the same region code shown in
 
 Mapping rules:
 
-- **Known region code** — map `us`, `us2`, `eu`, `eu2`, `in`, or `in2`
+- **Known region code**: map `us`, `us2`, `eu`, `eu2`, `in`, or `in2`
   case-insensitively.
-- **Hosted MCP URL** — accept `https://mcp.<region>.signoz.cloud/mcp` as-is
+- **Hosted MCP URL**: accept `https://mcp.<region>.signoz.cloud/mcp` as-is
   after normalizing the region to lowercase.
-- **Hosted MCP host only** — add `https://` and `/mcp`.
-- **Ingestion endpoint** — map `ingest.<region>.signoz.cloud` to the matching
+- **Hosted MCP host only**: add `https://` and `/mcp`.
+- **Ingestion endpoint**: map `ingest.<region>.signoz.cloud` to the matching
   hosted MCP URL.
-- **Self-hosted HTTP MCP URL** — accept any `http://.../mcp` or
+- **Self-hosted HTTP MCP URL**: accept any `http://.../mcp` or
   `https://.../mcp` URL that is not a SigNoz Cloud workspace URL. This plugin
   configuration path configures URL-based HTTP MCP. For stdio/local-binary
   mode, tell the user to register the SigNoz MCP server separately as
   `signoz`.
-- **SigNoz workspace URL** — do not infer the region from
+- **SigNoz workspace URL**: do not infer the region from
   `https://<workspace>.signoz.cloud`. Ask the user for the region from
   **Settings -> Ingestion**.
-- **Unknown hosted region code** — ask for confirmation before using
+- **Unknown hosted region code**: ask for confirmation before using
   `https://mcp.<region>.signoz.cloud/mcp`. New SigNoz Cloud regions may exist
   before this skill is updated.
 

--- a/plugins/signoz/skills/signoz-modifying-dashboards/SKILL.md
+++ b/plugins/signoz/skills/signoz-modifying-dashboards/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: signoz-modifying-dashboards
 description: >
-  Modify an existing SigNoz dashboard — add or remove panels, edit a
+  Modify an existing SigNoz dashboard: add or remove panels, edit a
   panel's query, threshold, or unit, rename the dashboard, change a
   panel type (graph ↔ table ↔ value), rearrange the layout, add or edit
   variables, or update tags. Make sure to use this skill whenever the
@@ -9,7 +9,7 @@ description: >
   panel", "remove the latency widget", "rename my dashboard", "update
   the filters", "rearrange the layout", "add a variable", "change panel
   type from graph to table", or otherwise asks to change something on a
-  dashboard that already exists — even if they don't say "modify" or
+  dashboard that already exists, even if they don't say "modify" or
   "edit" explicitly.
 ---
 
@@ -22,7 +22,7 @@ This skill calls SigNoz MCP server tools (`signoz_get_dashboard`,
 `signoz_list_metrics`, `signoz_get_field_keys`, `signoz_get_field_values`,
 `signoz_execute_builder_query`).
 Before running the workflow, confirm the `signoz_*` tools are available.
-If they are not, the SigNoz MCP server is not installed or configured —
+If they are not, the SigNoz MCP server is not installed or configured;
 run `signoz-mcp-setup` first to initialize or repair the MCP connection. Do not
 fall back to raw HTTP calls or hand-edit dashboard JSON without the MCP tools.
 
@@ -56,7 +56,7 @@ its id.
 ### Step 2: Fetch the current dashboard state
 
 Call `signoz_get_dashboard` with the dashboard id to retrieve its full
-configuration. This is **mandatory** — `signoz_update_dashboard` requires the
+configuration. This is **mandatory**: `signoz_update_dashboard` requires the
 complete post-update state, and a patch still needs the real panel ids and grid
 item indices. Never skip this step.
 
@@ -65,23 +65,23 @@ Examine the response to understand:
 - Current grid item positions (x, y, width, height in the 12-column grid)
 - Current variables
 - Current query on each panel (exactly one per panel)
-- The `spec.layouts` structure — one Grid per section, each with its own items
+- The `spec.layouts` structure: one Grid per section, each with its own items
 
 ### Step 3: Plan the modification
 
 Based on the user's request, plan the changes.
 
 **Confirm with the user before applying if:**
-- The modification is **destructive** — removing panels, deleting variables,
+- The modification is **destructive**: removing panels, deleting variables,
   replacing an entire query with a different one, changing a query's `signal`
   (e.g., traces → logs), or fundamentally altering what data is shown (changing
   aggregation from p99 to avg, removing groupBy dimensions)
-- The request is **ambiguous** — multiple panels could match "the latency panel"
-- The change is **large** — restructuring sections, adding many panels at once
+- The request is **ambiguous**: multiple panels could match "the latency panel"
+- The change is **large**: restructuring sections, adding many panels at once
 
 **Destructive means data loss or silent behavior change.** Even if the user says
 "just do it quickly," a brief confirmation ("I'll remove 'Memory Fragmentation'
-permanently — OK?") takes seconds and prevents irreversible mistakes. User urgency
+permanently. OK?") takes seconds and prevents irreversible mistakes. User urgency
 does not override this guardrail.
 
 **Non-destructive changes need no destructive confirmation:** renaming, adding a
@@ -90,7 +90,7 @@ thresholds. Variable additions still require the panel-applicability prompt belo
 
 **Compound modifications:** When a request involves multiple changes (e.g., remove a
 panel + add a panel + rename), plan all changes against the fetched state and apply
-them as a single write — one patch array may carry many ops. Do not apply and
+them as a single write: one patch array may carry many ops. Do not apply and
 re-fetch between changes.
 
 ### Step 4: Apply the modification
@@ -98,13 +98,13 @@ re-fetch between changes.
 **Pick the write tool first.** Default to `signoz_patch_dashboard` (RFC 6902):
 it sends only the changed ops, so it cannot drop a panel that was never in
 question. Read `signoz://dashboard/patch-instructions` for the JSON Pointer
-paths. Reach for `signoz_update_dashboard` — a full replacement merged into the
-Step 2 state — only when most of the dashboard changes. The rules below apply to
+paths. Reach for `signoz_update_dashboard` (a full replacement merged into the
+Step 2 state) only when most of the dashboard changes. The rules below apply to
 both; each names its patch path.
 
 **Ops apply in sequence, against the document as the previous ops left it.** When
-one patch removes several entries from the same array — grid items, layouts,
-variables, tags, or a composite's member queries — order those removals by
+one patch removes several entries from the same array (grid items, layouts,
+variables, tags, or a composite's member queries), order those removals by
 **descending index**. Otherwise each removal reindexes the entries after it, and a
 stale index quietly drops the wrong entry or no-ops (remove on a missing path is
 not an error). Indices planned against the Step 2 state are only valid for the
@@ -123,7 +123,7 @@ first removal from each array.
 
 - **Preserve panel/grid-item identity.** Every panel id in `spec.panels` needs
   exactly one grid item whose `content.$ref` names it; add or remove both
-  together. Reuse existing panel ids verbatim — a rename is a display change,
+  together. Reuse existing panel ids verbatim: a rename is a display change,
   not a new id.
 
 - **Read schemas before every write.** Read all required and applicable
@@ -136,8 +136,8 @@ first removal from each array.
   1. Build the panel with a short, stable id and `add` it at
      `/spec/panels/<id>`. When the dashboard already holds a panel of the
      target type, start from that panel's JSON in the Step 2 response instead
-     of composing one — the same diff-and-merge principle the update path
-     follows, and the server's own shape is known-valid. Re-point every field
+     of composing one (the same diff-and-merge principle the update path
+     follows, and the server's own shape is known-valid). Re-point every field
      that identifies the data (aggregation, `groupBy`, `filter.expression`,
      `order`, `legend`, alias, `signal`); a clone with one stale field is
      well-formed and will be accepted, so the mandatory dry-run below is what
@@ -152,13 +152,13 @@ first removal from each array.
      Grid. A panel with no grid item is accepted and never renders.
 - **Removing a panel:** Remove the grid item (0-based index within its Grid) and
   the `/spec/panels/<id>` entry together; an item left pointing at a removed panel is rejected.
-  **Do not** try to auto-compact or shift `y` positions of remaining panels — the
+  **Do not** try to auto-compact or shift `y` positions of remaining panels; the
   SigNoz frontend grid engine handles gap-closing automatically. Simply remove the
   two references (panel entry, grid item) and leave all other positions
   unchanged.
 
 - **Editing a panel's query:** Replace the query at `/spec/panels/<id>/spec/queries/0`
-  and keep all other panel fields intact — never append a second one, since a
+  and keep all other panel fields intact; never append a second one, since a
   panel holds exactly one query.
 
 - **Changing panel type:** Update the plugin `kind` and the query envelope `kind`
@@ -196,7 +196,7 @@ panel, read the compact
 [`dashboard-to-query-builder-v5` reference](./references/dashboard-to-query-builder-v5.md).
 The panel already stores the execution spec, so lift it into the outer envelope and
 call `signoz_execute_builder_query` with that payload. Dry-run over a short
-absolute Unix-ms window — usually the last 30-60 minutes, never the panel's
+absolute Unix-ms window, usually the last 30-60 minutes, never the panel's
 display range by reflex; apply the reference's dry-run hygiene rules before
 widening or retrying after a timeout. Use representative variable values in the
 dry-run copy and keep `$var` in saved state.
@@ -235,18 +235,18 @@ signoz_patch_dashboard({
 
 **If the write fails, never resend the same payload.** A client-side
 `InputValidationError` never reached SigNoz, so an identical retry cannot
-succeed — and working out *why* it failed does not license another attempt.
+succeed, and working out *why* it failed does not license another attempt.
 That reasoning is what turns two failures into twenty. Allow at most two
 attempts per approach, then change approach: clone-and-re-point rather than
 author, or split one patch into several. If two approaches have failed, stop
 and report the exact ops and error text to the user instead of trying a third.
-This bounds client-side validation failures only — a dry-run timeout is a
+This bounds client-side validation failures only; a dry-run timeout is a
 server-side condition where retrying over a narrower window is correct.
 
 For a full replacement, `signoz_update_dashboard` takes the merged state **flat**
 beside `id`, not nested under a `dashboard` key. Merge into the `data` object of the
-Step 2 response — passing the `{status, data}` envelope itself is rejected. Send the
-fetched `name` — an immutable machine label — back unchanged, and drop the read-only
+Step 2 response; passing the `{status, data}` envelope itself is rejected. Send the
+fetched `name` (an immutable machine label) back unchanged, and drop the read-only
 fields the GET returns (`createdAt`, `updatedBy`, `orgId`, `webUrl`, and friends):
 
 ```text
@@ -268,14 +268,14 @@ Briefly tell the user what was changed. Offer further modifications if relevant.
 - **Patch first; full state on update**: prefer `signoz_patch_dashboard` for
   targeted edits. When a full replacement is warranted, `signoz_update_dashboard`
   takes the complete dashboard **flat** beside `id` (`schemaVersion`, `name`,
-  `tags`, `spec`) — never nested under a `dashboard` key. Always call
+  `tags`, `spec`), never nested under a `dashboard` key. Always call
   `signoz_get_dashboard` first, merge into that response's `data` object, round-trip `name`
   unchanged, and never construct a payload from scratch.
 - **Preserve what you don't change**: Preserve supported mutable semantics for
   panels, variables, and grid items outside the request. Diff-and-merge;
   do not rebuild or promise byte-for-byte equality after MCP normalization.
 - **Confirm destructive changes**: Before removing panels, replacing queries, or
-  deleting variables, confirm with the user — even if they say "just do it" or
+  deleting variables, confirm with the user, even if they say "just do it" or
   express urgency. Additions, renames, type changes, and variable additions do not
   need confirmation.
 - **Validate changed queries** Follow the mandatory dry-run step above before
@@ -308,9 +308,9 @@ Briefly tell the user what was changed. Offer further modifications if relevant.
 **User:** "Add an error rate panel to my Redis dashboard"
 
 **Agent:**
-1. Calls `signoz_list_dashboards` with `filter="redis"` — finds "Redis Overview"
+1. Calls `signoz_list_dashboards` with `filter="redis"`; finds "Redis Overview"
    dashboard with id `abc-123`.
-2. Calls `signoz_get_dashboard` with id `abc-123` — gets full configuration with
+2. Calls `signoz_get_dashboard` with id `abc-123`; gets full configuration with
    8 existing panels across two Grid sections.
 3. Calls `signoz_list_metrics` to find available Redis error metrics.
 4. Creates a new timeseries panel (a `signoz/CompositeQuery` holding the two
@@ -318,8 +318,8 @@ Briefly tell the user what was changed. Offer further modifications if relevant.
    the last item in the Overview Grid.
 5. Dry-runs the new panel with `signoz_execute_builder_query`; fixes any error or
    unexpected empty result.
-6. Calls `signoz_patch_dashboard` with two ops — `add /spec/panels/error-rate` and
-   `add /spec/layouts/0/spec/items/-` — rather than re-sending all 9 panels.
+6. Calls `signoz_patch_dashboard` with two ops (`add /spec/panels/error-rate` and
+   `add /spec/layouts/0/spec/items/-`) rather than re-sending all 9 panels.
 7. Reports: "Added an 'Error Rate' timeseries panel to your Redis Overview dashboard
    under the Overview section. Want me to adjust anything?"
 
@@ -330,7 +330,7 @@ Briefly tell the user what was changed. Offer further modifications if relevant.
 **Agent:**
 1. Resolves "API Monitoring" through a filtered `signoz_list_dashboards`, then calls
    `signoz_get_dashboard` with its id.
-2. Finds the panel titled "Request Latency" — if multiple panels could match,
+2. Finds the panel titled "Request Latency"; if multiple panels could match,
    confirms with user: "I found 'Request Latency'. Convert that one to a table?"
 3. Changes the plugin `kind` to `signoz/TablePanel` and the query `kind` to
    `scalar`, matches the table shape in `widgets-examples`, and keeps the query
@@ -348,7 +348,7 @@ Briefly tell the user what was changed. Offer further modifications if relevant.
 **Agent:**
 1. Fetches the dashboard via `signoz_get_dashboard`.
 2. Finds the "CPU Usage" panel. Confirms: "I'll remove the 'CPU Usage' panel and
-   rename the dashboard to 'Service Health'. Proceed?" (Removal is destructive —
+   rename the dashboard to 'Service Health'. Proceed?" (Removal is destructive;
    always confirm.)
 3. User confirms.
 4. Removes the panel entry and its grid item. Leaves all other panel positions

--- a/plugins/signoz/skills/signoz-modifying-dashboards/references/dashboard-to-query-builder-v5.md
+++ b/plugins/signoz/skills/signoz-modifying-dashboards/references/dashboard-to-query-builder-v5.md
@@ -38,14 +38,14 @@ The query envelope's `kind` is the outer `requestType`, unchanged:
 graph/bar/histogram panels save `time_series`; table/pie/value save `scalar`;
 list saves `raw`; an existing trace panel saves `trace`. These are the only
 execution values; never invent `aggregate`, `table`, or `timeseries`. There is
-no trace panel plugin to author — use `signoz/ListPanel` with raw trace rows.
+no trace panel plugin to author; use `signoz/ListPanel` with raw trace rows.
 
 Put every dependency in one `compositeQuery.queries` array. A panel holds
 exactly one query envelope, and its plugin `kind` picks the execution `type`
 while `plugin.spec` becomes that entry's `spec`, unchanged:
 `signoz/BuilderQuery` -> `builder_query`; `signoz/Formula` ->
 `builder_formula`; `signoz/TraceOperator` -> `builder_trace_operator`.
-A `signoz/CompositeQuery` already holds `{type, spec}` members — lift its
+A `signoz/CompositeQuery` already holds `{type, spec}` members, so lift its
 `spec.queries` into `compositeQuery.queries` as-is.
 
 Bounds and ordering are part of the saved spec, so execute what the panel
@@ -65,7 +65,7 @@ stores rather than re-deriving it, and author them when you build the panel:
   payload. Raw and trace-request traces use timestamp desc; raw logs add id
   desc; aggregate logs/traces use the primary aggregation desc. A metrics
   `order` key is the composed `spaceAggregation(timeAggregation(metricName))`
-  expression — the bare metric name is rejected, while `__result` and groupBy
+  expression; the bare metric name is rejected, while `__result` and groupBy
   keys are accepted; a formula orders by `__result`.
 - Time-series top-N ranks groups over the whole window and can omit a
   short-lived local spike. Narrow filters or grouping if formula-input

--- a/plugins/signoz/skills/signoz-reducing-telemetry-cost/SKILL.md
+++ b/plugins/signoz/skills/signoz-reducing-telemetry-cost/SKILL.md
@@ -8,7 +8,7 @@ description: >
   ways to cut volume. Make sure to use this skill whenever the user asks
   "why is my SigNoz bill so high", "what's driving my ingestion cost",
   "reduce telemetry volume", "which metrics cost the most", "cardinality
-  health check", or "what can I safely drop" — or otherwise asks about
+  health check", or "what can I safely drop", or otherwise asks about
   telemetry spend, ingestion volume, or metric cardinality, even if they
   don't say "cost" or "optimize" explicitly.
 argument-hint: <investigation focus, such as metrics cost or cardinality health>
@@ -22,12 +22,12 @@ This skill calls SigNoz MCP server tools heavily (`signoz_list_metrics`,
 `signoz_aggregate_logs`, `signoz_aggregate_traces`, `signoz_search_logs`,
 `signoz_list_alert_rules`, `signoz_get_alert`, `signoz_get_service_top_operations`). Before
 running the workflow, confirm the `signoz_*` tools are available. If they are not, the SigNoz
-MCP server is not installed or configured — run `signoz-mcp-setup` first. The whole
+MCP server is not installed or configured; run `signoz-mcp-setup` first. The whole
 investigation is grounded in these queries; without the server there is nothing to analyze.
 
 Read both reference files before drawing conclusions:
-- `references/otel-attribute-cardinality.md` — classify any metric label you encounter.
-- `references/infra-do-not-drop.md` — the metrics that power the built-in Infrastructure page
+- `references/otel-attribute-cardinality.md`: classify any metric label you encounter.
+- `references/infra-do-not-drop.md`: the metrics that power the built-in Infrastructure page
   **and the APM/Services page** (span-derived `signoz_*` RED metrics); never present these as
   "safe to drop" even when usage shows them unused.
 
@@ -43,7 +43,7 @@ Establish the cross-signal cost picture first. Always call `signoz_list_metrics`
 `source: "meter"`; treat its returned metric names, types, temporalities, and units as the live
 source of truth because the meter set evolves. Then query each relevant discovered metric with
 `signoz_execute_builder_query` (`source: "meter"`, `requestType: "time_series"`,
-`stepInterval: 3600`, the discovered `temporality`, and `timeAggregation: "sum"`) — see
+`stepInterval: 3600`, the discovered `temporality`, and `timeAggregation: "sum"`); see
 `references/cost-meter-queries.md` for the full tool-argument template. Sum complete hourly
 buckets and exclude every datapoint marked `partial: true`. Do **not** use
 `signoz_query_metrics` for Cost Meter totals or grouped total attribution.
@@ -54,10 +54,10 @@ computed; never invent a total. If the tools are unavailable, follow the prerequ
 For a rolling 7-day window (`end` = now, `start` = end − 7 days), get the per-signal totals
 (span size, log size, metric datapoints), then compute and report:
 
-- **Primary cost driver.** The signal with the highest *dollar* weight — traces/logs at
+- **Primary cost driver.** The signal with the highest *dollar* weight: traces/logs at
   $0.30/GB, metrics at $0.10/M samples (orientation only; never quote dollar savings). This
   picks by cost, not by raw volume.
-- **Bytes per record.** span.size ÷ span.count and log.size ÷ log.count — tells you whether a
+- **Bytes per record.** span.size ÷ span.count and log.size ÷ log.count, which tells you whether a
   signal is a payload-size problem or a volume problem.
 
 Then break the primary signal down by environment and service. First call
@@ -74,39 +74,39 @@ before any signal-level change: https://signoz.io/docs/ingestion/signoz-cloud/ke
 Run when the Cost Meter shows metric data, ordered by its cost contribution, or when the user
 explicitly asks about metric cost or cardinality.
 
-**2a. Rank by volume — `signoz_get_top_metrics`.** Returns the top 100 metrics by ingested
+**2a. Rank by volume with `signoz_get_top_metrics`.** Returns the top 100 metrics by ingested
 samples with percentages pre-computed and `totalValue` sample counts (pass `start`/`end`). This
 is the volume-ranked worklist. Histogram metrics (`.bucket` suffix) are usually the top
-contributors — each bucket boundary is a separate sample per scrape.
+contributors, since each bucket boundary is a separate sample per scrape.
 
-**2b. Check usage — `signoz_check_metric_usage`.** Pass the top metric names (batch of ≤ 50 per
+**2b. Check usage with `signoz_check_metric_usage`.** Pass the top metric names (batch of ≤ 50 per
 call). Returns `{ dashboards, alerts, error }` per metric. A metric is a drop candidate only when
 its `error` is empty **and** both `dashboards` and `alerts` are empty. If `error` is non-empty the
 lookup is incomplete (a timeout, or an older SigNoz that lacks the endpoint) and the returned
-lists are unreliable — never treat that metric as unused; mark it **Needs one check first** (verify
-its usage manually). A clean lookup with both lists empty is a drop candidate — except the guard
+lists are unreliable, so never treat that metric as unused; mark it **Needs one check first** (verify
+its usage manually). A clean lookup with both lists empty is a drop candidate, except for the guard
 below.
 
 > **Do-not-drop guard (mandatory).** Before calling any empty-usage metric a "safe drop", check
 > it against `references/infra-do-not-drop.md`. The Infrastructure page (Hosts / Kubernetes)
-> queries `system.*` and many `k8s.*` / `container.*` metrics through built-in queries — *not*
-> dashboards — so usage-check reports them empty even though dropping them breaks that page. If
-> a candidate matches the do-not-drop set, present it as **"Infra-page dependency — breaks the
+> queries `system.*` and many `k8s.*` / `container.*` metrics through built-in queries, *not*
+> dashboards, so usage-check reports them empty even though dropping them breaks that page. If
+> a candidate matches the do-not-drop set, present it as **"Infra-page dependency: breaks the
 > Hosts/Kubernetes view; confirm you don't use that view before dropping,"** never as "safe to
 > drop." This overrides the empty usage result. Also exclude internal `signoz_` / `signoz.`
 > metrics (auto-generated RED metrics that power the APM page, not customer-controlled).
 
-**2c. Inspect cardinality — `signoz_check_metric_cardinality`.** Run this for metrics that are
+**2c. Inspect cardinality with `signoz_check_metric_cardinality`.** Run this for metrics that are
 not drop candidates and for any drop candidate the user chooses to retain. Cardinality analysis
 adds no value for a metric the user has agreed to drop. The tool returns attribute keys sorted
 highest-cardinality first, each with `valueCount` and sample `values`. Classify each with
 `references/otel-attribute-cardinality.md`:
 
 - **UNBOUNDED** (`url.full`, `http.target`, `db.query.text`, `client.port`, `trace.id`,
-  `exception.stacktrace`, …) — grow without ceiling; flag regardless of current count.
-- **ACCUMULATING** (`container.id`, `k8s.pod.uid`, `k8s.pod.name`, `k8s.pod.start_time`) —
+  `exception.stacktrace`, …): grow without ceiling; flag regardless of current count.
+- **ACCUMULATING** (`container.id`, `k8s.pod.uid`, `k8s.pod.name`, `k8s.pod.start_time`):
   `valueCount` reflects historical pod churn, not active series; explain the distinction.
-- **HIGH but bounded** (`valueCount` ≳ 100) — check whether dashboards/alerts actually filter on
+- **HIGH but bounded** (`valueCount` ≳ 100): check whether dashboards/alerts actually filter on
   that label before recommending aggregation.
 
 > **Infra identity override (mandatory).** For a metric protected by
@@ -116,7 +116,7 @@ highest-cardinality first, each with `valueCount` and sample `values`. Classify 
 > Pod Age. This overrides the generic ACCUMULATING fixes in the cardinality reference.
 
 To reduce cardinality use the `metricstransform` processor's `aggregate_labels` action to *merge*
-series (samples are the billable cost, so merging is what actually cuts it) — not the `transform`
+series (samples are the billable cost, so merging is what actually cuts it), not the `transform`
 processor's `delete_key`, which leaves the same sample count and creates colliding series. If a
 label is essential to the metric's identity, drop the whole metric or fix it at the SDK instead.
 For histograms, reducing bucket boundaries cuts samples with little P99 impact. Docs:
@@ -142,7 +142,7 @@ explicitly asks about log cost.
   meter metric whose live unit and meaning represent log bytes, summed as in Step 1.
 - Attribution: run the **same meter query grouped by `service.name`**. This returns one group per
   service plus an unset/empty-`service.name` group for logs with no attribution. Compute the ratio
-  entirely from THIS grouped result so numerator and denominator share one basis — a grouped sum can
+  entirely from THIS grouped result so numerator and denominator share one basis; a grouped sum can
   differ from the ungrouped total, so never divide the grouped attributed sum by the ungrouped
   total:
   - attributed GB = sum of the groups with a non-empty `service.name`.
@@ -152,14 +152,14 @@ explicitly asks about log cost.
   - **≥ 10% → Path A (service mode).**
   - **< 10% → Path B (namespace mode).** Logs come from an infra forwarder (Fluent Bit /
     Fluentd / Vector), not OTel SDKs, so `service.name` isn't set. Path B is a less common
-    setup — sanity-check its numbers.
+    setup, so sanity-check its numbers.
 
 **3b. Analyze the selected attribution path and identify candidate fixes.** The fixes in this
 step are candidates only. Complete the alert check in Step 3c before recommending any log-volume
 reduction, including a source log-level change.
 
-**Path A — service mode (≥ 10%).** Get the severity mix with `signoz_aggregate_logs`,
-`aggregation: count`, `groupBy: "service.name,severity_text"`. Classify severities — REDUCIBLE =
+**Path A, service mode (≥ 10%).** Get the severity mix with `signoz_aggregate_logs`,
+`aggregation: count`, `groupBy: "service.name,severity_text"`. Classify severities: REDUCIBLE =
 INFO, INFORMATION, DEBUG, TRACE, VERBOSE; HIGH-SIGNAL = ERROR, FATAL, CRITICAL, WARN, WARNING.
 For each top service by GB:
 - Reducible-dominant + own service code → candidate: set `LOG_LEVEL=WARN` (stops generation at
@@ -168,9 +168,9 @@ For each top service by GB:
   `instrumentation_scope.name`
   (read the scope from a `signoz_search_logs` sample's `scope_name`).
 - No source access → candidate: Collector filter on `severity_text` matching **only the reducible
-  set** (INFO/DEBUG/TRACE) — never a range that also catches WARN+.
+  set** (INFO/DEBUG/TRACE), never a range that also catches WARN+.
 - High-signal-dominant (WARN/ERROR > 50%) → the logs are worth keeping; a high error rate may be
-  a real problem — flag it separately, do not recommend filtering it away.
+  a real problem, so flag it separately, do not recommend filtering it away.
 
 > **Service severity guard.** The candidate fixes above (`LOG_LEVEL=WARN`, or a Collector filter
 > scoped to INFO/DEBUG only) preserve WARN+ by construction, so the severity mix does not block
@@ -178,23 +178,23 @@ For each top service by GB:
 > to actions that would *also* drop high-signal logs: a **blanket service drop**, or a
 > `severity_text` filter whose range includes WARN/ERROR/FATAL/CRITICAL. Before recommending one
 > of those, compute high-signal %
-> = (all HIGH-SIGNAL severities — ERROR, FATAL, CRITICAL, WARN, **and WARNING** — matched
+> = (all HIGH-SIGNAL severities, including ERROR, FATAL, CRITICAL, WARN, **and WARNING**, matched
 > case-insensitively) ÷ service total. **If it is > 1% (or a non-trivial absolute count), do not
-> take the blanket action** — keep the reduction scoped to INFO/DEBUG and flag the errors as a real
+> take the blanket action**: keep the reduction scoped to INFO/DEBUG and flag the errors as a real
 > signal.
 
-**Path B — namespace mode (< 10%).**
+**Path B, namespace mode (< 10%).**
 - Top namespaces: `signoz_aggregate_logs`, `count`,
   `groupBy: "k8s.namespace.name,deployment.environment"`, order by count desc, limit ~10. Use a
-  **24h** window (7-day namespace scans time out on large tenants; count is the proxy — the Cost
+  **24h** window (7-day namespace scans time out on large tenants; count is the proxy, since the Cost
   Meter has no namespace dimension).
 - Severity per namespace: `signoz_aggregate_logs`, `count`,
   `groupBy: "k8s.namespace.name,severity_text"`.
 - Samples: `signoz_search_logs`, `filter: "k8s.namespace.name = '<ns>'"`, small limit; read
   `body`, `severity_text`, `scope_name`.
 
-> **Namespace severity guard.** high-signal % = (all HIGH-SIGNAL severities — ERROR, FATAL,
-> CRITICAL, WARN, **and WARNING** — matched case-insensitively) ÷ namespace
+> **Namespace severity guard.** high-signal % = (all HIGH-SIGNAL severities, including ERROR, FATAL,
+> CRITICAL, WARN, **and WARNING**, matched case-insensitively) ÷ namespace
 > total. **If it is > 1% (or a non-trivial absolute count), do not consider dropping or
 > filtering the whole namespace.** Scope the filter to the specific noisy pattern (a log
 > category, a `severity_text` match, or a component). Never drop a namespace that carries active
@@ -206,9 +206,9 @@ For each top service by GB:
   impossible).
 - `k8s.event.*` logs are often high-volume / low-value → droppable if not alerted on.
 
-**3c. Log alerts — check before any log-reduction recommendation.** `signoz_list_alert_rules`,
+**3c. Log alerts: check before any log-reduction recommendation.** `signoz_list_alert_rules`,
 **paginating through every page** (follow `pagination.nextOffset` until `pagination.hasMore` is
-false — do not stop at the first page, or an alert on a later page is missed and a filter looks
+false; do not stop at the first page, or an alert on a later page is missed and a filter looks
 safe when it isn't). Keep `alertType == "LOGS_BASED_ALERT"`. For each, `signoz_get_alert(id)` and read
 `condition.compositeQuery.queries[].spec.filter.expression` + `groupBy` to see which service /
 severity / namespace it guards. If a filter would blind an alert, mark it **Will break alert
@@ -219,7 +219,7 @@ coverage** and name the alert. Docs: https://signoz.io/docs/logs-management/guid
 Run when the Cost Meter shows span data, ordered by its cost contribution, or when the user
 explicitly asks about span cost.
 
-**4a. Global operation-name view — read this first.** `signoz_aggregate_traces`,
+**4a. Global operation-name view, read this first.** `signoz_aggregate_traces`,
 `aggregation: count`, `groupBy: "name"`, `orderBy: "count() desc"`, limit 20, **no service
 filter**. This surfaces auto-instrumentation noise (health checks, SQL, cache, sidecars) across
 all services at once.
@@ -229,7 +229,7 @@ all services at once.
 represent span bytes, summed as in Step 1 and grouped by the `service.name` field returned by
 `signoz_get_field_keys` (copying its `name`, `fieldDataType`, `fieldContext`, and `signal`).
 Compute each service's % against the **grouped total (sum of all service groups from this same
-query)**, not a top-N sum and not the separately-fetched ungrouped total — keep numerator and
+query)**, not a top-N sum and not the separately-fetched ungrouped total; keep numerator and
 denominator on one grouped basis. For each top-3
 service by GB, get its dominant operations with `signoz_get_service_top_operations` (or
 `signoz_aggregate_traces` with `service: "<svc>"` + `groupBy: "name"`). The op breakdown is
@@ -247,7 +247,7 @@ service you consider reducing.
 - Common noise candidates: health/liveness (`/health`, `/ping`, `/ready`,
   `grpc.health.v1.Health/Check`); proxy/sidecar (`envoy.*`, `istio.*`, `linkerd.*`). Treat these as
   candidates, not automatically safe removals; the APM guard below still applies.
-- Research before concluding — do not assume: SQL fragments (the language decides the library:
+- Research before concluding, and do not assume: SQL fragments (the language decides the library:
   Java → JDBC, Python → SQLAlchemy, Node → pg/mysql2/sequelize, .NET → EF/Dapper); cache commands
   (HMGET/GET/SET… → ioredis, redis-py, Jedis, go-redis…); unfamiliar gRPC methods. Search first;
   if still unidentified after searching, say so.
@@ -270,11 +270,11 @@ Docs: https://signoz.io/docs/traces-management/guides/drop-spans/
 
 ### Step 5: Report what you found
 
-Lead with a **TL;DR** — concise, no headers, two parts:
-1. **Cost orientation** — which signal is the primary driver, how much, and what generates it
+Lead with a **TL;DR**: concise, no headers, two parts:
+1. **Cost orientation**: which signal is the primary driver, how much, and what generates it
    (name the service, environment, or metric). If several things together dominate, name them
    with individual shares and combined impact.
-2. **Prioritized action list** — every actionable finding in priority order, each with its
+2. **Prioritized action list**: every actionable finding in priority order, each with its
    status inline: **Safe to implement** / **Needs one check first** (state what) / **Will break
    dashboards** (name them) / **Will break alert coverage** (name the alert) / **Infra-page
    dependency** (breaks the Hosts/K8s view). For metric drops, include the volume % so the
@@ -284,7 +284,7 @@ After the TL;DR, add only evidence or context that was not already stated. Rank 
 the decision order in Steps 2–4, but state each finding and guardrail once instead of repeating
 the action list or the per-signal playbooks.
 
-Keep it conversational — a prioritized triage list, not a formatted report with headers and
+Keep it conversational: a prioritized triage list, not a formatted report with headers and
 tables. Cover every signal with Cost Meter data in that single list; do not ask whether to inspect
 a signal the workflow already analyzed.
 
@@ -293,11 +293,11 @@ a signal the workflow already analyzed.
 - **Never declare a drop or filter "safe" on a partial check.** Paginate
   `signoz_list_alert_rules` fully (through `pagination.hasMore`) before ruling out alert impact,
   and treat a non-empty `error` from `signoz_check_metric_usage` as *unknown* usage (needs a
-  manual check) — not as "unused." An incomplete lookup is not a green light.
+  manual check), not as "unused." An incomplete lookup is not a green light.
 - **Volume comes from discovered Cost Meter metrics and their live units:** bytes for span/log
   volume or samples for metric volume. Never cite span/log record counts as volume.
 - **Cost totals and grouped total attribution use `signoz_execute_builder_query`** with raw
-  `timeAggregation: sum`, hourly `stepInterval: 3600`, and complete datapoints only — never
+  `timeAggregation: sum`, hourly `stepInterval: 3600`, and complete datapoints only, never
   `signoz_query_metrics`.
 - Every Cost Meter `builder_query` sent through that raw escape hatch includes
   `limit: 100` and Query Builder v5 `order: [{key:{name:"__result"},
@@ -307,27 +307,27 @@ a signal the workflow already analyzed.
 - **Never present an Infra-page or APM metric as safe to drop** (see
   `references/infra-do-not-drop.md`), even when usage-check shows no dashboards or alerts.
 - **Logs:** never recommend dropping/filtering a whole service or namespace that carries active
-  ERROR/WARN (> 1% high-signal, or a non-trivial absolute count) — scope the filter to the noisy
+  ERROR/WARN (> 1% high-signal, or a non-trivial absolute count); scope the filter to the noisy
   pattern. Fix order: at source (`LOG_LEVEL=WARN`) → Collector scope filter
   (`instrumentation_scope.name`) → `severity_text` filter.
 - **Logs attribution is a hard threshold:** ≥ 10% → Path A; < 10% → Path B. Compute it.
 - **Traces:** never recommend or configure head, probabilistic, tail, or any other sampling.
   Sampling limits the built-in APM/Services metrics to retained traces, so absolute request counts
   and rates no longer represent all traffic.
-- **UNBOUNDED and IDENTIFIER labels are always worth flagging** — the problem is trajectory, not
+- **UNBOUNDED and IDENTIFIER labels are always worth flagging**: the problem is trajectory, not
   just current count.
 - **Never suggest changing retention. Never estimate dollar savings.** Never call a dashboard or
-  alert unused/noisy/redundant — report counts only.
-- **Anchor claims to query results.** If a signal has no Cost Meter data, say so — do not
+  alert unused/noisy/redundant; report counts only.
+- **Anchor claims to query results.** If a signal has no Cost Meter data, say so; do not
   substitute count-based proxies. Don't re-list metrics already shown in the breakdown; metrics
   outside the top ~20 by volume are individually negligible.
 
 ## Additional resources
 
-- `references/cost-meter-queries.md` — Cost Meter discovery, the full
+- `references/cost-meter-queries.md`: Cost Meter discovery, the full
   `signoz_execute_builder_query` template, unit conversion, and the grouped-vs-ungrouped caveat.
-- `references/infra-do-not-drop.md` — the metrics behind the built-in Infrastructure and
+- `references/infra-do-not-drop.md`: the metrics behind the built-in Infrastructure and
   APM/Services pages that must never be recommended for dropping.
-- `references/otel-attribute-cardinality.md` — reference for classifying metric labels
+- `references/otel-attribute-cardinality.md`: reference for classifying metric labels
   (UNBOUNDED / ACCUMULATING / BOUNDED / IDENTIFIER).
-- `signoz-generating-queries` skill — for the ad-hoc follow-up queries this investigation points to.
+- `signoz-generating-queries` skill: for the ad-hoc follow-up queries this investigation points to.

--- a/plugins/signoz/skills/signoz-reducing-telemetry-cost/references/infra-do-not-drop.md
+++ b/plugins/signoz/skills/signoz-reducing-telemetry-cost/references/infra-do-not-drop.md
@@ -1,29 +1,29 @@
-# Infra-page "do-not-drop" metrics — the safety guard
+# Infra-page "do-not-drop" metrics: the safety guard
 
 ## Contents
 - The rule (Infra page uses built-in queries, not dashboards)
-- Hosts view — families
-- Kubernetes view — enumerated names + workload/volume/namespace/cluster families
-- APM / Services page — span-derived `signoz_*` RED metrics
+- Hosts view: families
+- Kubernetes view: enumerated names + workload/volume/namespace/cluster families
+- APM / Services page: span-derived `signoz_*` RED metrics
 - Required attributes and page metadata (resolution / filtering)
 - Why the do-not-drop list matters
 - Caveat / discrepancy to keep in mind
 
 The SigNoz **Infrastructure** page (Hosts and Kubernetes views) queries these metrics
-via **built-in queries, not dashboards** — and fails silently when the data is missing.
+via **built-in queries, not dashboards**, and fails silently when the data is missing.
 So `signoz_check_metric_usage` will report them as having **no dashboards/alerts**, yet
 dropping them **breaks the Infra page.** This list is the authoritative exception to the
 "unused ⇒ drop candidate" rule.
 
 **Rule:** if a drop candidate matches anything below, do NOT present it as "safe to
-drop." Present it as **"Infra-page dependency — dropping breaks the Hosts/Kubernetes
+drop." Present it as **"Infra-page dependency: dropping breaks the Hosts/Kubernetes
 view; confirm you don't use that view before dropping."** This overrides the empty
 usage-check result.
 
-Bias intentionally conservative (family-level) — over-protecting a metric costs a little
+Bias intentionally conservative (family-level); over-protecting a metric costs a little
 saving; under-protecting silently breaks a product page.
 
-## Hosts view — families (treat whole prefix as load-bearing)
+## Hosts view: families (treat whole prefix as load-bearing)
 - `system.cpu.*` (incl. `system.cpu.load_average.1m/5m/15m`)
 - `system.memory.*`
 - `system.disk.*`
@@ -33,12 +33,12 @@ saving; under-protecting silently breaks a product page.
 - `system.processes.*`
 - `host.cpu.usage` (used for host entity validation)
 
-Exact `system.*` names are NOT enumerated in SigNoz docs — definitive list lives in the
+Exact `system.*` names are NOT enumerated in SigNoz docs; definitive list lives in the
 frontend Hosts query builders. Family-level protection is the safe default; refine from
 frontend source only if a user needs to drop a specific `system.*` metric.
 
-## Kubernetes view — enumerated names (from k8s-metrics.mdx, high confidence)
-Entity resolution (critical — missing = entities don't resolve / click errors):
+## Kubernetes view: enumerated names (from k8s-metrics.mdx, high confidence)
+Entity resolution (critical; missing = entities don't resolve / click errors):
 - `k8s.pod.cpu.usage`, `k8s.node.cpu.usage`
 Pods: `k8s.pod.cpu.usage`, `k8s.pod.cpu_request_utilization`, `k8s.pod.cpu_limit_utilization`,
   `k8s.pod.memory_request_utilization`, `k8s.pod.memory_limit_utilization`, `k8s.pod.memory.usage`,
@@ -48,7 +48,7 @@ Containers: `container.cpu.usage`, `container.uptime`,
   `k8s.container.memory_request_utilization`, `k8s.container.memory_limit_utilization`
 Nodes: `k8s.node.cpu.usage`, `k8s.node.condition`, `k8s.node.uptime`
 The Workload (Deployments/StatefulSets/DaemonSets/Jobs/ReplicaSets), Volumes, Namespaces, and
-Clusters tabs each render from their own metric families — `k8s.replicaset.*`, `k8s.deployment.*`,
+Clusters tabs each render from their own metric families: `k8s.replicaset.*`, `k8s.deployment.*`,
 `k8s.volume.*`, and the rest listed below are all load-bearing for those tabs.
 
 **Families safe to treat whole** (family-level protection is the safe default; exact names in
@@ -57,9 +57,9 @@ Clusters tabs each render from their own metric families — `k8s.replicaset.*`,
 `k8s.replicaset.*`, `k8s.statefulset.*`, `k8s.daemonset.*`, `k8s.job.*`, `k8s.cronjob.*`,
 `k8s.hpa.*`, `k8s.volume.*`, `k8s.namespace.*`, `k8s.cluster.*`
 
-## APM / Services page — powered exclusively by span-derived `signoz_*` RED metrics
+## APM / Services page: powered exclusively by span-derived `signoz_*` RED metrics
 The SigNoz APM / Services pages are built from span-derived RED metrics that the
-`signozspanmetrics` collector processor generates from the traces pipeline — not from any user
+`signozspanmetrics` collector processor generates from the traces pipeline, not from any user
 dashboard.
 
 The Services list and service-detail charts (rate, error %, p50/p90/p99 latency, apdex, DB
@@ -68,14 +68,14 @@ calls, external calls) query ONLY these span-derived metrics:
 - `signoz_latency_bucket`, `signoz_latency_count`, `signoz_latency_sum`
 - `signoz_db_latency_count`, `signoz_db_latency_sum`
 - `signoz_external_call_latency_count`, `signoz_external_call_latency_sum`
-- dotted variants (`signoz_latency.bucket`, …) when `dotMetricsEnabled` is on — same data.
+- dotted variants (`signoz_latency.bucket`, …) when `dotMetricsEnabled` is on (same data).
 
 **Handling in the skill:**
 - These already fall under the internal-`signoz_`/`signoz.` exclusion → never in the drop
   candidate list. Keep it that way; if a user asks about them, explain they power the APM
   page (do not drop).
 - **OTel-native `http.server.*` / `rpc.*` metrics do NOT back the APM page in SigNoz.** Treat
-  them as ordinary metrics — normal usage-check applies; if unused and not in a dashboard/alert
+  them as ordinary metrics: normal usage-check applies; if unused and not in a dashboard/alert
   they are genuinely droppable (histograms: trim buckets rather than hard-drop). No special APM
   protection.
 - **Trace-layer dependency:** because these RED metrics are generated from spans, trace sampling
@@ -87,8 +87,8 @@ calls, external calls) query ONLY these span-derived metrics:
   entirely. Treat that as a separate lever.
 
 ## Required attributes and page metadata (not metrics)
-- Hosts: `host.name` (required — missing = host not clickable), `host.id` (fallback)
-- Kubernetes entity resolution: each entity's `.uid` + `.name` —
+- Hosts: `host.name` (required; missing = host not clickable), `host.id` (fallback)
+- Kubernetes entity resolution: each entity's `.uid` + `.name`:
   `k8s.pod.uid`/`k8s.pod.name`,
   `k8s.node.uid`/`k8s.node.name`, `k8s.deployment.name`, `k8s.namespace.name`,
   `k8s.statefulset.name`, `k8s.daemonset.name`, `k8s.job.name`, `k8s.cronjob.name`,
@@ -103,7 +103,7 @@ calls, external calls) query ONLY these span-derived metrics:
 metrics as referenced by no dashboard and no alert. That is exactly the trap: the Infra page
 queries them directly rather than through a dashboard, so "no usage" does **not** mean "safe to
 drop." Top-volume `k8s.*` metrics like `k8s.node.condition` and the `k8s.container.*_utilization`
-family are common offenders — frequently the single biggest metric-volume contributors, and
+family are common offenders, frequently the single biggest metric-volume contributors, and
 exactly what a naive drop pass would remove first.
 
 ## Caveat / discrepancy to keep in mind

--- a/plugins/signoz/skills/signoz-reducing-telemetry-cost/references/otel-attribute-cardinality.md
+++ b/plugins/signoz/skills/signoz-reducing-telemetry-cost/references/otel-attribute-cardinality.md
@@ -20,11 +20,11 @@ For each attribute: profile, why it matters, and what to do about it.
 
 ## Profiles
 
-- **UNBOUNDED** — grows without ceiling. Every new URL, query, ID, or stack trace creates a new series permanently. These are the most dangerous.
-- **ACCUMULATING** — grows with infrastructure churn (pod restarts, deploys). Does not reflect concurrent active series — a metric with 20,000 `k8s.pod.uid` values may only have 50 active pods right now.
-- **BOUNDED** — fixed or near-fixed set of values. Safe to keep as a label dimension.
-- **DEPLOYMENT_DEPENDENT** — cardinality depends on the deployment scale. Fine at 10 services, dangerous at 500.
-- **IDENTIFIER** — always a unique ID per request/event. Should never appear as a metric label. Immediate red flag.
+- **UNBOUNDED**: grows without ceiling. Every new URL, query, ID, or stack trace creates a new series permanently. These are the most dangerous.
+- **ACCUMULATING**: grows with infrastructure churn (pod restarts, deploys). Does not reflect concurrent active series; a metric with 20,000 `k8s.pod.uid` values may only have 50 active pods right now.
+- **BOUNDED**: fixed or near-fixed set of values. Safe to keep as a label dimension.
+- **DEPLOYMENT_DEPENDENT**: cardinality depends on the deployment scale. Fine at 10 services, dangerous at 500.
+- **IDENTIFIER**: always a unique ID per request/event. Should never appear as a metric label. Immediate red flag.
 
 ---
 
@@ -49,7 +49,7 @@ For each attribute: profile, why it matters, and what to do about it.
 | `net.peer.name` | DEPLOYMENT_DEPENDENT | Hostname of remote peer. Fine if calling fixed upstream services, unbounded if calling arbitrary user-supplied hosts | Review actual cardinality |
 | `net.peer.port` | UNBOUNDED | Ephemeral client ports are unique per connection (range 32768–60999). Server ports are bounded but client ports are not. | Check if client or server port; drop client ports |
 | `net.host.port` | BOUNDED | Server-side listening port. Small fixed set | Safe |
-| `client.port` | UNBOUNDED | Client-side ephemeral port. Always unbounded | Drop — no diagnostic value |
+| `client.port` | UNBOUNDED | Client-side ephemeral port. Always unbounded | Drop (no diagnostic value) |
 | `client.address` | DEPLOYMENT_DEPENDENT | Client IP. Bounded in internal service mesh, unbounded for public-facing APIs | Check cardinality |
 | `server.address` | DEPLOYMENT_DEPENDENT | Upstream hostname. Usually bounded | Review |
 | `server.port` | BOUNDED | Server-side port. Fixed set | Safe |
@@ -83,7 +83,7 @@ For each attribute: profile, why it matters, and what to do about it.
 |-----------|---------|-------|-----|
 | `messaging.message_id` | IDENTIFIER | Unique per message. Should never be a metric label | Drop immediately |
 | `messaging.destination.name` | DEPLOYMENT_DEPENDENT | Topic/queue name. Bounded if topics are fixed, unbounded if dynamically created per user/tenant | Check cardinality |
-| `messaging.kafka.message_key` | UNBOUNDED | Message key — can be any string | Drop |
+| `messaging.kafka.message_key` | UNBOUNDED | Message key (can be any string) | Drop |
 | `messaging.kafka.partition` | BOUNDED | Partition number. Fixed per topic | Safe |
 | `messaging.kafka.consumer_group` | DEPLOYMENT_DEPENDENT | Consumer group name. Usually bounded | Usually safe |
 | `messaging.rabbitmq.routing_key` | DEPLOYMENT_DEPENDENT | Routing key. Bounded if fixed routes, unbounded if dynamic | Check cardinality |
@@ -107,7 +107,7 @@ For each attribute: profile, why it matters, and what to do about it.
 
 | Attribute | Profile | Notes | Fix |
 |-----------|---------|-------|-----|
-| `k8s.pod.uid` | ACCUMULATING | New UID per pod restart. Accumulates over time — 7-day window captures every pod that ever ran, not just current pods | Keep on Infra-page metrics; on unrelated custom metrics, aggregate only after identity and usage review |
+| `k8s.pod.uid` | ACCUMULATING | New UID per pod restart. Accumulates over time; a 7-day window captures every pod that ever ran, not just current pods | Keep on Infra-page metrics; on unrelated custom metrics, aggregate only after identity and usage review |
 | `k8s.pod.name` | ACCUMULATING | Pod names with random suffixes change on every restart/deploy. Same accumulation problem as pod.uid | Keep on Infra-page metrics; apply the generic fix only to unrelated custom metrics |
 | `k8s.pod.start_time` | ACCUMULATING | Timestamp of pod start. Unique per pod lifecycle; the Pods page uses it for Pod Age | Keep on Pod Infra metrics; remove from unrelated custom metrics only after usage review |
 | `container.id` | ACCUMULATING | Container runtime ID. New per restart; current Infra container identity uses `k8s.pod.uid` + `k8s.container.name` | Aggregate away after usage review |
@@ -189,9 +189,9 @@ For each attribute: profile, why it matters, and what to do about it.
 
 | Attribute | Profile | Notes | Fix |
 |-----------|---------|-------|-----|
-| `service.name` | BOUNDED | Service name. Fixed set — this is a required attribute | Safe, keep always |
+| `service.name` | BOUNDED | Service name. Fixed set; this is a required attribute | Safe, keep always |
 | `service.version` | DEPLOYMENT_DEPENDENT | Service version. Bounded if versioning is controlled. Can grow if CI deploys unique versions per commit | Check cardinality |
-| `service.instance.id` | DEPLOYMENT_DEPENDENT | Instance identifier. Bounded = one per running pod. But if it includes a UUID or timestamp, it becomes ACCUMULATING | Check format — if it contains hyphens/long random strings, treat as ACCUMULATING |
+| `service.instance.id` | DEPLOYMENT_DEPENDENT | Instance identifier. Bounded = one per running pod. But if it includes a UUID or timestamp, it becomes ACCUMULATING | Check format: if it contains hyphens/long random strings, treat as ACCUMULATING |
 | `service.namespace` | BOUNDED | Logical grouping of services. Fixed | Safe |
 | `deployment.environment` | BOUNDED | prod, staging, dev, uat etc. | Safe |
 | `telemetry.sdk.name` | BOUNDED | opentelemetry etc. | Safe |
@@ -210,7 +210,7 @@ If you encounter an attribute not listed above, reason through these questions:
 4. **Is it chosen from a fixed vocabulary defined at deploy time?** → Probably BOUNDED. Check actual cardinality to confirm.
 5. **Does the cardinality roughly equal the number of running instances/nodes/pods?** → DEPLOYMENT_DEPENDENT. Flag if count is high but not an immediate problem.
 
-When uncertain — report the attribute name, its observed cardinality, and the value pattern (e.g. "looks like UUIDs", "looks like IP:port pairs") and let the user verify.
+When uncertain, report the attribute name, its observed cardinality, and the value pattern (e.g. "looks like UUIDs", "looks like IP:port pairs") and let the user verify.
 
 ---
 
@@ -221,16 +221,16 @@ For Infra-page metric families, the required identity attributes and page metada
 
 | Problem | Fix | Where |
 |---------|-----|-------|
-| UNBOUNDED label on existing metric | `metricstransform` processor — aggregate the label away (merges series) | OTel Collector |
-| ACCUMULATING label | Same — `metricstransform` aggregate | OTel Collector |
-| IDENTIFIER label (span.id, trace.id, user.id) | `metricstransform` `aggregate_labels` to merge series — or stop emitting it as a metric label | OTel Collector / SDK |
-| Raw SQL / stack traces as labels | Instrument correctly — use `db.operation` not `db.query.text` | SDK / instrumentation config |
-| Client port (net.peer.port, client.port) | `metricstransform` `aggregate_labels` to merge series — or stop emitting it at the SDK | OTel Collector / SDK |
-| Too many service instances | `service.instance.id` is expected to be high — only a problem if it contains timestamps/UUIDs that don't reflect real instance count | Check format |
+| UNBOUNDED label on existing metric | `metricstransform` processor: aggregate the label away (merges series) | OTel Collector |
+| ACCUMULATING label | Same: `metricstransform` aggregate | OTel Collector |
+| IDENTIFIER label (span.id, trace.id, user.id) | `metricstransform` `aggregate_labels` to merge series, or stop emitting it as a metric label | OTel Collector / SDK |
+| Raw SQL / stack traces as labels | Instrument correctly: use `db.operation` not `db.query.text` | SDK / instrumentation config |
+| Client port (net.peer.port, client.port) | `metricstransform` `aggregate_labels` to merge series, or stop emitting it at the SDK | OTel Collector / SDK |
+| Too many service instances | `service.instance.id` is expected to be high; only a problem if it contains timestamps/UUIDs that don't reflect real instance count | Check format |
 
-**Important — cardinality reduction means fewer samples, and samples are the billable cost.**
+**Important: cardinality reduction means fewer samples, and samples are the billable cost.**
 Use the `metricstransform` processor's `aggregate_labels` action to *merge* the
-series that share the remaining labels — that is what actually cuts the series and sample count.
+series that share the remaining labels; that is what actually cuts the series and sample count.
 Do **not** use the `transform` processor's `delete_key`: removing a label key without merging
 leaves the same number of samples and produces colliding series (SigNoz sums them), so cost does
 not drop. If a label is essential to the metric's identity, drop the whole metric or stop

--- a/plugins/signoz/skills/signoz-searching-docs/README.md
+++ b/plugins/signoz/skills/signoz-searching-docs/README.md
@@ -6,14 +6,14 @@ This skill ships inside the official `signoz` Claude plugin and the shared `skil
 
 ## How it works
 
-1. **Docs fetch** — Prefers the SigNoz MCP server tools (`signoz_search_docs`, `signoz_fetch_doc`) when available, and falls back to direct HTTP fetch with `Accept: text/markdown` (which SigNoz docs support natively) so the agent gets clean markdown instead of scraping HTML.
-2. **Domain heuristics** — Decision trees route the user to the right guide before fetching docs, which avoids jumping to a random page without understanding the setup.
+1. **Docs fetch**: prefers the SigNoz MCP server tools (`signoz_search_docs`, `signoz_fetch_doc`) when available, and falls back to direct HTTP fetch with `Accept: text/markdown` (which SigNoz docs support natively) so the agent gets clean markdown instead of scraping HTML.
+2. **Domain heuristics**: decision trees route the user to the right guide before fetching docs, which avoids jumping to a random page without understanding the setup.
 
 ## Structure
 
 ```
 plugins/signoz/skills/signoz-searching-docs/
-├── SKILL.md              # Entry point — goal, docs-fetch method, workflow, heuristic routing table
+├── SKILL.md              # Entry point: goal, docs-fetch method, workflow, heuristic routing table
 ├── README.md
 └── heuristics/
     └── sending-logs.md   # Log collection method decision tree
@@ -31,6 +31,6 @@ plugins/signoz/skills/signoz-searching-docs/
 
 ## Planned heuristics
 
-- **Sending Traces** — language selection, auto vs manual instrumentation
-- **Sending Metrics** — application metrics vs infrastructure vs Prometheus
-- **Troubleshooting** — data not showing up, collector issues, common errors
+- **Sending Traces**: language selection, auto vs manual instrumentation
+- **Sending Metrics**: application metrics vs infrastructure vs Prometheus
+- **Troubleshooting**: data not showing up, collector issues, common errors

--- a/plugins/signoz/skills/signoz-searching-docs/SKILL.md
+++ b/plugins/signoz/skills/signoz-searching-docs/SKILL.md
@@ -5,8 +5,8 @@ description: >
   whenever the user asks "how do I", "where in the docs", "what does the
   docs say about", "find docs for", or otherwise needs reference material
   on SigNoz instrumentation, OpenTelemetry setup, self-hosted deployment,
-  API endpoints, auth headers, or troubleshooting steps — even if they
-  don't say the word "docs" explicitly. Docs lookup only — for actions
+  API endpoints, auth headers, or troubleshooting steps, even if they
+  don't say the word "docs" explicitly. Docs lookup only; for actions
   inside SigNoz, the agent will pick the matching `signoz-*` action skill.
 ---
 
@@ -20,10 +20,10 @@ Prefer the SigNoz MCP server tools when available; fall back to direct HTTP fetc
 
 ### Preferred: MCP tools
 
-- `signoz_search_docs` — BM25 search over the indexed docs corpus. Pass the user's natural-language query as `searchText`. Narrow with `section_slug` when the question maps cleanly to a single docs section (the tool's own schema lists valid slugs — defer to it rather than memorizing). Trust the ranking — the index handles relevance.
-- `signoz_fetch_doc` — markdown for one indexed page. Pass the canonical URL or `/docs/...` path; optionally narrow to a section with `heading`. Inspect `truncation_reason` and `available_headings` in every response rather than assuming the returned `content` is complete.
+- `signoz_search_docs`: BM25 search over the indexed docs corpus. Pass the user's natural-language query as `searchText`. Narrow with `section_slug` when the question maps cleanly to a single docs section (the tool's own schema lists valid slugs; defer to it rather than memorizing). Trust the ranking; the index handles relevance.
+- `signoz_fetch_doc`: markdown for one indexed page. Pass the canonical URL or `/docs/...` path; optionally narrow to a section with `heading`. Inspect `truncation_reason` and `available_headings` in every response rather than assuming the returned `content` is complete.
 
-Never call `signoz_search_docs` with empty `searchText` — always pass the user's phrase.
+Never call `signoz_search_docs` with empty `searchText`; always pass the user's phrase.
 Never call `signoz_fetch_doc` without a URL; neither tool guesses missing input.
 `signoz://...` URIs are MCP resources: read them through the MCP resource API,
 never `signoz_fetch_doc`, which accepts only `https://signoz.io/docs/...` URLs
@@ -53,10 +53,10 @@ Accept: text/markdown
 ## Workflow
 
 1. **Identify the domain** from the user's question: instrumentation, OpenTelemetry setup, querying, dashboards, alerts, troubleshooting, deployment, or API docs.
-2. **Check the heuristics table below**. If a heuristic matches, read it before answering — heuristics encode product decisions (which path/method fits the user's environment), useful in both paths.
-3. **Search and fetch** — pick the path based on tool availability:
+2. **Check the heuristics table below**. If a heuristic matches, read it before answering: heuristics encode product decisions (which path/method fits the user's environment), useful in both paths.
+3. **Search and fetch**: pick the path based on tool availability:
    - **With MCP tools**: call `signoz_search_docs` with the user's query; pass `section_slug` if the domain maps cleanly to one. Read the top 1-3 results and call `signoz_fetch_doc` on the chosen URL (use `heading` to narrow if the page is large and the question is sub-section-specific).
-   - **Without MCP tools**: grep `sitemap.md` for candidate pages, rank the best 2-5 by how directly they answer the task, and `GET` only URLs discovered in the sitemap with `Accept: text/markdown`. Heuristic coverage is sparse — for topics without a heuristic row, skim the sitemap by section path and prefer setup/troubleshooting/API-reference pages over overviews.
+   - **Without MCP tools**: grep `sitemap.md` for candidate pages, rank the best 2-5 by how directly they answer the task, and `GET` only URLs discovered in the sitemap with `Accept: text/markdown`. Heuristic coverage is sparse; for topics without a heuristic row, skim the sitemap by section path and prefer setup/troubleshooting/API-reference pages over overviews.
    - Fetch **one page** for narrow questions; fetch **multiple pages** when the task spans setup + troubleshooting, or method-selection + language guide. Keep the set small.
 4. **Handle truncated fetches before answering.** When `signoz_fetch_doc` returns `truncation_reason: "size"`, treat `content` as an incomplete prefix. Select the most relevant entry from `available_headings` and refetch the same search-result URL with that `heading`. If no heading covers the question, or the narrowed response is still truncated before the needed material, disclose that the fetched documentation is incomplete and do not infer that omitted content or a setting does not exist.
 5. **Answer from the fetched docs** and cite canonical `https://signoz.io/docs/...` URLs.
@@ -66,8 +66,8 @@ Accept: text/markdown
 
 On the terminal answer, emit FE-handoff actions per the SigNoz Skills & MCP spec:
 
-- **`open_docs`** — include with the canonical URL of the primary cited page. Docs lookups are precisely the case where deep-linking to the source page helps the user read in context and verify the answer.
-- **`follow_up`** — 1-2 next-step prompts that build on a docs answer. After a setup guide: *"walk me through the first command"* or *"what's a common gotcha here?"*. After a concept page: *"show me a worked example."*
+- **`open_docs`**: include with the canonical URL of the primary cited page. Docs lookups are precisely the case where deep-linking to the source page helps the user read in context and verify the answer.
+- **`follow_up`**: 1-2 next-step prompts that build on a docs answer. After a setup guide: *"walk me through the first command"* or *"what's a common gotcha here?"*. After a concept page: *"show me a worked example."*
 - **Do NOT emit `apply_filter`.** Docs answers do not produce a query for an explorer page; emitting `apply_filter` would overwrite the user's working query.
 
 Verbatim guardrail: *When answering a SigNoz docs question, include an `open_docs` action on the final message with the canonical URL of the primary cited page.*

--- a/plugins/signoz/skills/signoz-searching-docs/heuristics/sending-logs.md
+++ b/plugins/signoz/skills/signoz-searching-docs/heuristics/sending-logs.md
@@ -11,7 +11,7 @@ When a user asks about sending/collecting/forwarding logs to SigNoz, **do not ju
 
 ## 2. Is trace-log correlation needed?
 
-- **Yes** → SDK OTLP export (Path 1) — the only path with automatic `trace_id`/`span_id` injection
+- **Yes** → SDK OTLP export (Path 1), the only path with automatic `trace_id`/`span_id` injection
 - **No** → choose based on simplicity, reliability, and where logs already live
 
 ## 3. Is reliability or external collection more important than in-app export?

--- a/plugins/signoz/skills/signoz-setting-up-observability/SKILL.md
+++ b/plugins/signoz/skills/signoz-setting-up-observability/SKILL.md
@@ -2,14 +2,14 @@
 name: signoz-setting-up-observability
 description: >
   Run the full end-to-end observability setup for a service after its
-  telemetry is already flowing into SigNoz — sequence SLI/SLO capture,
+  telemetry is already flowing into SigNoz: sequence SLI/SLO capture,
   data exploration (RED/USE), focused dashboards, saved Explorer views,
   burn-rate and absent-data alerts, and a tuning loop into one
   opinionated, SLO-aware workflow. Make sure to use this skill whenever the user says "set up
   observability after ingestion", "now that data is flowing, give me
   dashboards and alerts", "onboard this service to SigNoz end-to-end",
   "I want the full monitoring setup for X", or asks to go from raw
-  telemetry to a complete dashboard + alerts + views package — even if
+  telemetry to a complete dashboard + alerts + views package, even if
   they don't say "observability" explicitly. This is the orchestration
   layer: for a single artifact (just a dashboard, just one alert, just a
   saved view, or one static threshold alert, or a one-off query) use
@@ -22,7 +22,7 @@ argument-hint: <service name + what to set up (dashboard / alerts / views)>
 
 Take a service from "telemetry is flowing into SigNoz" to "I have a
 dashboard, alerts, saved views, and a tuning loop." This skill is an
-**orchestration layer, not a standalone reference** — the mechanical
+**orchestration layer, not a standalone reference**: the mechanical
 work lives in the sibling SigNoz skills and the MCP tools/resources hold
 the current payload schemas. This skill sequences them and supplies the
 judgment calls (scope, SLOs, thresholds, what to skip) that no single
@@ -31,8 +31,8 @@ rules, so read the relevant `signoz://…` resource before composing any
 payload.
 
 Use this when traces, logs, or metrics are **already landing** in
-SigNoz and you want an opinionated, SLO-aware setup — not when you're
-still wiring up the SDK. Audience: two consumers — an autonomous AI SRE
+SigNoz and you want an opinionated, SLO-aware setup, not when you're
+still wiring up the SDK. Audience: two consumers, an autonomous AI SRE
 agent that runs without a human in the loop (e.g. an in-product SigNoz
 assistant), and an engineer at a Claude Code / Codex / Cursor prompt.
 Both follow the same flow; where a step needs a human decision (Phase 1
@@ -47,7 +47,7 @@ This skill calls SigNoz MCP server tools (`signoz_list_services`,
 `signoz_create_alert`, `signoz_create_view`, etc.) and
 delegates to sibling skills. Before running the workflow, confirm the
 `signoz_*` tools are available. If they are not, the SigNoz MCP
-server is not installed or configured — run `signoz-mcp-setup` first. Do
+server is not installed or configured; run `signoz-mcp-setup` first. Do
 not fall back to raw HTTP calls or fabricate payloads.
 
 ## When to use
@@ -56,12 +56,12 @@ Use this skill when the user wants the **whole post-ingestion setup**:
 SLI/SLO → exploration → dashboard → views → alerts → tuning, in any
 combination of those deliverables, sequenced as one workflow.
 
-Do NOT use this skill when the user wants a single artifact — hand off
+Do NOT use this skill when the user wants a single artifact; hand off
 directly:
 - Just a dashboard → `signoz-creating-dashboards`.
 - Just one static / threshold alert or notification rule →
   `signoz-creating-alerts`. (But SLO / burn-rate / error-budget
-  alerting — even with no dashboard — stays *here*: it needs the SLI/SLO
+  alerting, even with no dashboard, stays *here*: it needs the SLI/SLO
   capture and burn-rate judgment in the phases below.)
 - Just a saved Explorer view → `signoz-managing-views`.
 - A one-off exploratory query → `signoz-generating-queries`.
@@ -71,52 +71,52 @@ directly:
 Each phase below points to the skill that does the mechanical work; this
 skill owns the order and the decisions.
 
-## Phase 1 — Triage scope (don't skip)
+## Phase 1: Triage scope (don't skip)
 
 Before touching any tools, get these answers. Each unblocks a downstream
 phase.
 
 1. **What does this service do, and does it call external services?**
    One or two sentences. This shapes the SLI (what "working" means) and
-   flags downstream dependencies worth monitoring — if it calls a DB,
+   flags downstream dependencies worth monitoring: if it calls a DB,
    cache, queue, or third-party API, plan to watch the client-span
    latency and error rate to each dependency, since a healthy service
    fronting a sick dependency still fails users.
-2. **What deliverables?** dashboard / alerts / saved views — any
+2. **What deliverables?** dashboard / alerts / saved views, any
    combination.
-3. **Infra monitoring too? (optional — ask)** If the service runs on
+3. **Infra monitoring too? (optional; ask)** If the service runs on
    infra you own (k8s pods, VMs, containers) shipping telemetry under
    the same resource attributes, you can add USE/infra panels (CPU,
-   memory, restarts, network) with no extra instrumentation — see Phase
+   memory, restarts, network) with no extra instrumentation; see Phase
    3. Skip if a platform team already owns the host/cluster dashboard.
 4. **Which signals are emitted?** traces / logs / metrics. Drives which
    `signoz_get_field_keys` calls you make.
 5. **What's the canonical resource filter?** Usually `service.name`.
-   Confirm the exact value before querying — don't guess.
+   Confirm the exact value before querying; don't guess.
 6. **What does success look like for users of this service?** (Sets up
    Phase 2.) Even a one-line answer ("requests under 1s with no 5xx") is
-   enough — it becomes the SLI.
+   enough; it becomes the SLI.
 7. **Who owns it, and is there a runbook?** Owning team, service tier,
-   and the prod/staging scope — these become alert labels and
+   and the prod/staging scope; these become alert labels and
    annotations in Phase 8. Capture a real runbook URL if one exists;
    never invent one.
 
 Offer "explore data first" as an explicit option.
 
-## Phase 1.5 — Inventory what already exists
+## Phase 1.5: Inventory what already exists
 
 Each create sub-skill runs its own rigorous duplicate-check when invoked
 (`signoz-creating-dashboards` lists dashboards; `signoz-creating-alerts`
-paginates alert rules) — don't re-implement that here. The orchestration
+paginates alert rules); don't re-implement that here. The orchestration
 value is a single up-front sweep so you *sequence around* what exists
 instead of hitting collisions mid-build:
 
 - **Is the service reporting, and under what exact name?**
   (`signoz_list_services`.) This name is the resource filter every
-  later phase reuses — pin it before anything else.
+  later phase reuses; pin it before anything else.
 - **Does a dashboard / alert / saved view already exist for it?** If so,
-  plan to **extend** it — route to `signoz-modifying-dashboards`,
-  `signoz-managing-views`, or `signoz_update_alert` — rather than
+  plan to **extend** it (route to `signoz-modifying-dashboards`,
+  `signoz-managing-views`, or `signoz_update_alert`) rather than
   standing up a parallel one. `signoz-explaining-dashboards` /
   `signoz-explaining-alerts` summarize anything you're inheriting.
 - **Is there a notification channel to reuse?** (Carried into Phase 5.)
@@ -128,28 +128,28 @@ and meter separately.
 Learn just enough to decide extend-vs-create per artifact; leave the
 exhaustive listing to the sub-skills.
 
-## Phase 2 — Capture the SLI/SLO before designing anything
+## Phase 2: Capture the SLI/SLO before designing anything
 
 This is the gating artifact. Without it, alerts become "the metric
 crossed a line" instead of "the user-visible error budget is being burnt
 fast enough to matter."
 
 Collect:
-- **SLI formula** — `good events / valid events`. E.g. *successful
+- **SLI formula**: `good events / valid events`. E.g. *successful
   checkout requests / total checkout requests* (excluding health checks,
   synthetic probes, scanner traffic, and non-user long-poll endpoints).
-- **SLO target** — e.g. 99.5% over a 30-day rolling window.
-- **Exclusions** — what doesn't count as a valid event (synthetic
+- **SLO target**: e.g. 99.5% over a 30-day rolling window.
+- **Exclusions**: what doesn't count as a valid event (synthetic
   probes, scanner traffic, streaming endpoints).
-- **Error budget allowance** — `1 - SLO`, derived from the target. Remaining
+- **Error budget allowance**: `1 - SLO`, derived from the target. Remaining
   budget additionally requires observed bad/valid events over the SLO window.
 
-Carry these forward — they feed Phase 8 directly. (SLO/burn-rate
+Carry these forward; they feed Phase 8 directly. (SLO/burn-rate
 background: `signoz-searching-docs`.)
 
-## Phase 3 — Explore what's actually there (RED + USE coverage)
+## Phase 3: Explore what's actually there (RED + USE coverage)
 
-`signoz-generating-queries` owns the exploration itself — the
+`signoz-generating-queries` owns the exploration itself: the
 discover-before-querying rule, every discovery call
 (`signoz_list_metrics`, `signoz_get_field_keys`,
 `signoz_get_field_values`,
@@ -164,14 +164,14 @@ spot the gaps, and make the judgment calls generating-queries doesn't:
 
 **Coverage checklist** (RED for services, USE for infra/resources):
 
-- [ ] **R**ate — request/call rate per operation
-- [ ] **E**rrors — error count or rate per operation
-- [ ] **D**uration — p50/p95/p99 latency from spans or histograms
-- [ ] **U**tilization — CPU, memory, disk, queue depth, pool occupancy (only if you own the infra)
-- [ ] **S**aturation — request queue, GC pause, connection pool wait
-- [ ] **E**rrors at the resource layer — disk failures, evictions, OOM kills
+- [ ] **R**ate: request/call rate per operation
+- [ ] **E**rrors: error count or rate per operation
+- [ ] **D**uration: p50/p95/p99 latency from spans or histograms
+- [ ] **U**tilization: CPU, memory, disk, queue depth, pool occupancy (only if you own the infra)
+- [ ] **S**aturation: request queue, GC pause, connection pool wait
+- [ ] **E**rrors at the resource layer: disk failures, evictions, OOM kills
 
-A missing signal (e.g. no error count) is an **instrumentation gap** —
+A missing signal (e.g. no error count) is an **instrumentation gap**;
 flag it before building around what's there.
 
 **Span metrics back alerts, not just panels.** When generating-queries
@@ -180,25 +180,25 @@ surfaces SigNoz's trace→metrics output (`signoz_calls_total`,
 source for *both* the dashboard and the burn-rate alerts: it's
 pre-aggregated and cheap, whereas raw trace aggregation over a long alert
 window is expensive and an unstable alert source. (Confirm exact
-metric/label names via discovery — don't hardcode.)
+metric/label names via discovery; don't hardcode.)
 
 **Render any counter by the volume you just measured, not by reflex.**
-Not throughput-specific — it applies to every counter you'll graph
+This is not throughput-specific: it applies to every counter you'll graph
 (request rate, **error counts**, restarts, OOM kills, evictions), and
 low-volume errors and resource-layer events are the usual victims, not
 just requests. Per-second rate suits steady high-volume signals; where
 Phase 3 shows the count is low, bursty, or human-paced, a `/sec` graph
 renders as unreadable tiny decimals (`0.03/s`). Use the *symptom*, not a
 hard threshold: if per-second shows as fractions, pass that to Phase 6
-as intent — render a per-interval **increase** count over a wider window
-(24h–7d), not a rate. (Gauges — CPU, memory, queue depth — are already
+as intent: render a per-interval **increase** count over a wider window
+(24h–7d), not a rate. (Gauges such as CPU, memory, queue depth are already
 absolute; this is a counter concern.) It's a deliberate tradeoff
 (`increase` rescales its y-axis with the selected range), so make it a
 conscious call, never a blanket default either way.
 `signoz-creating-dashboards` owns the rate-vs-increase mechanic.
 
 **Verify the infra→service join (the USE half).** Don't assume
-`service.name` is present on host/container/k8s metrics — they often
+`service.name` is present on host/container/k8s metrics: they often
 carry only `host.name` / `k8s.pod.name` / `k8s.node.name`, and
 `k8s.deployment.name` may differ from `service.name`. Have
 generating-queries confirm which identity attribute actually joins the
@@ -208,35 +208,35 @@ rather than guessing.
 
 **Discover downstream topology from traces, not the human's memory**
 (Phase 1 Q1). The gotcha worth carrying: client spans are
-`kind_string = 'Client'` in the SigNoz v5 schema — *not* `kind`, *not*
-`SPAN_KIND_CLIENT` — so verify the field/value, then discover the populated
+`kind_string = 'Client'` in the SigNoz v5 schema (*not* `kind`, *not*
+`SPAN_KIND_CLIENT`), so verify the field/value, then discover the populated
 dependency attributes with `signoz_get_field_keys`. Current examples include
 `http_url`, `server.address`, `db.system`, and `db.operation`; use only fields
 the tenant actually returns.
 
-**Multi-tenant note** — if the service serves multiple tenants/regions,
+**Multi-tenant note**: if the service serves multiple tenants/regions,
 look for a stable non-PII tenant/region attribute (e.g. `tenant.id`,
-`region`, `deployment.environment`) — avoid raw URLs or user
+`region`, `deployment.environment`); avoid raw URLs or user
 identifiers. Per-tenant breakdowns belong on the dashboard;
 aggregate-only views hide single-tenant outages.
 
-**SLI hygiene** — confirm the events your SLI counts carry the right
+**SLI hygiene**: confirm the events your SLI counts carry the right
 labels. For a broad denominator ("all requests to the service"), scanner
-traffic on `/.env*`, `/.git*` is real but should be **excluded** — it's
+traffic on `/.env*`, `/.git*` is real but should be **excluded**, since it's
 not user traffic. The exclusion predicate should *only subtract scanners*
-and stay neutral otherwise, so use the **bare** negation —
-`<url_or_route_field> NOT REGEXP '/\\.(env|git|aws|ssh|well-known)'` —
+and stay neutral otherwise, so use the **bare** negation,
+`<url_or_route_field> NOT REGEXP '/\\.(env|git|aws|ssh|well-known)'`,
 **not** `EXISTS AND …`. SigNoz negative operators also match rows where
 the field is *absent*, so fieldless valid events (non-HTTP spans,
 internal ops) stay counted; let the SLI's own scope filter
 (`service.name`, `http.route`) define the event universe, not the
 scanner predicate. (Pair `EXISTS` with a negation only for the *opposite*
-intent — excluding a specific value among rows that have the field, e.g.
+intent, excluding a specific value among rows that have the field, e.g.
 `service.name EXISTS AND service.name != 'redis'`.) A well-scoped SLI
 already excludes scanner paths, so this mainly bites service-wide ratios.
 Keep a separate security view if you care about scanners.
 
-## Phase 4 — Classify labels by cardinality and cost
+## Phase 4: Classify labels by cardinality and cost
 
 Before wiring labels into queries, classify each. Wrong classification
 is the #1 source of metric-bill explosions and dashboard unreadability.
@@ -246,17 +246,17 @@ is the #1 source of metric-bill explosions and dashboard unreadability.
 | Routing | <20 | Alert label, inhibition rule, notification policy (e.g. `severity`, `team`) |
 | Variable | <100, human-readable | Dashboard variable (e.g. `environment`, `tenant`) |
 | Breakdown | <500 typically | groupBy on graphs / tables (e.g. `gen_ai.tool.name`) |
-| Trace/log-only | Unbounded | Only on traces or logs — never on metric series |
+| Trace/log-only | Unbounded | Only on traces or logs, never on metric series |
 
 Never let raw URLs, query strings, user IDs, session IDs, or request IDs
-end up as metric labels — they explode cardinality and the bill. Those
+end up as metric labels; they explode cardinality and the bill. Those
 belong on traces/logs.
 
-Cardinality matters more for *cost* than for *display performance* —
+Cardinality matters more for *cost* than for *display performance*;
 SigNoz/ClickHouse handles 100s of variable values fine; the limit is
 human readability of the dropdown.
 
-## Phase 5 — Confirm channels, burn-rate windows, recovery thresholds
+## Phase 5: Confirm channels, burn-rate windows, recovery thresholds
 
 Lock in before creating alerts:
 
@@ -264,7 +264,7 @@ Lock in before creating alerts:
    routes to (e.g. critical → PagerDuty, warning → Slack). Reuse an
    existing channel from `signoz_list_notification_channels` where
    one fits; never invent a name. The actual channel resolution/creation
-   and secret handling are owned by `signoz-creating-alerts` (Phase 8) —
+   and secret handling are owned by `signoz-creating-alerts` (Phase 8);
    here you only lock the tier→channel mapping.
 2. **Burn-rate windows.** Common starting points for a 99.9% SLO over a
    30-day budget:
@@ -275,7 +275,7 @@ Lock in before creating alerts:
    | Slow burn warning | 6× | 6h | 30m | Slack |
    | Ticket-level low | 1× | 3d | 6h | Ticket queue |
 
-   The burn-rate multipliers are SLO-independent — for a different
+   The burn-rate multipliers are SLO-independent, so for a different
    target, compute each absolute threshold inline as
    `error-rate = burn rate × (1 − SLO)` (e.g. 14.4× → 1.44% at 99.9%).
    `signoz-searching-docs` explains the burn-rate *method*; it can't
@@ -284,81 +284,81 @@ Lock in before creating alerts:
    Both windows must trip simultaneously for the alert to fire: the long
    window suppresses brief spikes; the short window gives fast recovery
    so a resolved incident stops paging quickly. (The 6× row is a page in
-   the canonical SRE table — routing it to Slack here is a deliberate
+   the canonical SRE table, so routing it to Slack here is a deliberate
    severity downgrade; adjust to your on-call norms.)
 3. **Recovery thresholds** (hysteresis). Decide that every numeric alert
    recovers *below* its firing target (e.g. fire at 80%, recover at 70%)
-   to prevent boundary flapping — `signoz-creating-alerts` carries this
+   to prevent boundary flapping. `signoz-creating-alerts` carries this
    into the `recoveryTarget` field.
 
 Surface these as a clarification with concrete proposed values, using
 the host application's question/UI mechanism (a structured clarification
-tool, inline tags, an interactive prompt — follow the host's rules).
-Never ask open-ended "what threshold do you want?" — propose, let the
+tool, inline tags, an interactive prompt; follow the host's rules).
+Never ask open-ended "what threshold do you want?"; propose, and let the
 user adjust.
 Get explicit sign-off on scope and thresholds before building. Flag
 baselines that affect thresholds ("current error rate is 5.1%, so a
-static 5% alert will be noisy — proposing a burn-rate alert instead").
+static 5% alert will be noisy, so proposing a burn-rate alert instead").
 
-## Phase 6 — Build the dashboard(s)
+## Phase 6: Build the dashboard(s)
 
-Hand off to `signoz-creating-dashboards` — it owns templates, the
+Hand off to `signoz-creating-dashboards`; it owns templates, the
 layout/variable/OTel-naming defaults, the v6 schema and its gotchas, the
 no-data probe, and the mandatory per-panel dry-run (`signoz-modifying-dashboards`
 for later edits). Do **not** restate panel JSON or grid mechanics here;
 pass intent and let that skill build.
 
 **Prefer several focused dashboards over one large one.** Since
-`signoz-creating-dashboards` builds one dashboard per call — and its
-template catalog is already organized per technology — the orchestration
+`signoz-creating-dashboards` builds one dashboard per call, and its
+template catalog is already organized per technology, the orchestration
 decision is *which set of boards to compose*. Default to splitting by
 category/audience and invoking the sub-skill once per board:
 
 - **Service / RED (APM):** KPI tiles + request rate, errors,
   p50/p95/p99. The primary on-call board.
-- **Infra / USE:** CPU, memory, restarts, network — only if infra
+- **Infra / USE:** CPU, memory, restarts, network, only if infra
   monitoring was opted into (Phase 1 Q3), scoped by the attribute
   *confirmed* in Phase 3. Usually a stock template (`hostmetrics`,
   `k8s`) imported as its own board.
 - **Downstream dependencies:** client-span p99 + error rate per
-  dependency — only if the service has external deps (Phase 1 Q1),
+  dependency, only if the service has external deps (Phase 1 Q1),
   grouped by the dependency attribute discovered in Phase 3.
 - **Business / SLO:** the SLI ratio and error budget, with a per-tenant
-  breakdown if multi-tenant (Phase 3) — aggregate-only panels hide
+  breakdown if multi-tenant (Phase 3); aggregate-only panels hide
   single-tenant outages.
 
 Splitting keeps each board fast, single-purpose, and ownable by the
 right audience (SRE vs app dev vs platform). **Collapse into one board
-only when the split would otherwise yield several near-empty ones** — a
+only when the split would otherwise yield several near-empty ones**: a
 small service's handful of panels reads better as rows on one board than
 as four 2-panel dashboards. Each board still passes the Phase 1.5
 extend-vs-create check, so you reuse an existing board rather than adding
 a parallel one.
 
 **Quality bar (every board you create):** production config for a 3am
-responder — each panel earns a "what to watch for" description and a
+responder, where each panel earns a "what to watch for" description and a
 drill-down, and each dashboard earns a top-of-page "start here". Pass
 this as intent so `signoz-creating-dashboards` applies it.
 
-## Phase 7 — Saved Explorer views
+## Phase 7: Saved Explorer views
 
 Hand off to `signoz-managing-views` for the create mechanics (it owns
 the view payload and the `extraData`/`selectColumns` shape). The
-orchestration value is *which* views to stand up — cheaper than panels
-and high-leverage mid-incident:
+orchestration value is *which* views to stand up, which are cheaper than panels
+and the fastest surfaces to reach for mid-incident:
 
 - ERROR/FATAL logs for the service.
-- API request list — the Traces *list* view over server spans
+- API request list: the Traces *list* view over server spans
   (`kind_string = 'Server'`, verify per Phase 3): a per-request table
   surfacing service / operation (or `http.route`) /
   `http.response.status_code` / duration / `trace_id`. The fastest "what
-  are my endpoints doing right now" surface — sortable by latency or
+  are my endpoints doing right now" surface, sortable by latency or
   status, one click to the full trace, and the broad view that the
   failing/slow-span views below are just filtered subsets of.
 - Failing spans for the canonical operation (`has_error = true`).
 - Slow spans (`duration_nano > <threshold>`).
 - Failed sub-flows (e.g. OAuth requests with errors).
-- Correlation drill-downs — error logs carrying `trace_id` (a log spike
+- Correlation drill-downs: error logs carrying `trace_id` (a log spike
   jumps straight to the trace) and slow/error traces that link back to
   their logs.
 
@@ -367,9 +367,9 @@ environment/tenant filter as the dashboard (so `prod` and `staging` rows
 never mix), and the selected columns pass the same PII / no-identifiers
 gate as Phase 4.
 
-## Phase 8 — Alerts
+## Phase 8: Alerts
 
-`signoz-creating-alerts` owns every per-alert mechanic — channel
+`signoz-creating-alerts` owns every per-alert mechanic: channel
 resolution (create-first with a test message, name-not-UUID, secret
 handling), severity defaults, `op`/`matchType`, units, annotations,
 `evalWindow`/`recoveryTarget`, anomaly-rule shape, and the mandatory
@@ -387,67 +387,67 @@ What this orchestration layer adds on top of that skill:
   the bad/total event definition (prefer the Phase-3 `signoz_calls_total`
   error/total split over raw trace aggregation), the long+short window
   lengths from Phase 5, and the firing target `burnRate × (1 − SLO)`.
-  Two judgment calls travel with those inputs — the long and short
+  Two judgment calls travel with those inputs. The long and short
   windows must be evaluated as **one rule that ANDs both** (two
   independent rules page on every short spike; if the SigNoz version
   can't express the short-window confirmation in a single rule, ship the
   long window alone and *say so*), and if no clean bad/total split
-  exists in the ingested data, burn-rate isn't buildable yet — fall back
+  exists in the ingested data, burn-rate isn't buildable yet, so fall back
   to a baseline-tuned threshold rather than emit a broken rule. Let
   `signoz-creating-alerts` + `signoz://alert/*` pick the
   version-correct rule shape. Note that creating-alerts' "would have
   fired N times in the last 1h" calibration can't grade a 6h/3d
-  burn-rate window — don't read a "fired 0 times" there as tuned; the
+  burn-rate window, so don't read a "fired 0 times" there as tuned; the
   Phase 9 re-tune-after-a-week loop is the real calibration.
-- **Burn-rate only covers ratio SLIs — schedule the non-ratio failure
+- **Burn-rate only covers ratio SLIs, so schedule the non-ratio failure
   modes too.** A service that stops emitting, or whose traffic
   collapses, never burns error budget (the SLI ratio is undefined at
   zero volume), so the burn-rate pair pages no one. A complete setup
   adds a telemetry-presence / absent-data alert on the primary signal,
   and treats traffic/throughput as its own signal. Hand these intents
-  to `signoz-creating-alerts` — it owns the rule shape (absent-data,
+  to `signoz-creating-alerts`; it owns the rule shape (absent-data,
   anomaly, threshold) and the healthy-zero handling; the orchestration
   decision is only that they belong in the package.
 - **Batch + sequence.** Resolve/confirm the channel (Phase 5 mapping)
   before any rule references it, then create the alerts as a batch
-  grouped by routing tier — not one rule per metric.
+  grouped by routing tier, not one rule per metric.
 - **Manual-TODO boundary.** Inhibition rules, org-level notification
   policies (`usePolicy: true` only *opts into* one), and maintenance
-  windows are configured in the SigNoz UI / Terraform — these tools
+  windows are configured in the SigNoz UI / Terraform; these tools
   don't create them. Flag as TODO; never report them done.
 
-## Phase 9 — Hand off
+## Phase 9: Hand off
 
 Hand back to the human:
 - Dashboard ID(s), view IDs, and alert IDs. Include a `webUrl` only when that
   exact value was returned by an MCP tool; otherwise return the ID. Never
   construct a frontend URL from an ID or tenant hostname.
-- Open questions you couldn't resolve — hand them over as explicit
+- Open questions you couldn't resolve; hand them over as explicit
   TODOs.
 - Baselines that may need tuning (e.g. "tool error rate is 5.1% today;
-  burn-rate alert tuned for 99% SLO will fire occasionally — re-tune
+  burn-rate alert tuned for 99% SLO will fire occasionally, so re-tune
   after a week of data").
 
 ## What to avoid
 
-- **Inventing channel names or webhook URLs.** Ask.
+- **Inventing channel names or webhook URLs.** Ask the user instead.
 - **Static thresholds for SLI-bound alerts.** Burn-rate pairs are the
   modern default; static thresholds for ratios produce flap.
 - **Wrong-sizing dashboards.** Don't cram 18 panels where 12 will do,
-  and don't scatter four 2-panel boards where one would read better —
-  split by category, then right-size each. Sprawl cuts both ways.
+  and don't scatter four 2-panel boards where one would read better:
+  split by category, then right-size each.
 - **Skipping dry-runs to save time.** A 500 at create time is harder to
   debug than at dry-run time.
 - **One alert per metric.** Group by routing tier, not per-metric.
-- **High-cardinality labels on metric series.** They detonate the bill.
-  Move to traces/logs.
+- **High-cardinality labels on metric series.** They multiply the
+  metric bill. Move them to traces/logs.
 - **Synthesizing frontend URLs.** Return an MCP-provided `webUrl` when present;
   otherwise return the resource ID only.
-- **Including scanner traffic in SLI denominators.** Real but
-  irrelevant. Exclude.
+- **Including scanner traffic in SLI denominators.** Scanner traffic
+  is real but it is not user traffic; exclude it.
 - **Treating exploration findings as throwaway.** Baselines,
   cardinalities, and error counts set your thresholds and tuning
-  baseline — don't drop them. Persist them where they survive *any*
+  baseline, so don't drop them. Persist them where they survive *any*
   host: bake the numbers into the artifacts (panel/dashboard
   descriptions, alert annotations) and the Phase 9 hand-off, all of
   which live in SigNoz. Don't rely on a local notes file.

--- a/plugins/signoz/skills/signoz-writing-clickhouse-queries/SKILL.md
+++ b/plugins/signoz/skills/signoz-writing-clickhouse-queries/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: signoz-writing-clickhouse-queries
 description: >-
-  Write raw ClickHouse SQL for a SigNoz dashboard panel — timeseries, value,
+  Write raw ClickHouse SQL for a SigNoz dashboard panel: timeseries, value,
   or table widgets that the builder UI cannot express (custom joins, window
   functions, regex extraction over log bodies, aggregations beyond builder
   syntax). Trigger when the user explicitly asks for a "ClickHouse query",

--- a/plugins/signoz/skills/signoz-writing-clickhouse-queries/references/clickhouse-logs-reference.md
+++ b/plugins/signoz/skills/signoz-writing-clickhouse-queries/references/clickhouse-logs-reference.md
@@ -9,7 +9,7 @@
   - Use Indexed (Selected) Columns Over Map Access
   - Use GLOBAL IN for Resource Fingerprint Subquery
   - Complete GROUP BY Projections
-  - Body Text Search — Engaging Skip Indexes (predicate engagement,
+  - Body Text Search: Engaging Skip Indexes (predicate engagement,
     anti-patterns, OR-of-LIKE, hyphens/punctuation, EXPLAIN, type traps)
 - Attribute Access Syntax (resource attributes, span/log attributes,
   existence checks, timestamp conversion)
@@ -95,8 +95,8 @@ WHERE timestamp >= $start_timestamp_nano AND timestamp <= $end_timestamp_nano
   AND ts_bucket_start BETWEEN $start_timestamp - 1800 AND $end_timestamp
 ```
 
-- `$start_timestamp_nano` / `$end_timestamp_nano` — nanosecond precision, filters the `timestamp` column.
-- `$start_timestamp` / `$end_timestamp` — seconds precision, filters the `ts_bucket_start` column.
+- `$start_timestamp_nano` / `$end_timestamp_nano`: nanosecond precision, filters the `timestamp` column.
+- `$start_timestamp` / `$end_timestamp`: seconds precision, filters the `ts_bucket_start` column.
 - The `- 1800` is required because `ts_bucket_start` is rounded down to 30-minute intervals.
 
 ### 3. Use Indexed (Selected) Columns Over Map Access
@@ -111,7 +111,7 @@ When an attribute has been promoted to a selected (indexed) field, a dedicated m
 
 **Naming convention**: prefix with `attribute_<dataType>_`, replace `.` with `$$` for dotted attribute names.
 
-An `_exists` variant is also created: `attribute_string_method_exists Bool` — use this to check existence of an indexed attribute.
+An `_exists` variant is also created: `attribute_string_method_exists Bool`: use this to check existence of an indexed attribute.
 
 ### 4. Use GLOBAL IN for Resource Fingerprint Subquery
 
@@ -132,7 +132,7 @@ dataset is demonstrably small and bounded.
 Every non-aggregated `SELECT` expression must appear in `GROUP BY`, including
 computed expressions: `SELECT JSONExtractString(body, 'kind') AS kind, count() ... GROUP BY kind`.
 
-### 6. Body Text Search — Engaging Skip Indexes
+### 6. Body Text Search: Engaging Skip Indexes
 
 The `body` column has two skip indexes, **both on `lower(body)`**:
 
@@ -141,7 +141,7 @@ INDEX body_index_v2_token  lower(body) TYPE tokenbf_v1(10000, 2, 0)   GRANULARIT
 INDEX body_index_v2_ngram  lower(body) TYPE ngrambf_v1(4, 15000, 3, 0) GRANULARITY 1
 ```
 
-ClickHouse compares predicate ASTs to the index expression **literally**. A predicate must reference `lower(body)` to engage either index — `hasToken(body, …)` and `body LIKE '%x%'` prune nothing.
+ClickHouse compares predicate ASTs to the index expression **literally**. A predicate must reference `lower(body)` to engage either index; `hasToken(body, …)` and `body LIKE '%x%'` prune nothing.
 
 #### Predicate engagement
 
@@ -150,10 +150,10 @@ ClickHouse compares predicate ASTs to the index expression **literally**. A pred
 | `hasToken(lower(body), 'tok')` | yes | no | Whole-token check; best for distinctive single words. |
 | `lower(body) = 'literal'` | yes | yes | Exact equality. |
 | `lower(body) LIKE '%substr%'` | no | yes | Substring must be ≥ 4 chars (ngrambf `N=4`). |
-| `lower(body) LIKE '%a%b%'` | no | yes | n-grams of each substring ANDed — more selective. |
+| `lower(body) LIKE '%a%b%'` | no | yes | n-grams of each substring ANDed, more selective. |
 | `lower(body) ILIKE '%x%'` | no | sometimes | Prefer the explicit `lower(body) LIKE '%x%'` form. |
 | `position(body, 'x') > 0` | no | no | Always rewrite to `lower(body) LIKE`. |
-| `positionCaseInsensitive(body, 'X') > 0` | no | no | Biggest trap — engages neither even with `lower(body)` index. |
+| `positionCaseInsensitive(body, 'X') > 0` | no | no | Biggest trap: engages neither even with `lower(body)` index. |
 | `match(lower(body), 'regex')` | no | partial | Only literal substrings inside the regex are usable. |
 
 #### Anti-patterns to rewrite
@@ -167,7 +167,7 @@ ClickHouse compares predicate ASTs to the index expression **literally**. A pred
 
 Lowercase the literal (the index value is lowercase). Escape `%` and `_` in the literal; pass other characters (hyphens, dots, parens, colons) through as-is.
 
-#### OR-of-LIKE — add a common AND-prefix
+#### OR-of-LIKE: add a common AND-prefix
 
 OR'd `LIKE` patterns weaken ngrambf to nearly nothing: any branch matching keeps the granule. Find a token or substring shared by **all** branches and AND it before the OR block:
 
@@ -185,13 +185,13 @@ WHERE hasToken(lower(body), 'failed')               -- tokenbf engages
      OR lower(body) LIKE '%failed to send baz%' )
 ```
 
-Pick the AND-prefix in this order: (1) most distinctive single token via `hasToken`, (2) two ANDed `hasToken` calls, (3) distinctive shared substring via `LIKE`. Avoid common words like `the`, `user`, `error` — high false-positive rate on the bloom filter.
+Pick the AND-prefix in this order: (1) most distinctive single token via `hasToken`, (2) two ANDed `hasToken` calls, (3) distinctive shared substring via `LIKE`. Avoid common words like `the`, `user`, `error`: high false-positive rate on the bloom filter.
 
 #### Hyphens and punctuation split tokens
 
 `tokenbf` only stores `[A-Za-z0-9_]+` runs. Anything else (hyphens, dots, slashes, quotes, parens, colons) is a token boundary. So:
 
-- `hasToken(lower(body), 'settlement-requested')` matches **nothing** — there is no such token.
+- `hasToken(lower(body), 'settlement-requested')` matches **nothing**: there is no such token.
 - Use `hasToken(lower(body), 'settlement') AND hasToken(lower(body), 'requested')`, or
 - Use `lower(body) LIKE '%settlement-requested%'` (ngrambf handles punctuation).
 
@@ -202,18 +202,18 @@ EXPLAIN indexes=1
 <your query>;
 ```
 
-Each `Skip` block under `ReadFromMergeTree` shows `Granules: kept/total`. For both `body_index_v2_token` and `body_index_v2_ngram`, kept should be `<` total. The `Combined` block is what feeds the actual scan — that's the number to drive down.
+Each `Skip` block under `ReadFromMergeTree` shows `Granules: kept/total`. For both `body_index_v2_token` and `body_index_v2_ngram`, kept should be `<` total. The `Combined` block is what feeds the actual scan; that's the number to drive down.
 
 Failure modes:
-- `Granules: 195/195` — predicate doesn't match the index expression, or the chosen token is too common.
-- `Skip` block missing — predicate engages no skip index at all.
+- `Granules: 195/195` means the predicate doesn't match the index expression, or the chosen token is too common.
+- `Skip` block missing: predicate engages no skip index at all.
 
 `tokenbf_v1(10000, …)` is small and saturates at high cardinality; `ngrambf_v1(4, 15000, …)` is the workhorse. If tokenbf looks idle even with a correct `hasToken(lower(body), …)`, lean on `lower(body) LIKE` rather than chasing tokenbf pruning the filter size won't deliver.
 
 #### Type traps in body-search queries
 
 - `toUnixTimestamp64Nano(now())` → `Code: 43, ILLEGAL_TYPE_OF_ARGUMENT`. Use `now64()` (or `toDateTime64(now(), 9)`). SigNoz dashboard macros like `$start_timestamp_nano` resolve to literal integers and sidestep this.
-- `max(fromUnixTimestamp64Nano(timestamp))` converts every row before aggregating. Use `fromUnixTimestamp64Nano(max(timestamp))` — `max` once on cheap UInt64, convert once at the end.
+- `max(fromUnixTimestamp64Nano(timestamp))` converts every row before aggregating. Use `fromUnixTimestamp64Nano(max(timestamp))`: `max` once on cheap UInt64, convert once at the end.
 
 ---
 
@@ -306,7 +306,7 @@ ORDER BY value DESC;
 
 ## Query Examples
 
-### Timeseries — Count per minute grouped by container name
+### Timeseries: Count per minute grouped by container name
 
 Shows `mapContains` for attribute existence check and attribute in GROUP BY.
 
@@ -324,7 +324,7 @@ GROUP BY container_name, ts
 ORDER BY ts ASC;
 ```
 
-### Timeseries — Filtered by service, severity, and attribute
+### Timeseries: Filtered by service, severity, and attribute
 
 Shows combining resource CTE with `severity_text` and attribute map access.
 
@@ -349,7 +349,7 @@ GROUP BY ts
 ORDER BY ts ASC;
 ```
 
-### Advanced — Top 10 largest logs for payload auditing
+### Advanced: Top 10 largest logs for payload auditing
 
 Calculates per-log byte size from body + all attributes. Keep queries to ≤6 hour windows for this pattern.
 

--- a/plugins/signoz/skills/signoz-writing-clickhouse-queries/references/clickhouse-traces-reference.md
+++ b/plugins/signoz/skills/signoz-writing-clickhouse-queries/references/clickhouse-traces-reference.md
@@ -231,7 +231,7 @@ ORDER BY value DESC;
 
 ## Query Examples
 
-### Timeseries — Error spans per service per minute
+### Timeseries: Error spans per service per minute
 
 Shows `has_error` filtering, resource attribute in SELECT, and multi-series grouping.
 
@@ -250,7 +250,7 @@ GROUP BY `service.name`, ts
 ORDER BY ts ASC;
 ```
 
-### Table — Average duration by HTTP method
+### Table: Average duration by HTTP method
 
 ```sql
 WITH __resource_filter AS (


### PR DESCRIPTION
## What

Two changes:

1. **Skill tree is now em-dash-free and fragment-free.** Converted all 635 em dashes across 27 files to ordinary punctuation, and restated 12 punchy fragments as the rules they encode.
2. **`CONTRIBUTING.md` records the conventions** under a new **Writing style** subsection, so the patterns don't creep back, plus a PR checklist item.

## Conversion rules

| Context | Replacement | Example |
|---|---|---|
| Label gloss | colon | `` `spec.variables`: dashboard-level filters `` |
| Independent clause | semicolon / period | `This is **mandatory**; you need the complete JSON` |
| Aside | parentheses | `(all HIGH-SIGNAL severities, including ERROR, FATAL, ..., matched case-insensitively)` |
| Brief apposition | comma / short connective | `in a single call; read it in-context` |
| Quoted example name | plain hyphen | `"High Error Rate - Checkout"` |

Untouched by design: en dashes (`24h–7d`, `2–4m`), arrows (`→`, `↔`), minus signs (`−42%`), hyphens, and the ✅/❌ investigation-trail markers.

## Fragments restated as rules

A rule an agent must follow needs to read as a rule, not a slogan:

- `No chips beat wrong chips` (3 files) → `Offering no follow-ups is better than offering wrong ones`
- `Better silent than padded` → `omit the section rather than pad it`
- `They detonate the bill` → `They multiply the metric bill`
- `Real but irrelevant. Exclude.` → `Scanner traffic is real but it is not user traffic; exclude it`
- `Compression plus proof` → `Keep it short and evidence-backed`
- `Honest uncertainty wins` → `Report uncertainty honestly`
- also `Ask.`, `Sprawl cuts both ways`, `this is where trust is earned`, and the `Not throughput-specific` fragment opener

Plus the only two banned-word hits in the tree: `high-leverage` → `high-impact` / `the fastest surfaces to reach for`.

## No behavioural change

Every hunk was verified as punctuation-only apart from the fragment rewrites above: of 554 hunks, 547 are byte-identical once punctuation is normalised, and the 7 remaining are the intended rewrites. No tool name, field name, threshold, query shape, JSON key, or workflow step changes.

## Verification

- `grep -ro '—' --include="*.md" plugins/signoz/skills` → **0**
- YAML frontmatter parses for all 13 `SKILL.md` files; every `name` still matches its directory; no `description` exceeds the 1024-char limit
- Markdown table pipe-counts consistent in every table
- No doubled words, stray leading punctuation, or broken sentence splits introduced

`CONTRIBUTING.md` keeps one deliberate em dash, inside the `` `grep -n '—'` `` command it recommends to reviewers.

## Out of scope

`README.md` (14) and `docs/signoz-creating-dashboards-evals.md` (16) still contain em dashes; happy to convert them in a follow-up.

## Checklist

- [x] Skill follows the Agent Skills specification
- [x] `name` in SKILL.md frontmatter matches the directory name
- [x] `README.md` updated if a new skill was added (n/a, no new skill)
- [x] Writing style respected: no em dashes, banned words, or AI-slop patterns
- [x] **Plugin versions left unchanged** for the follow-up auto-bump PR