### PR TITLE
fix(signoz-managing-views): align the skill with the v2 saved_views API

### DIFF
--- a/plugins/signoz/skills/signoz-managing-views/SKILL.md
+++ b/plugins/signoz/skills/signoz-managing-views/SKILL.md
@@ -9,7 +9,7 @@ description: >
   Explorer saved views, even if they don't say "view" explicitly. Also use
   when someone wants to share a recurring Explorer query with their team and
   asks how to "save" or "bookmark" it.
-argument-hint: <view name, sourcePage (traces/logs/metrics/meter), and filter intent>
+argument-hint: <view name, source (traces/logs/metrics/meter), and filter intent>
 ---
 
 # Managing Saved Views
@@ -17,7 +17,12 @@ argument-hint: <view name, sourcePage (traces/logs/metrics/meter), and filter in
 Create, read, update, and delete SigNoz **saved Explorer views** via the
 SigNoz MCP server. A saved view is a reusable snapshot of an Explorer query
 on the Logs, Traces, Metrics, or Cost Meter page: name + filters + panel
-type, scoped to one `sourcePage`. They are not dashboards and not alerts.
+type, scoped to one `source`. They are not dashboards and not alerts.
+
+The tools call the v2 `/api/v2/saved_views` API. The create/update payloads
+are the typed v2 shape (`source` + `spec`), not the retired v1
+`compositeQuery`/`category`/`tags`/`extraData` shape; the `sourcePage`
+parameter was renamed to `source`.
 
 This skill covers the full CRUD surface in one place because the operations
 share the same schema, the same identity model (UUID per view), and the same
@@ -41,9 +46,9 @@ without the MCP tools.
 Use this skill when the user wants to:
 
 - **Create** a saved view from a current or described Explorer query.
-- **List / find** existing views (by `sourcePage`, name, or category).
+- **List / find** existing views (by `source` or name).
 - **Inspect** a single view's filter or panel type.
-- **Update** a view: rename, recategorize, or change its filter,
+- **Update** a view: rename its display label, or change its filter,
   panel type, or aggregations.
 - **Delete** a view that is no longer useful.
 
@@ -57,27 +62,23 @@ Do NOT use when the user wants to:
 ## Schema reference
 
 **Read both resources BEFORE composing any create or update payload.** Do not
-hand-compose a `compositeQuery` from memory. The correct schema is not the
-legacy `builder.queryData` format; it is the v5 spec described in these
-resources. Sending a legacy payload causes a silent HTTP 400.
+hand-compose a `spec` from memory. The correct schema is the v2 typed spec
+(`schemaVersion: "v2"`) described in these resources; the retired v1 fields
+(`compositeQuery`, `category`, `tags`, `extraData`) are not accepted.
 
 Read both MCP resources by URI using your client's resource-read mechanism:
 
-- `signoz://view/instructions`: SavedView field reference, `sourcePage`
-  rules, the GET-then-PUT update flow, the minimal create body.
-- `signoz://view/examples`: round-tripped payloads (traces list, logs list,
-  metrics graph, and a Cost Meter graph) you can adapt verbatim.
-
-The server returns HTTP 400 on legacy v3/v4 fields (`builder`, `promql`,
-`unit`, top-level `id`, `queryFormulas`, `queryTraceOperator`); the failure
-mode is silent for the user, so reading the resources first is mandatory, not
-optional.
+- `signoz://view/instructions`: SavedView field reference, `source`
+  rules, the `spec` fields, the GET-then-replace update flow, the minimal
+  create body.
+- `signoz://view/examples`: round-tripped v2 payloads (traces list, logs
+  list, metrics graph, and a Cost Meter graph) you can adapt verbatim.
 
 ## Operation flows
 
 ### Create a view
 
-1. **Resolve `sourcePage`**: must be exactly one of `traces`, `logs`,
+1. **Resolve `source`**: must be exactly one of `traces`, `logs`,
    `metrics`, `meter`. If the user's intent is ambiguous ("save this query"),
    ask which Explorer they mean. It cannot be inferred from filter strings
    alone. Use `meter` for **Cost Meter** (usage / billing) views; it is a
@@ -86,8 +87,7 @@ optional.
 2. **Read the schema resources.** Read both `signoz://view/instructions`
    and `signoz://view/examples` using your client's resource-read mechanism
    before composing any payload. Do not skip this step even if you think
-   you know the schema; the legacy `builder.queryData` format is rejected
-   with HTTP 400.
+   you know the schema.
 3. **Build the query using `signoz-generating-queries`, mandatory.** Use
    the `Skill` tool to invoke `signoz-generating-queries`. The sub-skill
    handles field discovery, type checking, and live-data validation in one
@@ -98,23 +98,28 @@ optional.
    a saved view that must be deleted and recreated.
    For a `meter` view, tell `signoz-generating-queries` it's a **Cost Meter**
    query (`source=meter`) so discovery hits the meter store, not the default one.
-   Retain the exact `query` argument from its successful
+   Retain the exact `queries` array from its successful
    `signoz_execute_builder_query` validation call, then translate it explicitly:
 
    ```text
    execution query.compositeQuery.queries
-     -> saved compositeQuery.queries
+     -> saved spec.queries
    ```
 
-   Build the top-level `compositeQuery` argument to `signoz_create_view` as
-   `{ "queryType": "builder", "panelType": "<list|graph|table|value>",
-   "queries": <copied queries> }`. Copy the
-   `queries` array losslessly, but do not copy the execution-only envelope fields
-   `schemaVersion`, `start`, `end`, `requestType`, `formatOptions`, or
-   `variables`; do not put a `query` key or a second nested `compositeQuery`
-   inside the saved object.
-   Choose `panelType` from the saved-view intent rather than inventing it from
-   the execution envelope.
+   Build the `spec` argument to `signoz_create_view` as
+   `{ "displayName": "<human label>", "panelType": "<list|graph|table|value|trace>",
+   "requestType": "<raw|time_series|scalar|trace>", "queries": <copied queries> }`,
+   adding `selectedFields` / `display` when the Explorer layout calls for them.
+   Copy the `queries` array losslessly, but do not copy the execution-only
+   envelope fields `schemaVersion`, `start`, `end`, `requestType` (the
+   execution envelope's), `formatOptions`, or `variables`; do not put a
+   `query` key or a `compositeQuery` object inside the saved spec. Choose
+   `panelType` and `requestType` from the saved-view intent rather than
+   inventing them from the execution envelope.
+   Set the top-level `name` (a DNS-1123 label: lowercase letters, digits,
+   hyphens) or pass `generateName: true` to derive it from
+   `spec.displayName`. `schemaVersion` is always `"v2"`; the server fills it
+   in when omitted.
    The copied queries must retain every positive `spec.limit` and v5
    `spec.order` entry losslessly. Never translate them to dashboard `orderBy`.
    Raw/list views use 100 rows (logs: timestamp/id desc; traces: timestamp
@@ -124,23 +129,23 @@ optional.
    desc as appropriate. Time-series top-N ranks groups over the whole selected
    window and can omit a short-lived local spike.
 4. **Enforce the signal rule** in every `builder_query` spec.
-   - For `traces` / `logs` / `metrics`: `signal == sourcePage`. A
-     `sourcePage:"traces"` view with `signal:"logs"` is a server-side error.
+   - For `traces` / `logs` / `metrics`: `signal == source`. A
+     `source:"traces"` view with `signal:"logs"` is a server-side error.
    - For `meter` (Cost Meter): `signal:"metrics"` **and** `source:"meter"`:
      a Cost Meter view is queried on the metrics signal against the meter
      store. Omitting `source:"meter"` silently queries the default metrics
-     store; setting `source:"meter"` on a non-`meter` sourcePage is rejected.
+     store; setting `source:"meter"` on a non-`meter` source view is rejected.
 5. **Mandatory pre-save sample fetch.** Probe with the **exact** filter
-   from `compositeQuery.queries[0].spec` against the destination
+   from `spec.queries[0].spec` against the destination
    signal:
-   - `sourcePage=traces` → `signoz_search_traces` with `limit=1`
-   - `sourcePage=logs` → `signoz_search_logs` with `limit=1`
-   - `sourcePage=metrics` → `signoz_query_metrics` with the
+   - `source=traces` → `signoz_search_traces` with `limit=1`
+   - `source=logs` → `signoz_search_logs` with `limit=1`
+   - `source=metrics` → `signoz_query_metrics` with the
      `metricName` from `spec.aggregations[0].metricName` plus the same
      filter, `timeRange=1h`, `requestType=scalar`. Repeat per metric
      query if the view has multiple. The tool requires `metricName`;
      a filter-only probe is not supported.
-   - `sourcePage=meter` → `signoz_query_metrics` with the `metricName`
+   - `source=meter` → `signoz_query_metrics` with the `metricName`
      from `spec.aggregations[0].metricName`, **`source=meter`**, the same
      filter, `timeRange=24h` (Cost Meter rolls up hourly, so a 1h window
      can be a single partial bucket), `requestType=scalar`.
@@ -150,73 +155,79 @@ optional.
    Empty → save anyway / revise / abort. Autonomous mode without
    authorization to persist empty views: abort and escalate.
 6. **Preview before writing; this step is not optional.** Before calling
-   `signoz_create_view`, show the user a summary: name, sourcePage,
+   `signoz_create_view`, show the user a summary: name, source,
    panelType, the full filter expression, and the Step 5 probe result
    ("sample fetch: N rows in last 1h"; for a `meter` view the probe window
    is 24h, so report it as such). For a human in the loop, wait
    for confirmation. For an autonomous agent, log the preview and proceed.
-7. Call `signoz_create_view`. The server populates `id`,
+7. Call `signoz_create_view`. On success the response `data` carries the
+   new view's `id` (HTTP 201 upstream). The server populates `id`,
    `createdAt/By`, `updatedAt/By`; never send those.
 
 ### List or find views
 
-`signoz_list_views` requires a `sourcePage`. If the user did not
-specify one and is searching by name, call it once per page (traces,
-logs, metrics, meter) and merge; do not guess. Use the `name` and `category`
-parameters for server-side partial-match filtering when the user gives a
-substring; do not fetch everything and grep client-side.
+`signoz_list_views` requires a `source`. If the user did not
+specify one and is searching by name, call it once per source (traces,
+logs, metrics, meter) and merge; do not guess. Use the `name`
+parameter for server-side partial-match filtering when the user gives a
+substring; do not fetch everything and grep client-side. There is no
+`category` filter; it was removed with the v2 API.
 
 The response paginates. **Always check `pagination.hasMore`** before
 concluding a view does not exist. Default page size is 50; pass `offset =
 pagination.nextOffset` to continue. A view is only confirmed missing for a
-given `sourcePage` once you have walked pages until `hasMore = false`. As
+given `source` once you have walked pages until `hasMore = false`. As
 long as `hasMore = true`, keep paginating; there is no page-count cap.
 
 ### Get a single view
 
-Use `signoz_get_view` with the UUID. The returned `data` object is
+Use `signoz_get_view` with the UUID (`id`; the legacy alias
+`viewId` also works). The returned `data` object is
 the canonical SavedView shape; it is what you pass back to
 `signoz_update_view`. Treat that data as the source of truth, not
 whatever the user described from memory.
 
-### Update a view (GET-then-PUT)
+### Update a view (GET-then-replace)
 
-`signoz_update_view` is a **full-body replace** (HTTP PUT
-upstream). Sending a partial body wipes the unspecified fields. The flow:
+`signoz_update_view` is a **full replacement**. Sending a partial body
+wipes the unspecified fields. The machine `name` is immutable server-side;
+renaming a view means changing `spec.displayName`. The flow:
 
 1. `signoz_get_view` with the view's `id` → returns
    `{ "status": "success", "data": { ...SavedView... } }`.
 2. Take the `data` object. Strip server-populated fields (`id`,
-   `createdAt`, `createdBy`, `updatedAt`, `updatedBy`); the MCP server
-   strips them for you, but omitting them up front makes the diff
-   readable.
-3. **If the update changes `compositeQuery`** (new filter, different panel
+   `createdAt`, `createdBy`, `updatedAt`, `updatedBy`) and drop `name`; the
+   MCP server strips them for you, but omitting them up front makes the
+   diff readable.
+3. **If the update changes `spec.queries`** (new filter, different panel
    type, different aggregation), invoke `signoz-generating-queries` to
    build and validate the new query before proceeding. Do not hand-edit
-   `compositeQuery` from the user's description; the same Step 4 signal
+   `spec.queries` from the user's description; the same Step 4 signal
    rule applies (including the `meter` case: `signal:"metrics"` +
    `source:"meter"`), and `panelType` changes often imply a `stepInterval`
    change too. For a `meter` view, tell `signoz-generating-queries` it is a
    **Cost Meter** query (`source=meter`) so it discovers and validates against
-   the meter store. Derive the replacement saved `compositeQuery` from the
+   the meter store. Derive the replacement `spec.queries` from the
    successful execution query using the same explicit translation as Create:
-   copy only `query.compositeQuery.queries`, then add `queryType:"builder"` and
-   the intended `panelType`. Exclude `schemaVersion`, `start`, `end`,
-   `requestType`, `formatOptions`, and `variables`. For pure metadata tweaks (rename,
-   recategorize), skip this step and do not touch `compositeQuery`.
-4. Modify only the field(s) the user asked to change.
-5. **Mandatory pre-save sample fetch, when `compositeQuery` changed.**
+   copy only `query.compositeQuery.queries`. Exclude the execution-only
+   envelope fields. For pure metadata tweaks (display-label rename), skip
+   this step and do not touch `spec.queries`.
+4. Modify only the field(s) the user asked to change. Keep `source`
+   unchanged; a cross-source move is rejected.
+5. **Mandatory pre-save sample fetch, when `spec.queries` changed.**
    Run the 1-row probe from the Create flow's Step 5 against the new
    filter. Empty → save anyway / revise / abort. Skip only for pure
-   metadata tweaks (rename, recategorize).
+   metadata tweaks (display-label rename).
 6. **Show a diff-style preview before writing.** One line per changed
-   field: `name: "slow-checkout" → "slow-checkout-p99"`. Explicitly note
-   any fields that are unchanged (e.g. "compositeQuery: unchanged") and
-   include the Step 5 probe result when `compositeQuery` changed. This
-   prevents silent mistakes and gives the user a chance to catch a wrong
-   target view. Wait for confirmation on any change to `compositeQuery`,
-   since that changes what the view actually shows.
+   field: `spec.displayName: "slow-checkout" → "slow-checkout-p99"`.
+   Explicitly note any fields that are unchanged (e.g. "queries:
+   unchanged") and include the Step 5 probe result when `spec.queries`
+   changed. This prevents silent mistakes and gives the user a chance to
+   catch a wrong target view. Wait for confirmation on any change to
+   `spec.queries`, since that changes what the view actually shows.
 7. Call `signoz_update_view` with `{ "id": "<id>", "view": <modified data> }`.
+   `view` must carry `source` and the full `spec`; success is an empty
+   204 upstream.
 
 ### Delete a view
 
@@ -229,7 +240,7 @@ affordance, not a substitute for getting the delete right. Treat this like
 dropping a row from a shared table:
 
 1. **List to locate.** Call `signoz_list_views` to find the view
-   by name. If `sourcePage` is unknown, search all four pages (traces,
+   by name. If `source` is unknown, search all four sources (traces,
    logs, metrics, meter).
 2. **Get to confirm, mandatory.** Call `signoz_get_view` with the
    UUID from step 1. Do NOT skip this step even when you got the UUID from
@@ -237,9 +248,9 @@ dropping a row from a shared table:
    match is not a UUID guarantee; `signoz_get_view` is the confirmation
    that the UUID maps to the view the user named.
    Never call `signoz_delete_view` on a UUID without a prior
-   `signoz_get_view` confirming the matching name and `sourcePage`.
-3. **Show and ask.** Present the resolved view's name, `sourcePage`, and
-   category, and explicitly ask for confirmation. Do **not** auto-confirm
+   `signoz_get_view` confirming the matching name and `source`.
+3. **Show and ask.** Present the resolved view's name and `source`,
+   and explicitly ask for confirmation. Do **not** auto-confirm
    based on the original prompt, even an emphatic one; destructive
    operations get a fresh confirmation against the resolved target.
 4. Call `signoz_delete_view`. Report success with the deleted
@@ -252,7 +263,7 @@ call.
 
 ## Guardrails
 
-- **Mandatory pre-save sample fetch on create and on `compositeQuery`
+- **Mandatory pre-save sample fetch on create and on `spec.queries`
   updates.** Step 5 of each flow runs a 1-row probe against the
   destination signal using the exact filter from the about-to-save
   payload. Skipping is equivalent to skipping get-before-delete. The
@@ -268,7 +279,7 @@ call.
   different signal is the most common source of empty saved views.
   `signoz_get_field_keys signal=<destination signal>` is necessary but
   not sufficient; sparse emission still produces zero-result views.
-  Only the sample fetch confirms. The destination signal equals `sourcePage`
+  Only the sample fetch confirms. The destination signal equals `source`
   for traces/logs/metrics; for a `meter` view it is `signal=metrics` with
   `source=meter` (never `signal=meter`).
 
@@ -278,9 +289,9 @@ call.
   has no preview, so the sample fetch is the only safety net.
 
 - **Translate the execution envelope before saving.** The executable query and
-  saved-view query intentionally have different outer shapes. Save exactly
-  `{queryType, panelType, queries}` in the create `compositeQuery` argument or
-  update `view.compositeQuery`, where `queries`
+  saved-view spec intentionally have different outer shapes. Save exactly
+  `spec: {displayName, panelType, requestType, queries, ...}` in the create
+  call or `view.spec`, where `queries`
   comes from the validated execution `query.compositeQuery.queries`. Never copy
   the range, request, formatting, or variables envelope into a view.
 
@@ -288,38 +299,38 @@ call.
 
 | Operation | Tools called | Key guard |
 |-----------|-------------|-----------|
-| Create | read `signoz://view/instructions` + `signoz://view/examples` → `signoz-generating-queries` → **sample fetch on exact filter** → preview → `signoz_create_view` | Mandatory pre-save sample fetch; preview before write; no legacy fields |
-| List | `signoz_list_views` (× 4 if no sourcePage given: traces/logs/metrics/meter) | Check `pagination.hasMore` |
+| Create | read `signoz://view/instructions` + `signoz://view/examples` → `signoz-generating-queries` → **sample fetch on exact filter** → preview → `signoz_create_view` | Mandatory pre-save sample fetch; preview before write; no v1 fields |
+| List | `signoz_list_views` (× 4 if no source given: traces/logs/metrics/meter) | Check `pagination.hasMore` |
 | Get | `signoz_get_view(id)` | Returns canonical body for update |
-| Update | `signoz_get_view` → modify → **sample fetch if `compositeQuery` changed** → diff preview → `signoz_update_view` | Full-body replace; sample fetch when compositeQuery changes; diff preview required |
+| Update | `signoz_get_view` → modify → **sample fetch if `spec.queries` changed** → diff preview → `signoz_update_view` | Full replacement; name immutable (rename = `spec.displayName`); diff preview required |
 | Delete | `signoz_list_views` → `signoz_get_view` → confirm → `signoz_delete_view` | Get-before-delete mandatory; fresh confirmation |
 
 ## Common mistakes
 
 | Mistake | Fix |
 |---------|-----|
-| Hand-composing `compositeQuery` from examples or memory (even after reading `signoz://view/examples`) | Use the `Skill` tool to invoke `signoz-generating-queries`; reading examples and validating with `signoz_search_traces` is not a substitute |
-| Copying the full executable query envelope into the saved `compositeQuery` | Copy only `query.compositeQuery.queries`, then construct the saved shape `{queryType:"builder", panelType, queries}`; exclude `schemaVersion`, `start`, `end`, `requestType`, `formatOptions`, and `variables` |
-| Lifting an attribute name from a metric, alert rule, or sibling view and using it in a `sourcePage=traces` / `=logs` view filter without re-verifying on the destination signal | Field keys are signal-scoped; an attribute on metrics may not exist on traces or logs. Always re-check via `signoz_get_field_keys signal=<destination signal>` (for a `meter` view, `signal=metrics source=meter`, never `signal=meter`) **and** run the mandatory pre-save sample fetch; the key check is necessary but not sufficient |
+| Hand-composing `spec.queries` from examples or memory (even after reading `signoz://view/examples`) | Use the `Skill` tool to invoke `signoz-generating-queries`; reading examples and validating with `signoz_search_traces` is not a substitute |
+| Sending the retired v1 shape: `compositeQuery`, `category`, `tags`, `extraData`, or the `sourcePage` parameter | The v2 API takes `source` + `spec`; read both schema resources first |
+| Copying the full executable query envelope into the saved `spec` | Copy only `query.compositeQuery.queries`, then construct the spec `{displayName, panelType, requestType, queries}`; exclude the execution-only `schemaVersion`, `start`, `end`, `requestType`, `formatOptions`, and `variables` |
+| Lifting an attribute name from a metric, alert rule, or sibling view and using it in a `source=traces` / `=logs` view filter without re-verifying on the destination signal | Field keys are signal-scoped; an attribute on metrics may not exist on traces or logs. Always re-check via `signoz_get_field_keys signal=<destination signal>` (for a `meter` view, `signal=metrics source=meter`, never `signal=meter`) **and** run the mandatory pre-save sample fetch; the key check is necessary but not sufficient |
 | Skipping the pre-save sample fetch because `signoz-generating-queries` already validated the query | The sub-skill validates the query *it* authored; the filter you persist may have been edited or lifted since then. The Step 5 sample fetch is mandatory regardless |
-| Skipping `signoz_get_view` before delete (relying on list UUID alone) | Always call `signoz_get_view` to confirm name+sourcePage before `signoz_delete_view` |
-| Sending legacy fields: `builder`, `promql`, `unit`, top-level `id`, `queryFormulas` | Read schema resources; server returns HTTP 400 silently |
-| `signal` ≠ `sourcePage` in builder query | For traces/logs/metrics, every `builder_query.signal` must equal the view's `sourcePage`. For a `meter` view, use `signal:"metrics"` + `source:"meter"` (not `signal:"meter"`) |
-| Filing a Cost Meter view under `sourcePage:"metrics"` (with `source:"meter"`) | Cost Meter views go under `sourcePage:"meter"`; otherwise they're invisible in the Meter Explorer and mis-filed under Metrics. The server rejects `source:"meter"` on a non-`meter` page |
-| Partial update body (omitting unchanged fields) | GET full body first → modify only changed fields → PUT entire body |
+| Skipping `signoz_get_view` before delete (relying on list UUID alone) | Always call `signoz_get_view` to confirm name+source before `signoz_delete_view` |
+| Trying to rename the machine `name` on update | `name` is immutable server-side; change `spec.displayName` for the visible label |
+| `signal` ≠ `source` in builder query | For traces/logs/metrics, every `builder_query.signal` must equal the view's `source`. For a `meter` view, use `signal:"metrics"` + `source:"meter"` (not `signal:"meter"`) |
+| Filing a Cost Meter view under `source:"metrics"` (with `source:"meter"`) | Cost Meter views go under `source:"meter"`; otherwise they're invisible in the Meter Explorer and mis-filed under Metrics. The server rejects `source:"meter"` on a non-`meter` source |
+| Partial update body (omitting unchanged fields) | GET full body first → modify only changed fields → replace with `source` + full `spec` |
 | Declaring "no such view" after only page 1 | Check `pagination.hasMore`; continue with `offset = pagination.nextOffset` |
-| Using PromQL or raw ClickHouse in a view | Only `queryType: "builder"` is supported; offer a dashboard panel instead |
-| Setting `category` to an enum value | `category` is free-form string; omit if user doesn't specify |
+| Using PromQL or raw ClickHouse in a view | Builder envelopes are the supported path; offer a dashboard panel instead |
 
 ## Reporting back
 
 After any write (create / update / delete), include in your reply:
 - The view's name and UUID.
-- The `sourcePage`.
+- The `source`.
 - A direct link **only** if the MCP response or SigNoz frontend provides a
   canonical URL, or the user explicitly asks for one. Do not fabricate
   frontend routes; saved-view paths differ per signal and change over
-  time. When in doubt, omit the link and report the UUID + `sourcePage`.
+  time. When in doubt, omit the link and report the UUID + `source`.
 - For updates, what changed (one-line diff).
 - For deletes, an explicit "deleted" confirmation with the name.
 
@@ -350,5 +361,5 @@ Describe follow-ups by *user intent*, not by tool or skill name. The
 label the user clicks should read like the user's next prompt.
 
 Read-only operations (list, get) should report concisely (name, id,
-sourcePage, filter expression, panel type) and stop. Don't narrate
+source, filter expression, panel type) and stop. Don't narrate
 the schema back to the user.

--- a/plugins/signoz/skills/signoz-managing-views/evals/evals.json
+++ b/plugins/signoz/skills/signoz-managing-views/evals/evals.json
@@ -5,7 +5,7 @@
       "id": 0,
       "name": "create-trace-view-for-service",
       "prompt": "Save the current traces query as a view called 'checkout-errors' for the checkout service. I want to see only error spans from service.name = checkout.",
-      "expected_output": "Agent resolves sourcePage=traces, builds a builder_query with filter service.name='checkout' AND has_error=true, sets panelType=list, runs signoz_search_traces with limit=1 using the exact filter, previews, confirms, and calls signoz_create_view. Reports the name, UUID, and sourcePage.",
+      "expected_output": "Agent resolves source=traces, builds a builder_query with filter service.name='checkout' AND has_error=true, sets spec.panelType=list, runs signoz_search_traces with limit=1 using the exact filter, previews, confirms, and calls signoz_create_view. Reports the name, UUID, and source.",
       "files": [],
       "assertions": [
         {
@@ -13,31 +13,31 @@
           "description": "The primary write operation must be called"
         },
         {
-          "text": "sourcePage is set to 'traces' (not logs or metrics)",
-          "description": "sourcePage must match the user's intent; wrong value is a 400"
+          "text": "source is set to 'traces' (not logs or metrics)",
+          "description": "source must match the user's intent; wrong value is a 400"
         },
         {
           "text": "Filter includes service.name = checkout and has_error = true",
           "description": "View must capture the user's stated filter criteria"
         },
         {
-          "text": "The actual signoz_create_view payload sets its top-level compositeQuery argument to exactly queryType='builder', panelType='list', and queries copied losslessly from the successful execution query.compositeQuery.queries",
-          "description": "Execution and saved-view envelopes differ; the validated inner queries must be preserved while the saved wrapper is constructed explicitly"
+          "text": "The actual signoz_create_view payload sets spec to exactly displayName, panelType='list', requestType='raw', and queries copied losslessly from the successful execution query.compositeQuery.queries",
+          "description": "Execution and saved-view envelopes differ; the validated inner queries must be preserved while the v2 spec is constructed explicitly"
         },
         {
           "text": "The copied trace builder_query retains limit=100 plus Query Builder v5 order by timestamp desc and does not translate it to dashboard orderBy",
           "description": "Saved-view queries share the execution wire shape and must remain explicitly bounded and ordered during translation"
         },
         {
-          "text": "The actual signoz_create_view compositeQuery argument does not contain schemaVersion, start, end, requestType, formatOptions, variables, or a nested query/compositeQuery envelope",
-          "description": "Execution-only range and formatting fields are invalid in the saved-view compositeQuery"
+          "text": "The actual signoz_create_view spec does not contain start, end, formatOptions, variables, or a nested query/compositeQuery envelope",
+          "description": "Execution-only range and formatting fields are invalid in the saved-view spec"
         },
         {
           "text": "Agent runs the mandatory pre-save sample fetch via signoz_search_traces with limit=1 using the exact filter from the about-to-save payload before signoz_create_view",
           "description": "Step 5 of the create flow: a saved view returning zero rows is a permanent artifact; the sample fetch is the only confirmation that the filter matches data"
         },
         {
-          "text": "Agent shows a preview (name, sourcePage, filter) before calling create",
+          "text": "Agent shows a preview (name, source, filter) before calling create",
           "description": "Skill requires a preview step; without it user cannot catch errors"
         },
         {
@@ -48,21 +48,21 @@
     },
     {
       "id": 1,
-      "name": "list-views-no-sourcepage",
+      "name": "list-views-no-source",
       "prompt": "Show me all my saved views.",
-      "expected_output": "Agent recognizes no sourcePage was given, calls signoz_list_views four times (once for each of traces, logs, metrics, meter), merges results, and presents them organized by sourcePage. Checks pagination.hasMore for each page before concluding.",
+      "expected_output": "Agent recognizes no source was given, calls signoz_list_views four times (once for each of traces, logs, metrics, meter), merges results, and presents them organized by source. Checks pagination.hasMore for each page before concluding.",
       "files": [],
       "assertions": [
         {
-          "text": "Agent calls signoz_list_views for all four pages: traces, logs, metrics, and meter",
-          "description": "Without a sourcePage the agent must query all four Explorer pages, including meter (Cost Meter)"
+          "text": "Agent calls signoz_list_views for all four sources: traces, logs, metrics, and meter",
+          "description": "Without a source the agent must query all four Explorer pages, including meter (Cost Meter)"
         },
         {
           "text": "Agent checks pagination.hasMore before concluding the list is complete",
           "description": "A single page is not a complete list"
         },
         {
-          "text": "Results are organized/labeled by sourcePage in the reply",
+          "text": "Results are organized/labeled by source in the reply",
           "description": "Grouping by signal helps user find what they need"
         }
       ]
@@ -71,32 +71,36 @@
       "id": 2,
       "name": "rename-existing-view",
       "prompt": "Rename the 'slow-checkout' view to 'slow-checkout-p99'.",
-      "expected_output": "Because sourcePage is unknown, the agent searches all four source pages with full pagination, then calls signoz_get_view. It previews a rename-only diff and calls signoz_update_view with the full fetched view body, changing only the name. Reports UUID, old name, and new name.",
+      "expected_output": "Because the source is unknown, the agent searches all four sources with full pagination, then calls signoz_get_view. It previews a rename-only diff and calls signoz_update_view with the full fetched view body, changing only spec.displayName (the machine name is immutable server-side). Reports UUID, old label, and new label.",
       "files": [],
       "assertions": [
         {
-          "text": "Agent searches traces, logs, metrics, and meter with pagination because sourcePage was not supplied",
-          "description": "A saved-view name is not globally searchable through one sourcePage"
+          "text": "Agent searches traces, logs, metrics, and meter with pagination because the source was not supplied",
+          "description": "A saved-view name is not globally searchable through one source"
         },
         {
           "text": "Agent calls signoz_list_views (or signoz_get_view) to resolve the view before updating",
           "description": "Blind update without lookup risks wrong UUID"
         },
         {
-          "text": "Agent calls signoz_get_view to fetch the full body before composing update (GET-then-PUT)",
-          "description": "signoz_update_view is full-body replace; not fetching first risks wiping fields"
+          "text": "Agent calls signoz_get_view to fetch the full body before composing update (GET-then-replace)",
+          "description": "signoz_update_view is a full replacement; not fetching first risks wiping fields"
         },
         {
-          "text": "compositeQuery is not modified for a pure rename",
-          "description": "Touching compositeQuery for metadata-only change risks data loss"
+          "text": "Only spec.displayName changes; the machine name is not modified (it is immutable server-side)",
+          "description": "Renaming a view means changing the display label; upstream rejects a name change"
+        },
+        {
+          "text": "spec.queries is not modified for a pure rename",
+          "description": "Touching the queries for a metadata-only change risks data loss"
         },
         {
           "text": "Agent shows a diff-style preview before calling update",
           "description": "Skill requires showing what will change"
         },
         {
-          "text": "Agent calls signoz_update_view with the full fetched view body, preserving sourcePage, compositeQuery, category, tags, and extraData while changing only name",
-          "description": "The PUT is full-body replace; a name-only payload would wipe state"
+          "text": "Agent calls signoz_update_view with the full fetched view body, preserving source and every unchanged spec field",
+          "description": "The replace is full-body; a label-only payload would wipe state"
         }
       ]
     },
@@ -104,11 +108,11 @@
       "id": 3,
       "name": "delete-view-by-name",
       "prompt": "Delete the 'checkout-errors' view.",
-      "expected_output": "Because sourcePage is unknown, the agent searches all four source pages with full pagination, then calls signoz_get_view to confirm the UUID maps to checkout-errors. It shows the resolved name, sourcePage, and category, asks for confirmation, and only then calls signoz_delete_view.",
+      "expected_output": "Because the source is unknown, the agent searches all four sources with full pagination, then calls signoz_get_view to confirm the UUID maps to checkout-errors. It shows the resolved name and source, asks for confirmation, and only then calls signoz_delete_view.",
       "files": [],
       "assertions": [
         {
-          "text": "Agent searches traces, logs, metrics, and meter with pagination because sourcePage was not supplied",
+          "text": "Agent searches traces, logs, metrics, and meter with pagination because the source was not supplied",
           "description": "Deletion must not assume which Explorer owns the named view"
         },
         {
@@ -120,7 +124,7 @@
           "description": "Paste errors happen; the get-before-delete guard prevents deleting the wrong view"
         },
         {
-          "text": "Agent shows the resolved view's name, sourcePage, and category and asks for explicit confirmation",
+          "text": "Agent shows the resolved view's name and source and asks for explicit confirmation",
           "description": "Delete is permanent; skill requires fresh confirmation against the resolved target, not just the original prompt"
         },
         {
@@ -137,48 +141,48 @@
       "id": 4,
       "name": "update-view-filter",
       "prompt": "Update the 'checkout-errors' view to show only error spans slower than one second.",
-      "expected_output": "Because sourcePage is unknown, the agent searches all four source pages with full pagination, then gets the full view. It uses signoz-generating-queries to build has_error=true AND duration_nano>1000000000, sample-fetches the exact filter, previews the diff, confirms, and calls signoz_update_view with the full fetched view body containing the validated compositeQuery.",
+      "expected_output": "Because the source is unknown, the agent searches all four sources with full pagination, then gets the full view. It uses signoz-generating-queries to build has_error=true AND duration_nano>1000000000, sample-fetches the exact filter, previews the diff, confirms, and calls signoz_update_view with the full fetched view body containing the validated queries.",
       "files": [],
       "assertions": [
         {
-          "text": "Agent searches traces, logs, metrics, and meter with pagination because sourcePage was not supplied",
-          "description": "Update must locate the view across every Explorer before GET-then-PUT"
+          "text": "Agent searches traces, logs, metrics, and meter with pagination because the source was not supplied",
+          "description": "Update must locate the view across every Explorer before GET-then-replace"
         },
         {
-          "text": "Agent calls signoz_get_view to fetch the full body before composing update (GET-then-PUT)",
-          "description": "Full-body replace; not fetching first risks wiping fields"
+          "text": "Agent calls signoz_get_view to fetch the full body before composing update (GET-then-replace)",
+          "description": "Full replacement; not fetching first risks wiping fields"
         },
         {
-          "text": "Agent invokes signoz-generating-queries skill to build the new compositeQuery",
-          "description": "Query changes must go through signoz-generating-queries for validation; hand-editing compositeQuery risks malformed payloads"
+          "text": "Agent invokes signoz-generating-queries skill to build the new spec.queries",
+          "description": "Query changes must go through signoz-generating-queries for validation; hand-editing spec.queries risks malformed payloads"
         },
         {
           "text": "Agent runs the mandatory pre-save sample fetch via signoz_search_traces with limit=1 using the new filter before signoz_update_view",
-          "description": "Step 5 of the update flow: compositeQuery changed, so the 1-row probe against the new filter is required (skip only for pure metadata tweaks)"
+          "description": "Step 5 of the update flow: spec.queries changed, so the 1-row probe against the new filter is required (skip only for pure metadata tweaks)"
         },
         {
-          "text": "Agent shows a diff-style preview before writing, explicitly calling out the compositeQuery change",
-          "description": "Skill requires confirmation for compositeQuery changes; user must see what is changing"
+          "text": "Agent shows a diff-style preview before writing, explicitly calling out the spec.queries change",
+          "description": "Skill requires confirmation for query changes; user must see what is changing"
         },
         {
-          "text": "Agent calls signoz_update_view with the full fetched view body, preserving sourcePage, category, tags, and extraData while replacing compositeQuery with the validated query",
+          "text": "Agent calls signoz_update_view with the full fetched view body, preserving source and every unchanged spec field while replacing spec.queries with the validated query",
           "description": "The filter change must be written without dropping unrelated state"
         },
         {
-          "text": "The actual signoz_update_view payload sets view.compositeQuery to exactly queryType='builder', the intended panelType, and queries copied losslessly from the successful execution query.compositeQuery.queries",
-          "description": "A validated execution query must be translated to the saved-view wrapper rather than copied wholesale"
+          "text": "The actual signoz_update_view payload sets view.spec.queries to the queries copied losslessly from the successful execution query.compositeQuery.queries, with the intended panelType and requestType",
+          "description": "A validated execution query must be translated into the v2 spec rather than copied wholesale"
         },
         {
           "text": "Every copied builder_query/builder_formula retains its positive limit and Query Builder v5 order losslessly; formula inputs remain at 10000 and formula results at 100, with no dashboard orderBy introduced",
-          "description": "Changing a saved-view query must not drop its bounded result contract during GET-then-PUT"
+          "description": "Changing a saved-view query must not drop its bounded result contract during GET-then-replace"
         },
         {
-          "text": "The updated view.compositeQuery excludes schemaVersion, start, end, requestType, formatOptions, variables, and nested execution query/compositeQuery fields",
+          "text": "The updated view.spec excludes start, end, formatOptions, variables, and nested execution query/compositeQuery fields",
           "description": "Execution-only envelope fields must not leak into the saved view"
         },
         {
-          "text": "signal in every builder_query matches the view's sourcePage",
-          "description": "signal != sourcePage is a server-side error"
+          "text": "signal in every builder_query matches the view's source",
+          "description": "signal != source is a server-side error"
         }
       ]
     },
@@ -186,11 +190,11 @@
       "id": 5,
       "name": "create-cost-meter-view",
       "prompt": "Save a view that tracks our log ingestion volume from the Cost Meter so I can find it later.",
-      "expected_output": "Agent recognizes this is a Cost Meter view and resolves sourcePage=meter (not metrics). Reads the schema resources, then builds the query via signoz-generating-queries told it is a Cost Meter query (source=meter) so discovery hits the meter store and finds a meter metric (e.g. signoz.meter.log.size). The resulting builder_query has signal=metrics and source=meter, panelType=graph. Runs the mandatory pre-save sample fetch via signoz_query_metrics with source=meter, the metricName, timeRange=24h, requestType=scalar. Shows a preview (name, sourcePage=meter, metric/filter, sample-fetch result), confirms, and calls signoz_create_view. Reports name, UUID, and sourcePage=meter.",
+      "expected_output": "Agent recognizes this is a Cost Meter view and resolves source=meter (not metrics). Reads the schema resources, then builds the query via signoz-generating-queries told it is a Cost Meter query (source=meter) so discovery hits the meter store and finds a meter metric (e.g. signoz.meter.log.size). The resulting builder_query has signal=metrics and source=meter, spec.panelType=graph. Runs the mandatory pre-save sample fetch via signoz_query_metrics with source=meter, the metricName, timeRange=24h, requestType=scalar. Shows a preview (name, source=meter, metric/filter, sample-fetch result), confirms, and calls signoz_create_view. Reports name, UUID, and source=meter.",
       "files": [],
       "assertions": [
         {
-          "text": "sourcePage is set to 'meter' (not 'metrics')",
+          "text": "source is set to 'meter' (not 'metrics')",
           "description": "Cost Meter views file under the distinct 'meter' Explorer page; using 'metrics' mis-files them so they're invisible in the Meter Explorer"
         },
         {
@@ -206,15 +210,15 @@
           "description": "Aggregate saved views must remain explicitly bounded and ordered in the v5 wire shape"
         },
         {
-          "text": "The actual signoz_create_view payload uses compositeQuery={queryType:'builder', panelType:'graph', queries:[...]} with queries copied from the validated execution query and no execution-only envelope fields",
-          "description": "Cost Meter views use the same explicit execution-to-saved-view translation as every other sourcePage"
+          "text": "The actual signoz_create_view payload uses spec={displayName, panelType:'graph', requestType, queries:[...]} with queries copied from the validated execution query and no execution-only envelope fields",
+          "description": "Cost Meter views use the same explicit execution-to-saved-spec translation as every other source"
         },
         {
           "text": "Agent runs the pre-save sample fetch via signoz_query_metrics with source=meter before signoz_create_view",
           "description": "Step 5 of the create flow, adapted for meter: the 1-row/scalar probe must carry source=meter so it hits the meter store"
         },
         {
-          "text": "Agent shows a preview and calls signoz_create_view, reporting the UUID and sourcePage=meter",
+          "text": "Agent shows a preview and calls signoz_create_view, reporting the UUID and source=meter",
           "description": "Preview-before-write and report-back apply to meter views like any other"
         }
       ]

--- a/plugins/signoz/skills/signoz-setting-up-observability/SKILL.md
+++ b/plugins/signoz/skills/signoz-setting-up-observability/SKILL.md
@@ -122,7 +122,7 @@ instead of hitting collisions mid-build:
 - **Is there a notification channel to reuse?** (Carried into Phase 5.)
 
 Paginate every inventory list until a match is found or all pages are
-exhausted. When a view's `sourcePage` is unknown, search traces, logs, metrics,
+exhausted. When a view's `source` is unknown, search traces, logs, metrics,
 and meter separately.
 
 Learn just enough to decide extend-vs-create per artifact; leave the


### PR DESCRIPTION
## Summary

Companion PR for the saved-views v2 migration in **SigNoz/signoz-mcp-server#296** (nerve-pod#100), which moved the five `signoz_*_view` tools from v1 `/api/v1/explorer/views/*` to v2 `/api/v2/saved_views/*`. The CMP-3 note on that PR flagged this repo for the contract changes the skills teach.

What changed here:

- **`sourcePage` → `source`** throughout the managing-views skill, its evals, and one spot in `signoz-setting-up-observability`.
- **Create/update payloads** now teach the typed v2 shape: `source` + `spec{displayName, panelType, requestType, queries, selectedFields, display}`, replacing `compositeQuery`/`category`/`tags`/`extraData`. The execution-envelope translation now lands in `spec.queries` (execution-only fields still excluded).
- **Update flow**: `name` is immutable server-side (a rename changes `spec.displayName`); `view` requires `source` + full `spec`; success is an empty 204; cross-source moves stay rejected.
- **List**: the `category` filter is gone (unsupported by v2); `name` partial match and `pagination.hasMore` walking are unchanged.
- **Delete flow**: the confirm preview drops the removed `category` field.
- **evals.json**: all six eval scenarios updated to the new contract (source param, spec shapes, immutable name, no category/extraData to preserve).

All process guards are unchanged: mandatory pre-save sample fetch, `signoz-generating-queries` delegation, preview-before-write, get-before-delete, pagination walking, and the follow-up anti-rules. References still point at `signoz://view/instructions` and `signoz://view/examples` (rewritten for v2 in the server PR) as the schema source of truth.

Style checks: no em dashes, no banned words, bare tool names, SKILL.md under 500 lines.

## Test plan

- Reviewed against the merged tool schemas in `internal/handler/tools/views.go` (signoz-mcp-server main): `source` enum is traces/logs/metrics/meter; create params are `name`/`generateName`/`source`/`spec`; update takes `id` + full `view`.
- `python3 -m json.tool` on evals.json passes.
- `grep -n '—'` over changed files: clean.